### PR TITLE
Add a new layout option (list of titles) to blogs

### DIFF
--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -24,9 +24,16 @@ class App::Settings::BlogsController < AppController
 
     def blog_params
       if @blog.user.subscribed?
-        params.require(:blog).permit(:bio, :custom_domain, :title, :avatar, :email_subscriptions_enabled, social_links_attributes: [ :id, :platform, :url, :_destroy ])
+        params.require(:blog).permit(
+          :bio, :custom_domain, :title, :layout, :avatar,
+          :email_subscriptions_enabled,
+          social_links_attributes: [ :id, :platform, :url, :_destroy ]
+        )
       else
-        params.require(:blog).permit(:bio, :title, social_links_attributes: [ :id, :platform, :url, :_destroy ])
+        params.require(:blog).permit(
+          :bio, :title, :layout,
+          social_links_attributes: [ :id, :platform, :url, :_destroy ]
+        )
       end
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,7 +86,7 @@ module ApplicationHelper
 
     def post_summary(post)
       content = post.content.to_plain_text.gsub(/\[.*?\.(jpg|png|gif|jpeg|webp)\]/i, "").strip
-      summary = strip_links(content).truncate(140)
+      summary = strip_links(content).truncate(72, separator: /\s/)
 
       if summary.blank?
         "Untitled"

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -1,6 +1,8 @@
 class Blog < ApplicationRecord
   include DeliveryEmail, CustomDomain, EmailSubscribable
 
+  enum :layout, [ :stream_layout, :title_layout ]
+
   belongs_to :user, inverse_of: :blog
   has_many :posts, dependent: :destroy
   has_many :social_links, dependent: :destroy

--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -20,6 +20,35 @@
     <%= form.text_field :title, class: "mt-4 w-full dark:bg-slate-800 border border-slate-300 dark:border-slate-700 text-slate-800 dark:text-slate-200 rounded-lg" %>
   </div>
 
+  <div class="mt-8">
+    <h3 class="font-bold text-lg mb-2">Layout</h3>
+    <p>
+      Would you like your blog home page to be a stream of posts, or a list of titles?
+    </p>
+
+    <div class="mt-6 gap-x-2 sm:gap-x-4 flex">
+      <fieldset class="flex border dark:border-slate-700 rounded-lg tems-center hover:bg-slate-100 dark:hover:bg-slate-800 cursor-pointer">
+        <label class="text-slate-900 dark:text-slate-300 flex items-center space-x-2 w-full p-4 cursor-pointer">
+          <%= form.radio_button :layout, "stream_layout",
+            checked: @blog.stream_layout?,
+            class: "peer w-4 h-4 text-sky-600 bg-gray-100 border-gray-300 focus:ring-sky-500 dark:focus:ring-sky-600 dark:ring-offset-gray-800 dark:bg-gray-700 dark:border-gray-600 cursor-pointer",
+              id: "layout_stream" %>
+          <span>Stream</span>
+        </label>
+      </fieldset>
+
+      <fieldset class="flex border dark:border-slate-700 rounded-lg items-center hover:bg-slate-100 dark:hover:bg-slate-800 cursor-pointer">
+        <label class="text-slate-900 dark:text-slate-300 flex items-center space-x-2 w-full p-4 cursor-pointer">
+          <%= form.radio_button :layout, "title_layout",
+            checked: @blog.title_layout?,
+            class: "peer w-4 h-4 text-sky-600 bg-gray-100 border-gray-300 focus:ring-sky-500 dark:focus:ring-sky-600 dark:ring-offset-gray-800 dark:bg-gray-700 dark:border-gray-600 cursor-pointer",
+              id: "layout_titles" %>
+          <span>List of Titles</span>
+        </label>
+      </fieldset>
+    </div>
+  </div>
+
   <% if @blog.user.subscribed? %>
   <h3 class="mt-8 font-bold text-lg mb-2">Avatar</h3>
   <p>

