### PR TITLE
Rich text bios

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -31,7 +31,6 @@
 }
 
 trix-editor {
-  min-height: 300px;
   max-width: 100% !important;
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,8 @@ class User < ApplicationRecord
   validates :username, presence: true, uniqueness: true, length: { minimum: Username::MIN_LENGTH, maximum: Username::MAX_LENGTH }
   validate  :username_valid
 
-  validates :bio, length: { maximum: 512 }
+  has_rich_text :bio
+  validate :bio_length
 
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :custom_domain, uniqueness: true, allow_blank: true, format: { with: /\A(?!:\/\/)([a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}\z/ }
@@ -68,6 +69,12 @@ class User < ApplicationRecord
     def username_valid
       unless Username.valid_format?(username)
         errors.add(:username, "must only use alphanumeric characters, full stops (periods) or underscores")
+      end
+    end
+
+    def bio_length
+      if bio.to_plain_text.length > 500
+        errors.add(:bio, "is too long (maximum 500 characters)")
       end
     end
 end

--- a/app/views/app/account/_form.html.erb
+++ b/app/views/app/account/_form.html.erb
@@ -2,10 +2,12 @@
   <div>
     <h3 class="font-bold text-lg mb-2">Bio</h3>
 
-    <%= form.text_area :bio, placeholder: "add a bio to your profile if you like...", class: "w-full dark:bg-slate-800 border #{@user.errors[:bio].any? ? 'border-red-500' : 'border-slate-300 dark:border-slate-700'} text-slate-800 dark:text-slate-200 rounded-lg", data: { controller: "autogrow" } %>
-    <% if @user.errors[:bio].any? %>
-      <span class="text-red-500 text-sm"><%= @user.errors.full_messages_for(:bio).first %>
-    <% end %>
+    <div class="trix-container trix-minimal">
+    <%= form.rich_text_area :bio,
+        placeholder: "add a bio to your profile if you like...",
+        class: "trix-content min-h-[150px] prose border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg",
+        data: { controller: "autogrow trix", subscribed: false } %>
+    </div>
   </div>
 
   <% if @user.subscribed? %>

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="trix-container <%= "trix-no-attachments" unless Current.user.subscribed? %>">
   <%= form.rich_text_area :content,
       placeholder: "Write your post...",
-      class: "trix-content prose border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg",
+      class: "trix-content min-h-[300px] prose border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg",
       data: { controller: "autogrow trix", subscribed: Current.user.subscribed? } %>
   </div>
 

--- a/app/views/users/posts/_header.html.erb
+++ b/app/views/users/posts/_header.html.erb
@@ -15,7 +15,7 @@
 
   <% if @user.bio.present? %>
   <div class="mt-4 text-sm prose dark:prose-invert text-slate-500 dark:text-slate-400 break-words">
-    <%= simple_format(auto_link @user.bio) %>
+    <%= auto_link @user.bio %>
   </div>
   <% end %>
 </div>

--- a/db/migrate/20241203123953_change_bio_to_bio_text.rb
+++ b/db/migrate/20241203123953_change_bio_to_bio_text.rb
@@ -1,0 +1,10 @@
+class ChangeBioToBioText < ActiveRecord::Migration[8.1]
+  def change
+    rename_column :users, :bio, :bio_text
+
+    User.find_each do |user|
+      user.bio = user.bio_text&.gsub(/\n/, "<br>")
+      user.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2024_11_10_145930) do
+ActiveRecord::Schema[8.1].define(version: 2024_12_03_123953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -138,7 +138,7 @@ ActiveRecord::Schema[8.1].define(version: 2024_11_10_145930) do
     t.datetime "updated_at", null: false
     t.boolean "verified", default: false
     t.string "delivery_email"
-    t.text "bio"
+    t.text "bio_text"
     t.datetime "discarded_at"
     t.string "custom_domain"
     t.string "title"

--- a/test/controllers/app/users_controller_test.rb
+++ b/test/controllers/app/users_controller_test.rb
@@ -24,7 +24,7 @@ class App::UsersControllerTest < ActionDispatch::IntegrationTest
     patch app_user_url(@user), params: { user: { bio: "New bio" } }, as: :turbo_stream
 
     assert_response :success
-    assert_equal "New bio", @user.reload.bio
+    assert_equal "New bio", @user.reload.bio.to_plain_text
   end
 
   test "should update user custom domain" do

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -46,3 +46,11 @@ four:
   body: |
     <p><b>Photography was my first love</b>.</p>
     <p>I've taken photos every day since I got my first camera</p>
+
+five:
+  record: joel (User)
+  name: bio
+  body: |
+    Photographer
+
+    https://pagecord.com/joel

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,11 +2,11 @@ joel:
   email: joel@pagecord.com
   username: joel
   delivery_email: joel_gf35jsue@post.pagecord.com
-  bio: |
+  verified: true
+  bio_text: |
     Photographer
 
     https://pagecord.com/joel
-  verified: true
 
 elliot:
   email: elliot@pagecord.com


### PR DESCRIPTION
Customers have asked for rich text support in the bio. This PR changes the bio field on `User` to use ActionText. It has a stripped back Trix editor that only allows (in the UI) bold, underline and links.

<img width="290" alt="Screenshot 2024-12-03 at 13 07 07" src="https://github.com/user-attachments/assets/81acec00-1354-458c-ab6a-7dbf2ebc0421">

The old column will be removed in a future update. Keeping it around in case a rollback is needed.
