### PR TITLE
Option to show logo with custom domain

### DIFF
--- a/app/controllers/app/settings/appearance_controller.rb
+++ b/app/controllers/app/settings/appearance_controller.rb
@@ -20,8 +20,10 @@ class App::Settings::AppearanceController < AppController
         social_links_attributes: [ :id, :platform, :url, :_destroy ]
       ]
 
-      # Only allow avatar updates for subscribed users
-      permitted_params << :avatar if @blog.user.subscribed?
+      permitted_params << [
+        :avatar,
+        :show_branding
+       ] if @blog.user.subscribed?
 
       params.require(:blog).permit(permitted_params)
     end

--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -33,7 +33,8 @@ class App::Settings::BlogsController < AppController
       permitted_params << [
         :custom_domain,
         :email_subscriptions_enabled,
-        :reply_by_email
+        :reply_by_email,
+        :show_upvotes
       ] if @blog.user.subscribed?
 
       params.require(:blog).permit(permitted_params)

--- a/app/views/app/settings/appearance/_form.html.erb
+++ b/app/views/app/settings/appearance/_form.html.erb
@@ -79,6 +79,23 @@
     <% end %>
   </div>
 
+  <% if @blog.user.subscribed? %>
+    <h3 class="mt-8 font-bold text-lg mb-4">Branding</h3>
+
+    <div class="flex gap-3">
+      <div class="flex h-6 shrink-0 items-center">
+        <%= form.check_box :show_branding, { checked: @blog.show_branding, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" } %>
+      </div>
+      <div>
+        <%= form.label :show_branding, "Show Pagecord branding", class: "text-slate-800 dark:text-slate-100" %>
+        <p class="text-slate-500 text-sm">
+          When checked, the Pagecord logo will be displayed at the bottom of each page on your blog. Please consider
+          keeping this on to help spread the word about Pagecord!
+        </p>
+      </div>
+    </div>
+  <% end %>
+
   <div class="mt-12 flex items-center border-t border-t-slate-200 dark:border-slate-600 pt-4">
     <%= form.submit "Update", class: "btn-primary" %>
     <%= link_to "Cancel", app_settings_path, class: "btn-secondary" %>

--- a/app/views/app/settings/audience/index.html.erb
+++ b/app/views/app/settings/audience/index.html.erb
@@ -34,6 +34,21 @@
     </div>
   </div>
 
+  <div class="mt-6">
+    <div class="flex gap-3">
+      <div class="flex h-6 shrink-0 items-center">
+        <%= form.check_box :show_upvotes, { checked: @blog.show_upvotes, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" } %>
+      </div>
+      <div>
+        <%= form.label :show_upvotes, "Show Post Likes ❤️", class: "text-slate-800 dark:text-slate-100" %>
+        <p class="text-slate-500 text-sm">
+          When checked, a heart-shaped like button will appear next to each post for readers to show
+          their appreciation.
+        </p>
+      </div>
+    </div>
+  </div>
+
   <div class="mt-12 flex items-cente pt-4 border-t border-t-slate-200 dark:border-slate-600">
     <%= form.submit "Update", class: "btn-primary" %>
     <%= link_to "Cancel", app_settings_path, class: "btn-secondary" %>

--- a/app/views/blogs/posts/_post.html.erb
+++ b/app/views/blogs/posts/_post.html.erb
@@ -19,8 +19,10 @@
           <% end %>
         <% end %>
 
-        <%= turbo_frame_tag dom_id(post, :upvotes) do %>
-          <%= render "upvotes", post: post %>
+        <% if @user.blog.show_upvotes? %>
+          <%= turbo_frame_tag dom_id(post, :upvotes) do %>
+            <%= render "upvotes", post: post %>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,8 @@
     </main>
 
     <footer class="w-full flex flex-col text-center p-8 text-sm text-slate-400 dark:text-slate-500">
-      <% unless custom_domain_request? %>
-        <%= link_to root_path do %>
+      <% if @blog&.show_branding? %>
+        <%= link_to root_path, id: "brand" do %>
           <%= inline_svg_tag "logo.svg", class: "w-[100px] mt-8 inline-flex dark:text-slate-100 text-slate-900" %>
         <% end %>
       <% end %>

--- a/db/migrate/20250514105147_add_show_upvotes_flag_to_blog.rb
+++ b/db/migrate/20250514105147_add_show_upvotes_flag_to_blog.rb
@@ -1,0 +1,5 @@
+class AddShowUpvotesFlagToBlog < ActiveRecord::Migration[8.1]
+  def change
+    add_column :blogs, :show_upvotes, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20250514111136_add_show_branding_flag_to_blog.rb
+++ b/db/migrate/20250514111136_add_show_branding_flag_to_blog.rb
@@ -1,0 +1,5 @@
+class AddShowBrandingFlagToBlog < ActiveRecord::Migration[8.1]
+  def change
+    add_column :blogs, :show_branding, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_05_11_000001) do
+ActiveRecord::Schema[8.1].define(version: 2025_05_14_105147) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -94,6 +94,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_05_11_000001) do
     t.integer "layout", default: 0
     t.string "name", null: false
     t.boolean "reply_by_email", default: false, null: false
