### PR TITLE
New slug field on Post

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -160,6 +160,10 @@ trix-editor {
     }
   }
 
+  trix-editor[placeholder]::before {
+    color: var(--color-slate-600);
+  }
+
   li::marker {
     color: #9ba1aa;
   }

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -12,7 +12,7 @@ class App::PostsController < AppController
   end
 
   def edit
-    @post = Current.user.blog.posts.find_by!(token: params[:id])
+    @post = Current.user.blog.posts.find_by!(token: params[:token])
 
     prepare_content_for_trix
   end
@@ -23,36 +23,33 @@ class App::PostsController < AppController
       redirect_to app_posts_path, notice: "Post was successfully created"
     else
       @post = post
-      flash.now.alert = @post.errors.full_messages.to_sentence
       render :new, status: :unprocessable_entity
     end
   end
 
   def update
-    post = Current.user.blog.posts.find_by!(token: params[:id])
+    @post = Current.user.blog.posts.find_by!(token: params[:token])
 
-    if post.update(post_params)
+    if @post.update(post_params)
       redirect_to app_posts_path, notice: "Post was successfully updated"
     else
-      @post = post
-      flash.now.alert = @post.errors.full_messages.to_sentence
+      prepare_content_for_trix
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
-    post = Current.user.blog.posts.find_by!(token: params[:id])
+    post = Current.user.blog.posts.find_by!(token: params[:token])
     post.destroy!
 
     redirect_to app_posts_path, notice: "Post was successfully deleted"
   end
 
   private
-
     def post_params
       status = params[:button] == "save_draft" ? :draft : :published
 
-      params.require(:post).permit(:title, :content, :published_at, :canonical_url).merge(status: status)
+      params.require(:post).permit(:title, :content, :slug, :published_at, :canonical_url).merge(status: status)
     end
 
     # HTML from inbound email doesn't often play nicely with Trix

--- a/app/controllers/blogs/base_controller.rb
+++ b/app/controllers/blogs/base_controller.rb
@@ -5,7 +5,7 @@ class Blogs::BaseController < ApplicationController
   protected
 
   def blog_params
-    params.slice(:name, :page, :title, :token)
+    params.slice(:name, :page, :slug)
   end
 
   private

--- a/app/controllers/blogs/posts_controller.rb
+++ b/app/controllers/blogs/posts_controller.rb
@@ -23,7 +23,7 @@ class Blogs::PostsController < Blogs::BaseController
   def show
     @post = @blog.posts.visible
       .with_rich_text_content_and_embeds
-      .find_by!(token: blog_params[:token])
+      .find_by!(slug: blog_params[:slug])
 
     fresh_when @post, public: true, template: "blogs/posts/show"
   end

--- a/app/controllers/posts/replies_controller.rb
+++ b/app/controllers/posts/replies_controller.rb
@@ -35,7 +35,7 @@ class Posts::RepliesController < Blogs::BaseController
     end
 
     def load_post
-      @post = @blog.posts.find_by!(token: params[:post_id])
+      @post = @blog.posts.find_by!(token: params[:post_token])
     end
 
     def verify

--- a/app/controllers/posts/upvotes_controller.rb
+++ b/app/controllers/posts/upvotes_controller.rb
@@ -22,6 +22,6 @@ class Posts::UpvotesController < Blogs::BaseController
   private
 
     def load_post
-      @post = @blog.posts.find_by!(token: params[:post_id])
+      @post = @blog.posts.find_by!(token: params[:post_token])
     end
 end

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -1,12 +1,9 @@
 module RoutingHelper
   def post_link(post, type)
-    # Ensure we have a slug or use ID as fallback
-    slug = post.slug.presence || post.id.to_s
-
     if post.blog.custom_domain?
-      send("custom_blog_post_#{type}", slug, host: post.blog.custom_domain)
+      send("custom_blog_post_#{type}", post.slug, host: post.blog.custom_domain)
     else
-      send("blog_post_#{type}", post.blog.name, slug)
+      send("blog_post_#{type}", post.blog.name, post.slug)
     end
   end
 

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -1,17 +1,12 @@
 module RoutingHelper
   def post_link(post, type)
+    # Ensure we have a slug or use ID as fallback
+    slug = post.slug.presence || post.id.to_s
+
     if post.blog.custom_domain?