--- a/app/views/blogs/posts/_posts_stream.html.erb
+++ b/app/views/blogs/posts/_posts_stream.html.erb
@@ -1,0 +1,13 @@
+<%= turbo_frame_tag :posts do %>
+  <div data-controller="media-embeds">
+    <%= render partial: "post_without_upvotes", collection: @posts, as: :post %>
+  </div>
+
+  <% if @pagy.next %>
+    <% if custom_domain_request? %>
+      <%= turbo_frame_tag :posts, src: custom_blog_posts_path(page: @pagy.next), loading: :lazy %>
+    <% else %>
+      <%= turbo_frame_tag :posts, src: blog_posts_path(name: @blog.name, page: @pagy.next), loading: :lazy %>
+    <% end%>
+  <% end %>
+<% end %>

--- a/app/views/blogs/posts/_posts_titles.html.erb
+++ b/app/views/blogs/posts/_posts_titles.html.erb
@@ -1,0 +1,21 @@
+<div class="list-of-titles flex flex-col gap-y-1" data-turbo="false">
+  <% previous_year = nil %>
+  <% @posts.each do |post| %>
+    <% if post.published_at.year != previous_year %>
+      <div class="text-lg font-semibold mb-2 text-slate-900 <%= 'mt-6' unless previous_year.nil? %>">
+        <%= post.published_at.year %>
+
+        <% previous_year = post.published_at.year %>
+      </div>
+    <% end %>
+
+    <div class="flex gap-x-4">
+      <div class="text-slate-500 dark:text-slate-400 w-14 flex-shrink-0">
+        <%= post.published_at.to_date.to_formatted_s(:short) %>
+      </div>
+      <div>
+        <%= link_to post_title(post), post_path(post), class: "font-medium hover:underline" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/blogs/posts/index.html.erb
+++ b/app/views/blogs/posts/index.html.erb
@@ -10,17 +10,10 @@
         class: "font-semibold underline" %>
   </p>
 <% else %>
-  <%= turbo_frame_tag :posts do %>
-    <div data-controller="media-embeds">
-      <%= render partial: "post_without_upvotes", collection: @posts, as: :post %>
-    </div>
 
-    <% if @pagy.next %>
-      <% if custom_domain_request? %>
-        <%= turbo_frame_tag :posts, src: custom_blog_posts_path(page: @pagy.next), loading: :lazy %>
-      <% else %>
-        <%= turbo_frame_tag :posts, src: blog_posts_path(name: @blog.name, page: @pagy.next), loading: :lazy %>
-      <% end%>
-    <% end %>
+  <% if @blog.stream_layout? %>
+    <%= render "posts_stream" %>
+  <% else %>
+    <%= render "posts_titles" %>
   <% end %>
 <% end %>

--- a/db/migrate/20250203102136_add_layout_to_blog.rb
+++ b/db/migrate/20250203102136_add_layout_to_blog.rb
@@ -1,0 +1,5 @@
+class AddLayoutToBlog < ActiveRecord::Migration[8.1]
+  def change
+    add_column :blogs, :layout, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_01_08_102500) do
+ActiveRecord::Schema[8.1].define(version: 2025_02_03_102136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -84,6 +84,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_01_08_102500) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.integer "layout", default: 0
     t.index ["name"], name: "index_blogs_on_name", unique: true
     t.index ["user_id"], name: "index_blogs_on_user_id"
   end

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -3,11 +3,22 @@ require "test_helper"
 class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
   include RoutingHelper
 
-  test "should get index" do
+  test "should get index as stream of posts" do
     get blog_posts_path(name: blogs(:joel).name)
 
     assert_response :success
     assert_not_nil assigns(:posts)
+    assert_select ".list-of-titles", count: 0
+  end
+
+  test "should render a list of post titles" do
+    blog = blogs(:joel)
+    blog.title_layout!
+
+    get blog_posts_path(name: blog.name)
+
+    assert_response :success
+    assert_select ".list-of-titles", count: 1
   end
 
   test "should show email subscription form on index if enabled" do


### PR DESCRIPTION
By default blogs display a continuous stream of posts. This PR introduces a new option to just display a list of post titles.
Implements https://github.com/lylo/pagecord/issues/130

![post-titles](https://github.com/user-attachments/assets/7e902d30-359f-434a-bd2e-c297e4e8675d)
