### PR TITLE
Introduce status for posts. Allows drafts to be created

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -34,6 +34,10 @@
     @apply inline-flex items-center px-4 py-2 text-sm font-medium text-center text-slate-800 dark:text-slate-100 bg-slate-200 rounded-lg hover:bg-slate-300 focus:ring-4 focus:outline-none focus:ring-slate-300 dark:bg-slate-600 dark:hover:bg-slate-700 dark:focus:ring-slate-800 cursor-pointer;
   }
 
+  .btn-optional {
+    @apply inline-flex items-center px-4 py-2 text-sm font-medium text-center text-slate-800 dark:text-slate-100 border border-slate-200 dark:border-slate-700 rounded-lg hover:bg-slate-50 focus:ring-4 focus:outline-none focus:ring-slate-300 dark:hover:bg-slate-800 dark:focus:ring-slate-800 cursor-pointer;
+  }
+
   .btn-secondary {
     @apply inline-flex items-center px-4 py-2 text-sm font-medium text-center text-slate-800 dark:text-slate-100;
   }

--- a/app/controllers/app/feed_controller.rb
+++ b/app/controllers/app/feed_controller.rb
@@ -7,14 +7,14 @@ class App::FeedController < AppController
 
   def index
     followed_blog_ids = @user.followed_blogs.pluck(:followed_id)
-    @posts = Post.where(blog_id: followed_blog_ids).order(published_at: :desc)
+    @posts = Post.where(blog_id: followed_blog_ids).visible.order(published_at: :desc)
 
     @pagy, @posts = pagy(@posts)
   end
 
   def private_rss
     followed_blog_ids = @user.followed_blogs.pluck(:followed_id)
-    @posts = Post.where(blog_id: followed_blog_ids).order(published_at: :desc).limit(30)
+    @posts = Post.where(blog_id: followed_blog_ids).visible.order(published_at: :desc).limit(30)
 
     respond_to do |format|
       format.rss { render layout: false }

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -2,7 +2,9 @@ class App::PostsController < AppController
   include Pagy::Backend
 
   def index
-    @pagy, @posts =  pagy(Current.user.blog.posts.order(published_at: :desc), limit: 10)
+    @pagy, @posts =  pagy(Current.user.blog.posts.published.order(published_at: :desc), limit: 25)
+
+    @drafts = Current.user.blog.posts.draft.order(updated_at: :desc)
   end
 
   def new
@@ -48,7 +50,9 @@ class App::PostsController < AppController
   private
 
     def post_params
-      params.require(:post).permit(:title, :content, :published_at, :canonical_url)
+      status = params[:button] == "save_draft" ? :draft : :published
+
+      params.require(:post).permit(:title, :content, :published_at, :canonical_url).merge(status: status)
     end
 
     # HTML from inbound email doesn't often play nicely with Trix

--- a/app/controllers/blogs/posts_controller.rb
+++ b/app/controllers/blogs/posts_controller.rb
@@ -4,7 +4,7 @@ class Blogs::PostsController < Blogs::BaseController
   rescue_from Pagy::OverflowError, with: :redirect_to_last_page
 
   def index
-    @posts = @blog.posts.published
+    @posts = @blog.posts.visible
       .with_rich_text_content_and_embeds
       .order(published_at: :desc)
 
@@ -17,7 +17,7 @@ class Blogs::PostsController < Blogs::BaseController
   end
 
   def show
-    @post = @blog.posts.published
+    @post = @blog.posts.visible
       .with_rich_text_content_and_embeds
       .find_by!(token: blog_params[:token])
 

--- a/app/helpers/app/posts_helper.rb
+++ b/app/helpers/app/posts_helper.rb
@@ -1,2 +1,21 @@
 module App::PostsHelper
+  def publish_button_text(post)
+    if post.persisted?
+      if post.published?
+        "Update Post"
+      else
+        "Publish Post"
+      end
+    else
+      "Publish Post"
+    end
+  end
+
+  def draft_button_text(post)
+    if post.persisted? && post.published?
+      "Unpublish"
+    else
+      "Save Draft"
+    end
+  end
 end