-      if post.url_title.present?
-        send("custom_post_with_title_#{type}", post.url_title, post.token, host: post.blog.custom_domain)
-      else
-        send("custom_post_without_title_#{type}", post.token, host: post.blog.custom_domain)
-      end
+      send("custom_blog_post_#{type}", slug, host: post.blog.custom_domain)
     else
-      if post.url_title.present?
-        send("post_with_title_#{type}", post.blog.name, post.url_title, post.token)
-      else
-        send("post_without_title_#{type}", post.blog.name, post.token)
-      end
+      send("blog_post_#{type}", post.blog.name, slug)
     end
   end
 
@@ -70,17 +65,17 @@ module RoutingHelper
 
   def new_post_reply_path_for(post)
     if post.blog.custom_domain?
-      new_custom_post_reply_path(post.token)
+      new_custom_post_reply_path(post)
     else
-      new_post_reply_path(post.blog.name, post.token)
+      new_post_reply_path(post.blog.name, post)
     end
   end
 
   def post_replies_path_for(post)
     if post.blog.custom_domain?
-      custom_post_replies_path(post.token)
+      custom_post_replies_path(post)
     else
-      post_replies_path(post.blog.name, post.token)
+      post_replies_path(post.blog.name, post)
     end
   end
 
@@ -88,17 +83,17 @@ module RoutingHelper
 
   def post_upvote_path_for(post, upvote)
     if post.blog.custom_domain?
-      custom_post_upvote_path(post.token, upvote)
+      custom_post_upvote_path(post, upvote)
     else
-      post_upvote_path(post.blog.name, post.token, upvote)
+      post_upvote_path(post.blog.name, post, upvote)
     end
   end
 
   def post_upvotes_path_for(post)
     if post.blog.custom_domain?
-      custom_post_upvotes_path(post.token)
+      custom_post_upvotes_path(post)
     else
-      post_upvotes_path(post.blog.name, post.token)
+      post_upvotes_path(post.blog.name, post)
     end
   end
 end

--- a/app/models/blog/export.rb
+++ b/app/models/blog/export.rb
@@ -56,7 +56,7 @@ class Blog::Export < ApplicationRecord
       template_path = Rails.root.join("app/views/blog/exports/post.html.erb")
       template = ERB.new(File.read(template_path), trim_mode: "-")
 
-      File.open(File.join(dir, "#{post.to_title_param}.html"), "w") do |file|
+      File.open(File.join(dir, "#{post.slug}.html"), "w") do |file|
         file.write(template.result(binding))
       end
     end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -13,6 +13,8 @@ module Sluggable
       loop do
         self.slug = to_title_param
         break unless self.class.exists?(slug: slug)
+
+        self.slug = "#{slug}-#{SecureRandom.hex(4)}"
       end
     end
 end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -11,8 +11,9 @@ module Sluggable
       return if slug.present?
 
       loop do
+        puts self.blog.posts.count
         self.slug = to_title_param
-        break unless self.class.exists?(slug: slug)
+        break unless self.blog.posts.exists?(slug: slug)
 
         self.slug = "#{slug}-#{SecureRandom.hex(4)}"
       end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -2,20 +2,46 @@ module Sluggable
   extend ActiveSupport::Concern
 
   included do
-    before_create :set_slug
+    before_validation :set_slug
+    validates :slug,
+      presence: true,
+      length: { maximum: 100 },
+      format: {
+        with: /\A[a-z0-9]+(-[a-z0-9]+)*\z/,
+        message: "can only contain lowercase letters, numbers, and single hyphens between words"
+      },
+      uniqueness: {
+        scope: :blog_id,
+        message: "This slug has already been taken. Please choose another one."
+      }
   end
 
   private
 
     def set_slug
-      return if slug.present?
-
-      loop do
-        puts self.blog.posts.count
-        self.slug = to_title_param
-        break unless self.blog.posts.exists?(slug: slug)
-
-        self.slug = "#{slug}-#{SecureRandom.hex(4)}"
+      if slug.blank? || title_changed?
+        generate_slug
       end
+    end
+
+    def generate_slug
+      temp_token = self.token.presence || SecureRandom.hex(4)
+      base_slug = parameterized_title.presence || temp_token
+
+      candidate_slug = base_slug
+      while slug_taken?(candidate_slug)
+        candidate_slug = "#{base_slug}-#{temp_token}"
+        temp_token = SecureRandom.hex(4)
+      end
+
+      self.slug = candidate_slug
+    end
+
+    def slug_taken?(candidate)
+      blog.posts.where.not(id: id).exists?(slug: candidate)
+    end
+
+    def parameterized_title
+      title.to_s.parameterize.truncate(100, omission: "") || ""
     end
 end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -1,0 +1,18 @@
