### PR TITLE
Stop using Tailwind prose on the Trix editor. Style editor accordingly.

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -5,6 +5,30 @@
  *
  *= require trix
 */
+trix-toolbar {
+  margin-top: 2em;
+  position: sticky;
+}
+
+trix-toolbar .trix-button.trix-button--icon {
+  border: 0;
+}
+
+trix-toolbar .trix-button-group {
+  border: 0;
+}
+
+trix-toolbar .trix-button-group:not(:first-child) {
+  margin-left: 0;
+}
+
+.trix-button-row {
+  margin-left: -0.5em;
+}
+
+.trix-content h1 strong {
+  font-weight: bold;
+}
 
 /*
  * We need to override trix.css’s image gallery styles to accommodate the
@@ -33,18 +57,59 @@
 trix-editor {
   max-width: 100% !important;
 
-  .attachment.attachment--content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  .attachment img {
+    max-height: 600px !important;
+    width: auto;
+    display: inline-block;
+  }
+
+  .attachment.attachment--preview {
     text-align: center;
     margin: 0 auto;
     width: 100%;
   }
 
-  .attachment--preview img {
-    max-width: 400px;
+  li {
+    margin: 0.5rem 0 0.5rem 1rem !important;
+    &:first-child {
+      margin: 0 0 0 1rem !important;
+    }
+  }
+
+  ol {
+    list-style: decimal;
+    margin-left: 1rem !important;
+  }
+
+  ul {
+    list-style: disc;
+    margin-left: 1rem !important;
+  }
+
+  li::marker {
+    color: #5d646f;
+  }
+
+  h1 {
+    font-weight: 700;
+  }
+
+  a {
+    font-weight: 500;
+    text-decoration: underline;
+  }
+
+  blockquote {
+    margin-bottom: .5rem !important;
+    margin-top: .5rem !important;
+  }
+
+  pre {
+    margin-bottom: .5rem !important;
+    margin-top: .5rem !important;
+    background-color: rgb(2 6 23) !important; /* bg-slate-950 */
+    color: rgb(203 213 225); /* text-slate-300 */
+    font-size: 0.9rem !important;
   }
 }
 
@@ -65,10 +130,6 @@ trix-editor {
   }
 }
 
-/* trix-editor figure {
-  margin-bottom: 1.5rem !important;
-} */
-
 trix-editor .attachment__caption {
   display: none;
 }
@@ -82,12 +143,13 @@ trix-editor .attachment__caption {
       color: #fff !important;
     }
 
-    pre, code {
-      background-color: rgb(2 6 23); /* bg-slate-950 */
-    }
     blockquote {
       color: #fff;
     }
+  }
+
+  li::marker {
+    color: #9ba1aa;
   }
 
   .trix-input--dialog {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,36 +1,3 @@
-/* Trix styles */
-
-trix-toolbar {
-  margin-top: 2em;
-  position: sticky;
-}
-
-trix-toolbar .trix-button.trix-button--icon {
-  border: 0;
-}
-
-trix-toolbar .trix-button-group {
-  border: 0;
-}
-
-trix-toolbar .trix-button-group:not(:first-child) {
-  margin-left: 0;
-}
-
-.trix-button-row {
-  margin-left: -0.5em;
-}
-
-.trix-content .attachment--preview img {
-  display: inline;
-}
-
-.trix-content h1 strong {
-  font-weight: bold;
-}
-
-/* Tailwind */
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -53,10 +20,6 @@ trix-toolbar .trix-button-group:not(:first-child) {
 
 @layer base {
   article {
-    .trix-content p {
-      @apply mb-4;
-    }
-
     h1:not(.title) {
       @apply text-xl mb-0;
 
@@ -70,7 +33,7 @@ trix-toolbar .trix-button-group:not(:first-child) {
     }
 
     img {
-      @apply rounded-lg;
+      @apply rounded-lg max-h-[640px] inline-block;
     }
   }
 
@@ -80,12 +43,24 @@ trix-toolbar .trix-button-group:not(:first-child) {
       content: "";
     }
 
-    img {
-      @apply my-2 mx-auto;
+    br {
+      display: block;
+      content: "";
+      margin-bottom: 1.25em; /* Reduce the spacing */
+    }
+
+    img, figure {
+      @apply my-0 mx-auto;
     }
 
     ul, ol {
       @apply my-0 !important;
+    }
+
+    li {
+      &:first-child {
+        @apply my-0;
+      }
     }
 
     blockquote {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -33,7 +33,7 @@
     }
 
     img {
-      @apply rounded-lg max-h-[640px] inline-block;
+      @apply rounded-lg max-h-[640px];
     }
   }
 
@@ -49,12 +49,12 @@
       margin-bottom: 1.25em; /* Reduce the spacing */
     }
 
-    img, figure {
-      @apply my-0 mx-auto;
-    }
-
     ul, ol {
       @apply my-0 !important;
+    }
+
+    img {
+      @apply my-2 mx-auto;
     }
 
     li {

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -52,8 +52,8 @@ class App::PostsController < AppController
     end
 
     def prepare_content_for_trix
-      # To pacify Trix, remove new line characters and substitue <p> tags with <br> tags
-      @post.content = @post.content.to_s.gsub(/\n/, "")
+      # To pacify Trix, remove new line characters (except for within <pre> tags) and substitue <p> tags with <br> tags
+      @post.content = @post.content.to_s.gsub(/(?!<pre[^>]*?>.*?)\n(?![^<]*?<\/pre>)/m, "")
       @post.content = Html::StripParagraphs.new.transform(@post.content.to_s)
     end
 end

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -38,7 +38,7 @@
     <div class="trix-container <%= "trix-no-attachments" unless Current.user.subscribed? %>">
     <%= form.rich_text_area :content,
         placeholder: "Write your post...",
-        class: "trix-content min-h-[300px] prose border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg",
+        class: "trix-content min-h-[300px] border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg",
         data: { controller: "autogrow trix", subscribed: Current.user.subscribed? } %>
     </div>
 


### PR DESCRIPTION
Previously the Trix editor had the `prose` class assigned which was causing all sorts of issues. This PR removes the `prose` class and adds custom styles for the Trix editor to make it look _almost_ WYSIWYG.