### PR TITLE
Add support for Google Site Verification

### DIFF
--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -28,7 +28,8 @@ class App::Settings::BlogsController < AppController
       permitted_params = [
         :subdomain,
         :fediverse_author_attribution,
-        :allow_search_indexing
+        :allow_search_indexing,
+        :google_site_verification
       ]
 
       permitted_params << [

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -24,6 +24,7 @@ class Blog < ApplicationRecord
 
   validates :subdomain, presence: true, uniqueness: true, length: { minimum: Subdomain::MIN_LENGTH, maximum: Subdomain::MAX_LENGTH }
   validate  :subdomain_valid
+  validates :google_site_verification, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "can only contain letters, numbers, underscores, and hyphens" }, allow_blank: true
 
   def custom_title?
     title.present?

--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -50,6 +50,22 @@
   </div>
 
   <div class="mt-8">
+    <h3 class="font-bold text-lg mb-2">Google Site Verification</h3>
+    <p>
+      If you need to add a Google Site Verification meta tag to your blog (e.g. for Google Search Console), enter the verification code below. You should only add the code - not the full meta tag. This will appear in your blog HTML as <code class="text-sm bg-slate-100 dark:bg-slate-800">&lt;meta name="google-site-verification" content="YOUR_VERIFICATION_CODE" /&gt;</code>
+    </p>
+
+    <%= styled_text_field(form, :google_site_verification, placeholder: "e.g. Gzm-PA_FXh231_cgsIxY_h9OgR6r8DZ", class: "mt-4 md:w-full") %>
+    <%= field_error(@blog, :google_site_verification) %>
+
+    <% if @blog.google_site_verification.present? %>
+      <p class="mt-2 text-slate-500 dark:text-slate-400 text-sm">
+        To remove your Google site verification, clear the box above and click Update.
+      </p>
+    <% end %>
+  </div>
+
+  <div class="mt-8">
     <h3 class="font-bold text-lg mb-2">Fediverse Author Attribution</h3>
     <p>
       To allow your Pagecord posts to be attributed to you when shared on Mastodon (or any other Fediverse platform), enter your

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -7,6 +7,10 @@
 <meta name="description" content="<%= meta_description %>">
 <meta name="keywords" content="open-source blog, email-first publishing, no-code blogging, privacy-first platform, exportable blog, minimalist blogging">
 
+<% if @blog&.google_site_verification.present? %>
+<meta name="google-site-verification" content="<%= @blog.google_site_verification %>" />
+<% end %>
+
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="<%= page_type %>">
 <meta property="og:url" content="<%= request.original_url %>">

--- a/db/migrate/20250604144504_add_google_site_verification_to_blogs.rb
+++ b/db/migrate/20250604144504_add_google_site_verification_to_blogs.rb
@@ -1,0 +1,5 @@
+class AddGoogleSiteVerificationToBlogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :blogs, :google_site_verification, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_05_29_124914) do
+ActiveRecord::Schema[8.1].define(version: 2025_06_04_144504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -83,6 +83,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_05_29_124914) do
 
   create_table "blogs", force: :cascade do |t|
     t.boolean "allow_search_indexing", default: true, null: false
+    t.string "analytics_id"
+    t.string "analytics_service"
     t.datetime "created_at", null: false
     t.string "custom_domain"
     t.string "delivery_email"
@@ -91,6 +93,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_05_29_124914) do
     t.string "features", default: [], array: true
     t.string "fediverse_author_attribution"
     t.string "font", default: "sans", null: false
+    t.string "google_site_verification"
     t.integer "layout", default: 0
     t.boolean "reply_by_email", default: false, null: false
     t.boolean "show_branding", default: true, null: false

--- a/test/controllers/app/settings/blogs_controller_test.rb
+++ b/test/controllers/app/settings/blogs_controller_test.rb
@@ -14,6 +14,7 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "h3", { count: 1, text: "Custom Domain" }
     assert_select "h3", { count: 1, text: "Search Engine Visibility" }
+    assert_select "h3", { count: 1, text: "Google Site Verification" }
     assert_select "h3", { count: 1, text: "Fediverse Author Attribution" }
     assert_response :success
   end
@@ -120,5 +121,28 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to app_settings_url
     assert_equal "@example@mastodon.social", @blog.reload.fediverse_author_attribution
+  end
+
+  test "should update google site verification" do
+    patch app_settings_blog_url(@blog), params: { blog: { google_site_verification: "GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44" } }, as: :turbo_stream
+
+    assert_redirected_to app_settings_url
+    assert_equal "GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44", @blog.reload.google_site_verification
+  end
+
+  test "should clear google site verification" do
+    @blog.update!(google_site_verification: "existing_code")
+
+    patch app_settings_blog_url(@blog), params: { blog: { google_site_verification: "" } }, as: :turbo_stream
+
+    assert_redirected_to app_settings_url
+    assert_equal "", @blog.reload.google_site_verification
+  end
+
+  test "should not update google site verification with invalid format" do
+    patch app_settings_blog_url(@blog), params: { blog: { google_site_verification: "invalid code with spaces" } }, as: :turbo_stream
+
+    assert_response :unprocessable_entity
+    assert_nil @blog.reload.google_site_verification
   end
 end

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -336,6 +336,43 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "link[href*='inter']", count: 0
   end
 
+  test "should render google site verification meta tag when present" do
+    @blog.update!(google_site_verification: "GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44")
+
+    get blog_posts_path
+
+    assert_response :success
+    assert_select "meta[name='google-site-verification'][content='GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44']", count: 1
+  end
+
+  test "should not render google site verification meta tag when blank" do
+    @blog.update!(google_site_verification: "")
+
+    get blog_posts_path
+
+    assert_response :success
+    assert_select "meta[name='google-site-verification']", count: 0
+  end
+
+  test "should not render google site verification meta tag when nil" do
+    @blog.update!(google_site_verification: nil)
+
+    get blog_posts_path
+
+    assert_response :success
+    assert_select "meta[name='google-site-verification']", count: 0
+  end
+
+  test "should render google site verification meta tag on post show page" do
+    @blog.update!(google_site_verification: "GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44")
+    post = @blog.posts.visible.first
+
+    get blog_post_path(post.slug)
+
+    assert_response :success
+    assert_select "meta[name='google-site-verification'][content='GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44']", count: 1
+  end
+
   private
 
     def host_subdomain!(name)

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -100,4 +100,25 @@ class BlogTest < ActiveSupport::TestCase
       @blog.destroy
     end
   end
+
+  test "should validate google site verification" do
+    @blog.google_site_verification = "GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44"
+    assert @blog.valid?
+
+    @blog.google_site_verification = "abc123_DEF-456"
+    assert @blog.valid?
+
+    @blog.google_site_verification = "simple123"
+    assert @blog.valid?
+
+    @blog.google_site_verification = ""
+    assert @blog.valid?
+
+    @blog.google_site_verification = nil
+    assert @blog.valid?
+
+    @blog.google_site_verification = "invalid code with spaces"
+    assert_not @blog.valid?
+    assert_includes @blog.errors.full_messages, "Google site verification can only contain letters, numbers, underscores, and hyphens"
+  end
 end


### PR DESCRIPTION
Configure a blog so that legit meta tag for Google site verification is present in the `HEAD`

```
<meta name="google-site-verification" content="GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44" />
```