+module Sluggable
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :set_slug
+  end
+
+  private
+
+    def set_slug
+      return if slug.present?
+
+      loop do
+        self.slug = to_title_param
+        break unless self.class.exists?(slug: slug)
+      end
+    end
+end

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -2,15 +2,20 @@ module Tokenable
   extend ActiveSupport::Concern
 
   included do
-    before_create :set_token
+    # Use prepend: true to ensure this runs before other before_validation callbacks
+    before_validation :set_token, prepend: true
   end
 
   private
 
     def set_token
+      self.token ||= generate_unique_token
+    end
+
+    def generate_unique_token
       loop do
-        self.token = SecureRandom.hex(4)
-        break unless self.class.exists?(token: token)
+        token = SecureRandom.hex(4)
+        break token unless self.class.exists?(token: token)
       end
     end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,14 +14,10 @@ class Post < ApplicationRecord
   before_create :set_published_at, :limit_content_size
   after_create  :detect_open_graph_image
 
-  validate :body_or_title
+  validates :content, presence: true
   # validates :slug, presence: true, length: { maximum: 100 }, uniqueness: { scope: :blog_id }
 
   scope :visible, -> { published.where("published_at <= ?", Time.current) }
-
-  def body_or_title
-    errors.add(:base, "A body or a title must be present") unless content.body.present? || title.present?
-  end
 
   def to_param
     token

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,7 +15,6 @@ class Post < ApplicationRecord
   after_create  :detect_open_graph_image
 
   validate :content_present
-  # validates :slug, presence: true, length: { maximum: 100 }, uniqueness: { scope: :blog_id }
 
   scope :visible, -> { published.where("published_at <= ?", Time.current) }
 
@@ -25,18 +24,6 @@ class Post < ApplicationRecord
 
   def to_param
     token
-  end
-
-  def to_title_param
-    if url_title.blank?
-      token
-    else
-      "#{url_title}-#{token}"
-    end
-  end
-
-  def url_title
-    title&.parameterize&.truncate(72, omission: "") || ""
   end
 
   def pending?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,10 +14,14 @@ class Post < ApplicationRecord
   before_create :set_published_at, :limit_content_size
   after_create  :detect_open_graph_image
 
-  validates :content, presence: true
+  validate :content_present
   # validates :slug, presence: true, length: { maximum: 100 }, uniqueness: { scope: :blog_id }
 
   scope :visible, -> { published.where("published_at <= ?", Time.current) }
+
+  def content_present
+    errors.add(:content, "can't be blank") unless content.body.present?
+  end
 
   def to_param
     token

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-  include Draftable, Tokenable, Trimmable, Upvotable
+  include Draftable, Sluggable, Tokenable, Trimmable, Upvotable
 
   belongs_to :blog, inverse_of: nil
 
@@ -15,7 +15,7 @@ class Post < ApplicationRecord
   after_create  :detect_open_graph_image
 
   validate :body_or_title
-  # validates :slug, presence: true, length: { maximum: 150 }, uniqueness: { scope: :blog_id }
+  # validates :slug, presence: true, length: { maximum: 100 }, uniqueness: { scope: :blog_id }
 
   scope :visible, -> { published.where("published_at <= ?", Time.current) }
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,6 +15,7 @@ class Post < ApplicationRecord
   after_create  :detect_open_graph_image
 
   validate :body_or_title
+  # validates :slug, presence: true, length: { maximum: 150 }, uniqueness: { scope: :blog_id }
 
   scope :visible, -> { published.where("published_at <= ?", Time.current) }
 

--- a/app/views/app/feed/_post.html.erb
+++ b/app/views/app/feed/_post.html.erb
@@ -10,13 +10,7 @@
     <% end %>
   </div>
 
-  <% if post.title.present? %>
-    <%= link_to post_path(post), class: "no-underline", data: { turbo_frame: "_top" } do %>
-      <h1>
-        <%= post.title %>
-      </h1>
-    <% end %>
-  <% end %>
+  <%= render "/blogs/posts/post_title", post: post %>
 
   <%= auto_link post.content %>
 </article>

--- a/app/views/app/feed/index.html.erb
+++ b/app/views/app/feed/index.html.erb
@@ -12,7 +12,9 @@
   <% end %>
 
   <%= turbo_frame_tag :feed do %>