--- a/app/models/concerns/draftable.rb
+++ b/app/models/concerns/draftable.rb
@@ -1,0 +1,18 @@
+module Draftable
+  extend ActiveSupport::Concern
+
+  included do
+    enum :status, [ :draft, :published ]
+
+    scope :draft, -> { where(status: :draft) }
+    scope :published, -> { where(status: :published) }
+  end
+
+  def publish!
+    update!(status: :published)
+  end
+
+  def unpublish!
+    update!(status: :draft)
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-  include Trimmable, Upvotable, Tokenable
+  include Draftable, Tokenable, Trimmable, Upvotable
 
   belongs_to :blog, inverse_of: nil
 
@@ -15,7 +15,7 @@ class Post < ApplicationRecord
 
   validate :body_or_title
 
-  scope :published, -> { where("published_at <= ?", Time.current) }
+  scope :visible, -> { published.where("published_at <= ?", Time.current) }
 
   def body_or_title
     errors.add(:base, "A body or a title must be present") unless content.body.present? || title.present?
@@ -37,8 +37,8 @@ class Post < ApplicationRecord
     title&.parameterize&.truncate(72, omission: "") || ""
   end
 
-  def published?
-    published_at <= Time.current
+  def pending?
+    published_at > Time.current
   end
 
   def summary(limit: 64)

--- a/app/models/post_digest.rb
+++ b/app/models/post_digest.rb
@@ -16,7 +16,7 @@ class PostDigest < ApplicationRecord
     last_digest = blog.post_digests.delivered.order(created_at: :desc).first
     since_date = last_digest&.created_at || 1.week.ago
 
-    new_posts = blog.posts
+    new_posts = blog.posts.visible
       .where.not(id: DigestPost.select(:post_id))
       .where("created_at > ?", since_date)
 

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -9,7 +9,7 @@
       <%= render "drop_down_menu" %>
   </div>
 
-  <%= form_with(model: [:app, @post]) do |form| %>
+  <%= form_with(model: [:app, @post], html: { id: "post-form" }) do |form| %>
 
     <div class="hidden mb-8" data-post-attributes-target="section" data-section="published-at">
       <div class="mt-4 font-bold">
@@ -43,7 +43,14 @@
         data: { controller: "autogrow trix", subscribed: Current.user.subscribed? } %>
     </div>
 
-    <%= form.submit class: "mt-8 btn-primary" %>
-    <%= link_to "Cancel", app_posts_path, class: "btn-secondary" %>
+    <div class="flex items-center justify-between mt-8">
+      <div>
+        <%= form.submit publish_button_text(@post), class: "btn-primary" %>
+        <%= link_to "Cancel", app_posts_path, class: "btn-secondary" %>
+      </div>
+      <div>
+        <%= form.button draft_button_text(@post), value: "save_draft", class: "btn-optional" %>
+      </div>
+    </div>
   <% end %>
 </div>

--- a/app/views/app/posts/index.html.erb
+++ b/app/views/app/posts/index.html.erb
@@ -75,8 +75,8 @@
           <div class="flex items-top gap-x-4 text-slate-400 dark:text-slate-400">
             <% if @user.subscribed? && post.upvotes_count > 0 %>
               <div class="flex items-top gap-x-0.5">
-                <span class="mt-1"><%= inline_svg_tag "icons/heart.svg", class: "w-4 h-4" %></span>
                 <%= post.upvotes_count %>
+                <span class="mt-1"><%= inline_svg_tag "icons/heart.svg", class: "w-4 h-4" %></span>
                </div>
             <% end %>
 

--- a/app/views/app/posts/index.html.erb
+++ b/app/views/app/posts/index.html.erb
@@ -27,32 +27,67 @@
       <% end %>
     </p>
 
