### PR TITLE
Don't overload the mail server when sending digests

### DIFF
--- a/app/jobs/send_post_digest_email_job.rb
+++ b/app/jobs/send_post_digest_email_job.rb
@@ -1,0 +1,14 @@
+class SendPostDigestEmailJob < ApplicationJob
+  queue_as :mailers
+
+  def perform(post_digest_id, email_subscriber_id)
+    digest = PostDigest.find(post_digest_id)
+    subscriber = EmailSubscriber.find(email_subscriber_id)
+
+    return unless subscriber&.confirmed?
+    return if digest.deliveries.exists?(email_subscriber_id: subscriber.id)
+
+    PostDigestMailer.with(digest: digest, subscriber: subscriber).weekly_digest.deliver_now
+    digest.deliveries.create!(email_subscriber: subscriber, delivered_at: Time.current)
+  end
+end

--- a/app/models/post_digest_scheduler.rb
+++ b/app/models/post_digest_scheduler.rb
@@ -1,6 +1,6 @@
 class PostDigestScheduler
   def self.run
-    Blog.where(email_subscriptions_enabled: true).includes(:user).find_each do |blog|
+    Blog.where(email_subscriptions_enabled: true).includes(:user).find_each(batch_size: 100) do |blog|
       user = blog.user
       next unless user&.kept? && user.subscribed?
 

--- a/app/models/post_digest_scheduler.rb
+++ b/app/models/post_digest_scheduler.rb
@@ -1,13 +1,13 @@
 class PostDigestScheduler
   def self.run
-    Blog.where(email_subscriptions_enabled: true).includes(:user).find_each(batch_size: 100) do |blog|
+    Blog.where(email_subscriptions_enabled: true).includes(:user).find_each(batch_size: 100).with_index do |blog, index|
       user = blog.user
       next unless user&.kept? && user.subscribed?
 
       Time.use_zone(user.timezone || "UTC") do
         if Time.current.hour == 8
           Rails.logger.info "Generating digest for blog #{blog.id} (#{blog.subdomain}) - local time: #{Time.current}"
-          GeneratePostDigestJob.perform_later(blog.id)
+          GeneratePostDigestJob.set(wait: index * 2.seconds).perform_later(blog.id)
         end
       end
     end


### PR DESCRIPTION
If a blog has hundreds (or thousands!) of email subscribers, we don't want to schedule that many email jobs at once. It _might_ work depending on the mail server (Postmark at time of writing), but it's not very considerate. 

With this PR change, a digest is only generated every 2 seconds. For each digest, individual email deliveries are staggered by 0.2s for each email.

This seems like a reasonable foundation to prevent rate limiting issues.