-    <%= render partial: "post", collection: @posts, cached: true %>
+    <div class="blog">
+      <%= render partial: "post", collection: @posts, cached: true %>
+    </div>
   <% end %>
 
   <% if @pagy.next %>

--- a/app/views/app/posts/_drop_down_menu.html.erb
+++ b/app/views/app/posts/_drop_down_menu.html.erb
@@ -16,6 +16,13 @@
         <% end %>
       </div>
 
+      <div class="p-1">
+        <%= link_to "#", class: "flex rounded-lg px-2 py-1 text-sm text-gray-500 dark:text-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-50",
+          data: { action: "click->post-attributes#showSection", toggle_target: "slug" } do %>
+          <span class="ms-1">Change Slug</span>
+        <% end %>
+      </div>
+
       <% if @post.persisted? %>
         <hr class="mx-2 mt-2 dark:border-gray-600">
 

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -23,6 +23,23 @@
       </div>
     </div>
 
+    <div class="<%= 'hidden' unless @post.errors[:slug].any? %> mb-8" data-post-attributes-target="section" data-section="slug">
+      <div class="mt-4 font-bold">
+      <%= form.label :slug, "Slug" %>
+      </div>
+
+      <div class="mt-2">
+        <%= form.text_field :slug,
+            class: "w-full placeholder-slate-300 dark:placeholder-slate-600 dark:bg-slate-900 border border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg #{'!border-red-500' if @post.errors[:slug].any?}",
+            placeholder: "custom-url-path" %>
+        <% if @post.errors[:slug].any? %>
+          <div class="mt-1 text-xs text-red-500">
+            <%= @post.errors[:slug].to_sentence %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
     <div class="hidden mb-8" data-post-attributes-target="section" data-section="canonical-url">
       <div class="mt-4 font-bold">
       <%= form.label :canonical_url, "Canonical URL" %>

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -43,7 +43,7 @@
       data: { controller: "autogrow trix", attachments: true } %>
     <% if @post.errors[:content].any? %>
       <div class="mt-1 text-xs text-red-500">
-      <%= @post.errors[:content].join(", ") %>
+        A body is required
       </div>
     <% end %>
     </div>

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -50,12 +50,15 @@
       </div>
     </div>
 
-    <%= form.text_field :title, placeholder: "Optional post title", class: "w-full placeholder-slate-300 dark:placeholder-slate-600 dark:bg-slate-900 border border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg" %>
+    <%= form.text_field :title,
+    placeholder: "Optional post title",
+    class: "w-full placeholder-slate-300 dark:placeholder-slate-600 dark:bg-slate-900 border border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg focus:outline-none focus:ring-0 focus:border-slate-500 dark:focus:border-slate-400",
+    autofocus: true %>
 
     <div class="trix-container <%= 'trix-no-attachments' unless Current.user.subscribed? %>">
     <%= form.rich_text_area :content,
       placeholder: "Write your post...",
-      class: "trix-content #{'!border-red-500' if @post.errors[:content].any?}",
+      class: "trix-content focus:ring-0 focus:!border-slate-500 dark:focus:!border-slate-400 #{'!border-red-500' if @post.errors[:content].any?}",
       spellcheck: true,
       data: { controller: "autogrow trix", attachments: true } %>
     <% if @post.errors[:content].any? %>

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -35,12 +35,17 @@
 
     <%= form.text_field :title, placeholder: "Optional post title", class: "w-full placeholder-slate-300 dark:placeholder-slate-600 dark:bg-slate-900 border border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 rounded-lg" %>
 
-    <div class="trix-container <%= "trix-no-attachments" unless Current.user.subscribed? %>">
+    <div class="trix-container <%= 'trix-no-attachments' unless Current.user.subscribed? %>">
     <%= form.rich_text_area :content,
-        placeholder: "Write your post...",
-        class: "trix-content",
-        spellcheck: true,
-        data: { controller: "autogrow trix", attachments: true } %>
+      placeholder: "Write your post...",
+      class: "trix-content #{'!border-red-500' if @post.errors[:content].any?}",
+      spellcheck: true,
+      data: { controller: "autogrow trix", attachments: true } %>
+    <% if @post.errors[:content].any? %>
+      <div class="mt-1 text-xs text-red-500">
+      <%= @post.errors[:content].join(", ") %>
+      </div>
+    <% end %>
     </div>
 
     <div class="flex items-center justify-between mt-8">