-    <% @posts.each do |post| %>
-      <div class="flex gap-x-4 justify-between px-4 py-4 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-lg break-words">
-        <div class="flex flex-col">
-          <%= link_to edit_app_post_path(post), title: "Click to edit this post" do %>
-            <div class="font-semibold">
-              <%= post_title(post) %>
+    <% if @drafts.any? %>
+      <div class="mb-8" id="draft_posts">
+        <div class="text-lg font-semibold mb-4 text-slate-900 dark:text-slate-100">
+          🖋️ Drafts
+        </div>
+
+        <% @drafts.each do |post| %>
+          <div class="flex gap-x-2 mb-2 items-top">
+            <div class="text-slate-500 dark:text-slate-400 w-16 flex-shrink-0">
+              <%= post.published_at.to_date.to_formatted_s(:short) %>
             </div>
-
-            <div class="mt-2 text-xs text-slate-400 dark:text-slate-400">
-              <%= post.published_at.to_formatted_s(:long) %>
-
-              <% if @user.subscribed? %>
-                <div class="mt-1 flex items-center gap-x-0.5">
-                  <%= inline_svg_tag "icons/heart.svg", class: "w-4 h-4" %><%= post.upvotes_count %>
+            <div class="flex w-full justify-between items-top">
+              <%= link_to edit_app_post_path(post), title: "Click to edit this post" do %>
+                <div class="font-medium pe-2">
+                  <%= post_title(post) %>
                 </div>
               <% end %>
             </div>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
 
-        <div class="text-slate-400 dark:text-slate-400 ">
-          <% if post.published? %>
-            <%= link_to post_path(post), title: "View this post" do %>
-              <%= inline_svg_tag "icons/arrow-top-right-on-square.svg", class: "w-5 h-5" %>
+    <% previous_year = nil %>
+    <% @posts.each do |post| %>
+      <% if post.published_at.year != previous_year %>
+        <div class="text-lg font-semibold mb-4 text-slate-900 dark:text-slate-100 <%= 'mt-8' unless previous_year.nil? %>">
+          <%= post.published_at.year %>
+
+          <% previous_year = post.published_at.year %>
+        </div>
+      <% end %>
+
+      <div class="flex gap-x-2 mb-2 items-top">
+        <div class="text-slate-500 dark:text-slate-400 w-16 flex-shrink-0">
+          <%= post.published_at.to_date.to_formatted_s(:short) %>
+        </div>
+        <div class="flex w-full justify-between items-top">
+          <div>
+            <%= link_to edit_app_post_path(post), title: "Click to edit this post" do %>
+              <div class="font-medium pe-2">
+                <%= post_title(post) %>
+              </div>
             <% end %>
-          <% end %>
+          </div>
+          <div class="flex items-top gap-x-4 text-slate-400 dark:text-slate-400">
+            <% if @user.subscribed? && post.upvotes_count > 0 %>
+              <div class="flex items-top gap-x-0.5">
+                <span class="mt-1"><%= inline_svg_tag "icons/heart.svg", class: "w-4 h-4" %></span>
+                <%= post.upvotes_count %>
+               </div>
+            <% end %>
+
+            <div>
+              <% unless post.pending? %>
+                <%= link_to post_path(post), title: "View this post" do %>
+                  <%= inline_svg_tag "icons/arrow-top-right-on-square.svg", class: "w-5 h-5" %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
         </div>
       </div>
     <% end %>