+    t.boolean "show_upvotes", default: true, null: false
     t.string "theme", default: "base", null: false
     t.string "title"
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_05_14_105147) do
+ActiveRecord::Schema[8.1].define(version: 2025_05_14_111136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -94,6 +94,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_05_14_105147) do
     t.integer "layout", default: 0
     t.string "name", null: false
     t.boolean "reply_by_email", default: false, null: false
+    t.boolean "show_branding", default: true, null: false
     t.boolean "show_upvotes", default: true, null: false
     t.string "theme", default: "base", null: false
     t.string "title"

--- a/test/controllers/app/settings/appearance_controller_test.rb
+++ b/test/controllers/app/settings/appearance_controller_test.rb
@@ -56,6 +56,26 @@ class App::Settings::AppearanceControllerTest < ActionDispatch::IntegrationTest
     assert_equal "title_layout", @blog.reload.layout
   end
 
+  test "should update show branding flag for subscriber" do
+    patch app_settings_appearance_url(@blog), params: { blog: { show_branding: false } }, as: :turbo_stream
+
+    assert_redirected_to app_settings_url
+    assert_not @blog.reload.show_branding
+    assert_select "input#blog_show_branding[checked]", false
+  end
+
+  test "should not update show branding flag for non-subscriber" do
+    @user = users(:vivian)
+    login_as @user
+    @blog = @user.blog
+
+    patch app_settings_appearance_url(@blog), params: { blog: { show_branding: false } }, as: :turbo_stream
+
+    assert_redirected_to app_settings_url
+    assert @blog.reload.show_branding
+    assert_select "input#blog_show_branding", false
+  end
+
   test "should update avatar if subscribed" do
     file = fixture_file_upload("avatar.png", "image/png")
     patch app_settings_appearance_url(@blog), params: { blog: { avatar: file } }, as: :turbo_stream

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -225,6 +225,34 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "link[rel='icon'][type='image/svg+xml'][href*='/assets/favicon']"
   end
 
+  test "should render upvotes for a subscriber" do
+    blog = blogs(:joel)
+
+    get "/#{blog.name}"
+
+    assert_response :success
+    assert_select "turbo-frame[id^='upvotes_post_']"
+  end
+
+  test "should not render upvotes for a non-subscriber" do
+    blog = blogs(:vivian)
+
+    get "/#{blog.name}"
+
+    assert_response :success
+    assert_select "turbo-frame[id^='upvotes_post_']", count: 0
+  end
+
+  test "should not render upvotes if show_upvotes is false" do
+    blog = blogs(:joel)
+    blog.update!(show_upvotes: false)
+
+    get "/#{blog.name}"
+
+    assert_response :success
+    assert_select "turbo-frame[id^='upvotes_post_']", count: 0
+  end
+
   test "post published_at is stored and rendered correctly in UTC" do
     user = users(:joel)
     user.update!(timezone: "Hawaii")

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -272,4 +272,23 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "time[datetime='2025-05-11T10:00:00Z']"
   end
+
+  test "should pagecord branding" do
+    blog = blogs(:joel)
+
+    get "/#{blog.name}"
+
+    assert_response :success
+    assert_select "footer a[id=brand]", count: 1
+  end
+
+  test "should hide pagecord branding when show_branding off" do
+    blog = blogs(:joel)
+    blog.update!(show_branding: false)
+
+    get "/#{blog.name}"
+
+    assert_response :success
+    assert_select "footer a[id=brand]", count: 0
+  end
 end


### PR DESCRIPTION
The Pagecord logo is now _always_ displayed for free or paying customers, custom domain or not. There is now a flag to disable this in the appearance settings.

Fixes https://github.com/lylo/pagecord/issues/255