--- a/app/views/blog/exports/index.html.erb
+++ b/app/views/blog/exports/index.html.erb
@@ -20,7 +20,7 @@
     <% end -%>
     <li>
       <%= post.published_at.strftime("%d %b") %> &mdash;
-      <a href="<%= post.to_title_param %>.html"><%= post.title.presence || post.summary %></a>
+      <a href="<%= post.slug %>.html"><%= post.title.presence || post.summary %></a>
     </li>
   <% end -%>
   <% if blog.posts.any? -%>

--- a/app/views/blogs/posts/_post_title.html.erb
+++ b/app/views/blogs/posts/_post_title.html.erb
@@ -1,5 +1,5 @@
 <% if post.title.present? %>
-  <%= link_to post_path(post), class: "no-underline", data: { turbo_frame: "_top" } do %>
+  <%= link_to post_url(post), class: "no-underline", data: { turbo_frame: "_top" } do %>
     <h1 class="post-title">
       <%= post.title %>
     </h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
   get "/verify/:token", to: "access_requests#verify", as: :verify_access_request
 
   namespace :app do
-    resources :posts
+    resources :posts, param: :token
     resources :settings, only: [ :index ]
 
     resource :onboarding, only: [ :show, :update ], path: "onboarding" do
@@ -139,8 +139,7 @@ Rails.application.routes.draw do
     get "/", to: "blogs/posts#index", as: :blog_posts
     get "/feed.xml", to: "blogs/posts#index", defaults: { format: :rss }, as: :blog_feed_xml
     get "/feed", to: "blogs/posts#index", defaults: { format: :rss }, as: :blog_feed
-    get "/:token", to: "blogs/posts#show", constraints: { token: /[0-9a-f]+/ }, as: :post_without_title
-    get "/:title-:token", to: "blogs/posts#show", constraints: { token: /[0-9a-f]+/ }, as: :post_with_title
+    get "/:slug", to: "blogs/posts#show", as: :blog_post
 
     resources :email_subscribers, controller: "blogs/email_subscribers", only: [ :create, :destroy ]
 
@@ -148,7 +147,7 @@ Rails.application.routes.draw do
     get "/email_subscribers/:token/unsubscribe", to: "blogs/email_subscribers/unsubscribes#show", as: :email_subscriber_unsubscribe
     post "/email_subscribers/:token/unsubscribe", to: "blogs/email_subscribers/unsubscribes#create"
 
-    resources :posts, only: [] do
+    resources :posts, only: [], param: :token do
       resources :upvotes, only: [ :create, :destroy ], module: :posts
       resources :replies, only: [ :new, :create ], module: :posts
     end

--- a/db/migrate/20250520074054_add_slug_to_post.rb
+++ b/db/migrate/20250520074054_add_slug_to_post.rb
@@ -1,0 +1,7 @@
+class AddSlugToPost < ActiveRecord::Migration[8.1]
+  def change
+    add_column :posts, :slug, :string
+
+    add_index :posts, [ :blog_id, :slug ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_05_14_111136) do
+ActiveRecord::Schema[8.1].define(version: 2025_05_20_074054) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -209,11 +209,13 @@ ActiveRecord::Schema[8.1].define(version: 2025_05_14_111136) do
     t.datetime "created_at", null: false
     t.datetime "published_at"
     t.text "raw_content"
+    t.string "slug"
     t.integer "status", default: 1, null: false
     t.string "title"
     t.string "token", null: false
     t.datetime "updated_at", null: false
     t.integer "upvotes_count", default: 0, null: false
+    t.index ["blog_id", "slug"], name: "index_posts_on_blog_id_and_slug", unique: true
     t.index ["blog_id"], name: "index_posts_on_blog_id"
     t.index ["published_at"], name: "index_posts_on_published_at"
     t.index ["status"], name: "index_posts_on_status"

--- a/lib/tasks/posts.rake
+++ b/lib/tasks/posts.rake
@@ -1,0 +1,9 @@
+namespace :posts do
+  desc "Backfill slugs for posts"
+  task backfill_slugs: :environment do
+    Post.find_each do |post|
+      post.slug = post.to_title_param
+      post.save!
+    end
+  end
+end

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -34,7 +34,7 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
     post = posts(:one)
 
-    get post_without_title_path(post.blog.name, post.token)
+    get blog_post_path(post.blog.name, post.slug)
 
     assert_response :success
     assert_equal posts(:one), assigns(:post)