--- a/db/migrate/20250411072658_add_status_to_post.rb
+++ b/db/migrate/20250411072658_add_status_to_post.rb
@@ -1,0 +1,8 @@
+class AddStatusToPost < ActiveRecord::Migration[8.1]
+  def change
+    add_column :posts, :status, :integer, default: 1
+
+    add_index :posts, :status
+    change_column_null :posts, :status, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_03_18_132638) do
+ActiveRecord::Schema[8.1].define(version: 2025_04_11_072658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -175,12 +175,14 @@ ActiveRecord::Schema[8.1].define(version: 2025_03_18_132638) do
     t.datetime "created_at", null: false
     t.datetime "published_at"
     t.text "raw_content"
+    t.integer "status", default: 1, null: false
     t.string "title"
     t.string "token", null: false
     t.datetime "updated_at", null: false
     t.integer "upvotes_count", default: 0, null: false
     t.index ["blog_id"], name: "index_posts_on_blog_id"
     t.index ["published_at"], name: "index_posts_on_published_at"
+    t.index ["status"], name: "index_posts_on_status"
     t.index ["token"], name: "index_posts_on_token", unique: true
   end
 

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -166,11 +166,15 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
   test "should insert author attribution into the head" do
     blog = blogs(:joel)
 
-    get post_without_title_path(blog.name, blog.posts.first.token)
+    get post_without_title_path(blog.name, blog.posts.visible.first.token)
+
+    assert_response :success
     assert_select 'meta[name="fediverse:creator"][content="@joel@pagecord.com"]', count: 0
 
     blog.update!(fediverse_author_attribution: "@joel@pagecord.com")
-    get post_without_title_path(blog.name, blog.posts.first.token)
+
+    assert_response :success
+    get post_without_title_path(blog.name, blog.posts.visible.first.token)
 
     assert_select 'meta[name="fediverse:creator"][content="@joel@pagecord.com"]'
   end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,23 +1,44 @@
+DEFAULTS: &default
+  status: published
+
 one:
   title: The Art of Street Photography
   blog: joel
   published_at: <%= 1.day.ago %>
   token: <%= SecureRandom.hex(4) %>
+  <<: *default
 
 two:
   title: The Beauty of Landscape Photography
   blog: joel
   published_at: <%= 2.days.ago %>
   token: <%= SecureRandom.hex(4) %>
+  <<: *default
 
 three:
   title: My first post
   blog: vivian
   published_at: <%= 1.week.ago %>
   token: <%= SecureRandom.hex(4) %>
+  <<: *default
 
 four:
   title: What I've learned about photography
   blog: annie
   published_at: <%= 1.day.ago %>
   token: <%= SecureRandom.hex(4) %>
+  <<: *default
+
+joel_draft:
+  title: Draft post
+  blog: joel
+  token: <%= SecureRandom.hex(4) %>
+  published_at: <%= 1.day.ago %>
+  status: draft
+
+vivian_draft:
+  title: Draft post
+  blog: vivian
+  token: <%= SecureRandom.hex(4) %>
+  published_at: <%= 1.day.ago %>
+  status: draft

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -31,9 +31,25 @@ class PostTest < ActiveSupport::TestCase
     assert_equal published_at.to_time.to_i, post.published_at.to_time.to_i
   end
 
-  test "should exclude future-dated posts from published" do
+  test "should exclude future-dated posts from visible scope" do
     post = Post.create(blog: blogs(:joel), title: "a new post", published_at: 1.day.from_now)
+    assert_not Post.visible.include?(post)
+  end
+
+  test "should exclude draft posts from visible scope" do
+    post = Post.create(blog: blogs(:joel), title: "a new post", status: :draft)
+    assert_not Post.visible.include?(post)
+  end
+
+  test "should exclude draft posts from published scope" do
+    post = Post.create(blog: blogs(:joel), title: "a new post", status: :draft)
     assert_not Post.published.include?(post)
+  end
+
+  test "should include draft posts in draft scope" do
+    post = Post.create(blog: blogs(:joel), title: "a new post", status: :draft)
+    assert Post.draft.include?(post)
+    assert Post.draft.include?(posts(:joel_draft))
   end
 
   test "post with blank title and body should be invalid" do

--- a/test/system/upvote_post_test.rb
+++ b/test/system/upvote_post_test.rb
@@ -6,7 +6,7 @@ class UpvotePostTest < ApplicationSystemTestCase
     blog.features << "upvotes"
     blog.save!
 
-    post = blog.posts.first
+    post = blog.posts.published.first
     initial_upvotes = post.upvotes.count
 
     visit post_without_title_path(post.blog.name, post.token)


### PR DESCRIPTION
This PR adds a new enum `status` field to post. The allowed values are `published` (the default) and `draft`. When editing in the app, you can choose to save a post as draft or publish it. If a post is already published, you can unpublished it. 

The app posts index view has also been reworked to make better use of space and display drafts at the top.

<img width="751" alt="Screenshot 2025-04-11 at 10 56 50" src="https://github.com/user-attachments/assets/ce64163c-c77e-4ba1-ae8b-6754cb5ca334" />