@@ -106,7 +106,7 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
   test "should get show on custom domain" do
     post = posts(:four)
 
-    get "/#{post.token}", headers: { "HOST" => post.blog.custom_domain }
+    get "/#{post.slug}", headers: { "HOST" => post.blog.custom_domain }
 
     assert_response :success
   end
@@ -114,7 +114,7 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
   test "should redirect to pagecord home page for unrecognised custom domain" do
     post = posts(:four)
 
-    get "/#{post.token}", headers: { "HOST" => "gadzooks.com" }
+    get "/#{post.slug}", headers: { "HOST" => "gadzooks.com" }
 
     assert_redirected_to "http://www.example.com/"
   end
@@ -122,17 +122,17 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
   test "should redirect from default domain index to custom domain" do
     post = posts(:four)
 
-    get post_without_title_path(name: post.blog.name, token: post.token)
+    get blog_post_path(name: post.blog.name, slug: post.slug)
 
-    assert_redirected_to "http://#{post.blog.custom_domain}/#{post.token}"
+    assert_redirected_to "http://#{post.blog.custom_domain}/#{post.slug}"
   end
 
   test "should redirect from default domain post to custom domain post" do
     post = posts(:four)
 
-    get "/#{post.blog.name}/#{post.token}"
+    get "/#{post.blog.name}/#{post.slug}"
 
-    assert_redirected_to "http://#{post.blog.custom_domain}/#{post.token}"
+    assert_redirected_to "http://#{post.blog.custom_domain}/#{post.slug}"
   end
 
   test "should redirect to last page on pagy overflow" do
@@ -143,17 +143,17 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
 
   test "should set the canonical_url to the page URL by default" do
     post = posts(:one)
-    get post_without_title_path(post.blog.name, post.token)
+    get blog_post_path(post.blog.name, post.slug)
 
     assert_response :success
-    assert_select "link[rel=canonical][href=?]", post_without_title_url(post.blog.name, post.token)
+    assert_select "link[rel=canonical][href=?]", blog_post_url(post.blog.name, post.slug)
   end
 
   test "should set the canonical_url to the custom URL if present" do
     post = posts(:one)
     post.update!(canonical_url: "https://myblog.net")
 
-    get post_without_title_path(post.blog.name, post.token)
+    get blog_post_path(post.blog.name, post.slug)
 
     assert_response :success
     assert_select "link[rel=canonical][href=?]", "https://myblog.net"
@@ -178,7 +178,7 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
   test "should insert author attribution into the head" do
     blog = blogs(:joel)
 
-    get post_without_title_path(blog.name, blog.posts.visible.first.token)
+    get blog_post_path(blog.name, blog.posts.visible.first.slug)
 
     assert_response :success
     assert_select 'meta[name="fediverse:creator"][content="@joel@pagecord.com"]', count: 0
@@ -186,7 +186,7 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     blog.update!(fediverse_author_attribution: "@joel@pagecord.com")
 
     assert_response :success
-    get post_without_title_path(blog.name, blog.posts.visible.first.token)
+    get blog_post_path(blog.name, blog.posts.visible.first.slug)
 
     assert_select 'meta[name="fediverse:creator"][content="@joel@pagecord.com"]'
   end

--- a/test/controllers/posts/replies_controller_test.rb
+++ b/test/controllers/posts/replies_controller_test.rb
@@ -13,7 +13,9 @@ class Posts::RepliesControllerTest < ActionDispatch::IntegrationTest
 
   test "should get new reply form for custom domain" do
     post = posts(:four)
+
     get new_custom_post_reply_url(post, host: post.blog.custom_domain)
+
     assert_response :success
     assert_select "form[action=?]", custom_post_replies_path(post)
   end
@@ -21,7 +23,7 @@ class Posts::RepliesControllerTest < ActionDispatch::IntegrationTest
   test "should redirect to post if reply by email is disabled" do
     @post.blog.update(reply_by_email: false)
     get new_post_reply_path(@post.blog.name, @post)
-    assert_redirected_to post_with_title_path(@post.blog.name, @post.url_title, @post.token)
+    assert_redirected_to blog_post_path(@post.blog.name, @post.slug)
   end
 
   test "should create reply and send email" do
@@ -32,7 +34,7 @@ class Posts::RepliesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_enqueued_emails 1
-    assert_redirected_to post_with_title_path(@post.blog.name, @post.url_title, @post.token)
+    assert_redirected_to blog_post_path(@post.blog.name, @post.slug)
     follow_redirect!
     assert_equal "Reply sent successfully!", flash[:notice]
   end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -6,6 +6,7 @@ one:
   blog: joel
   published_at: <%= 1.day.ago %>
   token: <%= SecureRandom.hex(4) %>
+  slug: the-art-of-street-photography
   <<: *default
 
 two:
@@ -13,6 +14,7 @@ two:
   blog: joel
   published_at: <%= 2.days.ago %>
   token: <%= SecureRandom.hex(4) %>
+  slug: the-beauty-of-landscape-photography
   <<: *default
 
 three:
@@ -20,6 +22,7 @@ three:
   blog: vivian
   published_at: <%= 1.week.ago %>
   token: <%= SecureRandom.hex(4) %>
+  slug: my-first-post
   <<: *default
 
 four:
@@ -27,6 +30,7 @@ four:
   blog: annie
   published_at: <%= 1.day.ago %>
   token: <%= SecureRandom.hex(4) %>
+  slug: what-ive-learned-about-photography
   <<: *default
 
 joel_draft:
@@ -35,6 +39,7 @@ joel_draft:
   token: <%= SecureRandom.hex(4) %>
   published_at: <%= 1.day.ago %>
   status: draft
+  slug: draft-post
 
 vivian_draft:
   title: Draft post
@@ -42,9 +47,11 @@ vivian_draft:
   token: <%= SecureRandom.hex(4) %>
   published_at: <%= 1.day.ago %>
   status: draft
+  slug: draft-post-as232df4
 
 joel_titleless:
   blog: joel
   published_at: <%= 2.weeks.ago %>
   token: <%= SecureRandom.hex(4) %>
+  slug: d3423ssd4
   <<: *default

--- a/test/models/blog/export_test.rb
+++ b/test/models/blog/export_test.rb
@@ -39,7 +39,7 @@ class Blog::ExportTest < ActiveSupport::TestCase
     Dir.mktmpdir do |dir|
       export.send(:export_posts, dir)
 
-      html_file = File.join(dir, "#{@post.to_title_param}.html")
+      html_file = File.join(dir, "#{@post.slug}.html")
       assert File.exist?(html_file)
 
       content = File.read(html_file)

--- a/test/models/concerns/sluggable_test.rb
+++ b/test/models/concerns/sluggable_test.rb
@@ -7,15 +7,71 @@ class SluggableTest < ActiveSupport::TestCase
 
   test "should generate a slug before creating a post" do
     post = @blog.posts.create!(title: "A New Post", content: "This is a test post")
-    assert_equal post.to_title_param, post.slug
+    assert_equal "a-new-post", post.slug
   end
 
   test "should prevent a duplicate slug for the same blog" do
-    @blog.posts.as_json
-    post1 = @blog.posts.create!(title: "A New Post", content: "This is a test post")
+    post1 = @blog.posts.first
+    post2 = @blog.posts.create!(title: "A New Post", content: "This is a test post")
 
     assert_raises do
-      @blog.posts.create!(title: "A New Post", content: "This is a test post", slug: post1.slug)
+      post1.update!(slug: post2.slug)
     end
   end
+
+  test "should validate slug format" do
+    post = @blog.posts.first
+
+    assert_invalid_slug_format post, "Invalid Slug"
+    assert_invalid_slug_format post, "-invalid-slug"
+    assert_invalid_slug_format post, "invalid-slug-"
+    assert_invalid_slug_format post, "invalid slug"
+    assert_invalid_slug_format post, "invalid--slug"
+  end
+
+  test "should generate slug from token if title is blank" do
+    post = @blog.posts.create!(content: "Content without title")
+    assert_equal post.token, post.slug
+  end
+
+  test "should update slug when title changes" do
+    post = posts(:one)
+
+    post.update!(title: "Updated Title")
+
+    assert_equal "updated-title", post.slug
+  end
+
+  test "should handle duplicate slugs by appending a unique identifier" do
+    post1 = @blog.posts.create!(title: "Duplicate", content: "Content 1")
+    post2 = @blog.posts.create!(title: "Duplicate", content: "Content 2")
+
+    assert_equal "duplicate", post1.slug
+    assert_not_equal post1.slug, post2.slug
+    assert_equal "#{post1.slug}-#{post2.token}", post2.slug
+  end
+
+  test "should allow identical slugs across different blogs" do
+    post1 = blogs(:joel).posts.first
+    vivian = blogs(:vivian)
+    post2 = vivian.posts.create!(title: post1.title, content: "Content 2")
+
+    assert_equal post1.slug, post2.slug
+  end
+
+  test "should truncate long titles for slug generation" do
+    long_title = "This is an extremely long title that should be truncated when generating the slug" * 3
+    post = @blog.posts.create!(title: long_title, content: "Content")
+
+    assert post.slug.length <= 100
+    assert_equal post.title.parameterize.truncate(100, omission: ""), post.slug
+  end
+
+  private
+
+    def assert_invalid_slug_format(post, slug)
+      post.update(slug: slug)
+      assert_not post.valid?
+      assert_includes post.errors[:slug], "can only contain lowercase letters, numbers, and single hyphens between words"
+    end
 end

--- a/test/models/concerns/sluggable_test.rb
+++ b/test/models/concerns/sluggable_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class SluggableTest < ActiveSupport::TestCase
+  setup do
+    @blog = blogs(:joel)
+  end
+
+  test "should generate a slug before creating a post" do
+    post = @blog.posts.create!(title: "A New Post")
+    assert_equal post.to_title_param, post.slug
+  end
+
+  test "should prevent a duplicate slug for the same blog" do
+    @blog.posts.as_json
+    post1 = @blog.posts.create!(title: "A New Post")
+
+    assert_raises do
+      @blog.posts.create!(title: "A New Post", slug: post1.slug)
+    end
+  end
+end

--- a/test/models/concerns/sluggable_test.rb
+++ b/test/models/concerns/sluggable_test.rb
@@ -6,16 +6,16 @@ class SluggableTest < ActiveSupport::TestCase
   end
 
   test "should generate a slug before creating a post" do
-    post = @blog.posts.create!(title: "A New Post")
+    post = @blog.posts.create!(title: "A New Post", content: "This is a test post")
     assert_equal post.to_title_param, post.slug
   end
 
   test "should prevent a duplicate slug for the same blog" do
     @blog.posts.as_json
-    post1 = @blog.posts.create!(title: "A New Post")
+    post1 = @blog.posts.create!(title: "A New Post", content: "This is a test post")
 
     assert_raises do
-      @blog.posts.create!(title: "A New Post", slug: post1.slug)
+      @blog.posts.create!(title: "A New Post", content: "This is a test post", slug: post1.slug)
     end
   end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -4,7 +4,7 @@ class PostTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
   test "should generate a token on create" do
-    post = Post.create(blog: blogs(:joel), title: "a new post")
+    post = Post.create(blog: blogs(:joel), title: "a new post", content: "content")
     assert post.token.present?
   end
 
@@ -37,17 +37,17 @@ class PostTest < ActiveSupport::TestCase
   end
 
   test "should exclude draft posts from visible scope" do
-    post = Post.create(blog: blogs(:joel), title: "a new post", status: :draft)
+    post = Post.create(blog: blogs(:joel), title: "a new post", content: "content", status: :draft)
     assert_not Post.visible.include?(post)
   end
 
   test "should exclude draft posts from published scope" do
-    post = Post.create(blog: blogs(:joel), title: "a new post", status: :draft)
+    post = Post.create(blog: blogs(:joel), title: "a new post", content: "content", status: :draft)
     assert_not Post.published.include?(post)
   end
 
   test "should include draft posts in draft scope" do
-    post = Post.create(blog: blogs(:joel), title: "a new post", status: :draft)
+    post = Post.create(blog: blogs(:joel), title: "a new post", content: "content", status: :draft)
     assert Post.draft.include?(post)
     assert Post.draft.include?(posts(:joel_draft))
   end

--- a/test/system/upvote_post_test.rb
+++ b/test/system/upvote_post_test.rb
@@ -7,7 +7,7 @@ class UpvotePostTest < ApplicationSystemTestCase
     post = blog.posts.published.first
     initial_upvotes = post.upvotes.count
 
-    visit post_without_title_path(post.blog.name, post.token)
+    visit blog_post_path(post.blog.name, post.slug)
 
     within "turbo-frame##{dom_id(post, :upvotes)}" do
       find("button[type=submit]").click


### PR DESCRIPTION
Introduce a `slug` field on `Post`. This is used in the public-facing URLs for blogs. URLs for upvoting, replying by email and in the app continue to use `token`.

Slugs can be changed via a new option in the post drop down menu.

Fixes https://github.com/lylo/pagecord/issues/269