### PR TITLE
Use Cloudflare Image Transformations for generating Active Storage / Action Text variants

### DIFF
--- a/app/helpers/image_helper.rb
+++ b/app/helpers/image_helper.rb
@@ -1,0 +1,19 @@
+module ImageHelper
+  def resized_image_url(blob, width:, height:)
+    cloudflare_enabled = Rails.configuration.x.cloudflare_image_resizing.present?
+
+    if cloudflare_enabled
+      public_url = rails_public_blob_url(blob)
+      base_url = "https://#{Rails.configuration.x.domain}"
+
+      "#{base_url}/cdn-cgi/image/width=#{width},height=#{height},format=webp,quality=90/#{public_url}"
+    else
+      variant = blob.variant(
+        resize_to_limit: [ width, height ],
+        format: :webp,
+        saver: { quality: 90, strip: true, compression: 6 }
+      )
+      rails_public_blob_url(variant)
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,4 +3,6 @@ class ApplicationMailer < ActionMailer::Base
           reply_to: "Pagecord <hello@pagecord.com>"
 
   layout "mailer"
+
+  helper ImageHelper
 end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -12,7 +12,7 @@
                              Rails.configuration.x.cloudflare_image_resizing
 
         image_url = if cloudflare_enabled
-          "/cdn-cgi/image/width=#{width},height=#{height},format=webp,quality=90/#{rails_public_blob_url(blob)}"
+          "https://#{Rails.configuration.x.domain}/cdn-cgi/image/width=#{width},height=#{height},format=webp,quality=90/#{rails_public_blob_url(blob)}"
         else
           variant = blob.variant(
             resize_to_limit: [width, height],

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -5,13 +5,25 @@
     <% if blob.content_type == "image/gif" %>
       <%= image_tag rails_public_blob_url(blob), alt: "Uploaded image" %>
     <% else %>
-      <% variant = blob.variant(
-          resize_to_limit: (local_assigns[:in_gallery] ? [800, 600] : [1600, 1200]),
-          format: :webp,
-          saver: { quality: 90, strip: true, compression: 6 }
-        ) %>
+      <%
+        width, height = local_assigns[:in_gallery] ? [800, 600] : [1600, 1200]
 
-      <%= image_tag rails_public_blob_url(variant), alt: "Uploaded image" %>
+        cloudflare_enabled = Rails.configuration.x.respond_to?(:cloudflare_image_resizing) &&
+                             Rails.configuration.x.cloudflare_image_resizing
+
+        image_url = if cloudflare_enabled
+          "/cdn-cgi/image/width=#{width},height=#{height},format=webp,quality=90/#{rails_public_blob_url(blob)}"
+        else
+          variant = blob.variant(
+            resize_to_limit: [width, height],
+            format: :webp,
+            saver: { quality: 90, strip: true, compression: 6 }
+          )
+          rails_public_blob_url(variant)
+        end
+      %>
+
+      <%= image_tag image_url, alt: "Uploaded image" %>
     <% end %>
   <% end %>
 </figure>

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -5,25 +5,8 @@
     <% if blob.content_type == "image/gif" %>
       <%= image_tag rails_public_blob_url(blob), alt: "Uploaded image" %>
     <% else %>
-      <%
-        width, height = local_assigns[:in_gallery] ? [800, 600] : [1600, 1200]
-
-        cloudflare_enabled = Rails.configuration.x.respond_to?(:cloudflare_image_resizing) &&
-                             Rails.configuration.x.cloudflare_image_resizing
-
-        image_url = if cloudflare_enabled
-          "https://#{Rails.configuration.x.domain}/cdn-cgi/image/width=#{width},height=#{height},format=webp,quality=90/#{rails_public_blob_url(blob)}"
-        else
-          variant = blob.variant(
-            resize_to_limit: [width, height],
-            format: :webp,
-            saver: { quality: 90, strip: true, compression: 6 }
-          )
-          rails_public_blob_url(variant)
-        end
-      %>
-
-      <%= image_tag image_url, alt: "Uploaded image" %>
+      <% width, height = local_assigns[:in_gallery] ? [800, 600] : [1600, 1200] %>
+      <%= image_tag resized_image_url(blob, width: width, height: height), alt: "Uploaded image" %>
     <% end %>
   <% end %>
 </figure>

--- a/app/views/app/settings/appearance/_avatar.html.erb
+++ b/app/views/app/settings/appearance/_avatar.html.erb
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-center w-20 h-20 border border-slate-200 dark:border-slate-800 shadow-sm rounded-full">
   <% if blog.avatar&.attached? %>
-    <%= image_tag rails_public_blob_url(blog.avatar), class: "object-cover rounded-full w-full h-full", alt: "#{blog.title} Avatar" %>
+    <%= image_tag resized_image_url(blog.avatar, width: 80, height: 80), class: "object-cover rounded-full w-full h-full", alt: "#{blog.title} Avatar" %>
   <% else %>
     <img class="object-cover rounded-full w-full h-full hidden" src="https://pbs.twimg.com/profile_images/1851287065062981632/t6ZpG7Pm_400x400.jpg">
     <div class="avatar-placeholder">

--- a/app/views/blogs/_blog_titlebar.html.erb
+++ b/app/views/blogs/_blog_titlebar.html.erb
@@ -3,7 +3,7 @@
     <div class="flex w-full items-top justify-between gap-x-4">
       <div class="w-16 h-16">
         <%= link_to blog_home_url(@blog), aria: { label: "#{@blog.title} Home" } do %>
-          <%= image_tag rails_public_blob_url(@blog.avatar), class: "border border-slate-200 dark:border-slate-800 shadow-sm object-cover rounded-full w-16 h-16", alt: "#{@blog.title} Avatar" %>
+          <%= image_tag resized_image_url(@blog.avatar, width: 80, height: 80), class: "border border-slate-200 dark:border-slate-800 shadow-sm object-cover rounded-full w-16 h-16", alt: "#{@blog.title} Avatar" %>
         <% end %>
       </div>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,7 @@ Rails.application.configure do
 
   # Set domain configuration for development
   config.x.domain = ENV.fetch("APP_DOMAIN", "lvh.me")
+  config.x.cloudflare_image_resizing = false
 
   config.action_controller.default_url_options = { host: "lvh.me", port: "3000", protocol: "http" }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,6 +18,7 @@ Rails.application.configure do
 
   # Set domain configuration once
   config.x.domain = ENV.fetch("APP_DOMAIN", "pagecord.com")
+  config.x.cloudflare_image_resizing = true
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
     policy.font_src :self, :https, :data
 
     # Images
-    policy.img_src :self, :data,
+    policy.img_src :self, :data, :https,
                    "http://lvh.me:3000",
                    "https://storage.pagecord.com",
                    "https://githubusercontent.com",

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,7 +9,9 @@ Rails.application.configure do
     policy.font_src :self, :https, :data
 
     # Images
-    policy.img_src :self, :https, :data,
+    policy.img_src :self, :data,
+                   "http://lvh.me:3000",
+                   "https://storage.pagecord.com",
                    "https://githubusercontent.com",
                    "https://github.githubassets.com"
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -25,39 +25,3 @@ cloudflare_dev:
   bucket: pagecord-dev
   request_checksum_calculation: when_required
   response_checksum_validation: when_required
-
-s3:
-  service: S3
-  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
-  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
-  region: eu-west-2
-  bucket: pagecord-activestorage-prod
-  upload:
-    cache_control: "public, max-age=31536000"
-
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name-<%= Rails.env %>
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]


### PR DESCRIPTION
Add a configuration (`config.x.cloudflare_image_resizing`) to use Cloudflare Image Transformations for producing variants, rather than using the Pagecord server. 

This offloads all image processing to Cloudflare. 5000 transformations/mo are free which should be fine for a while (🤞).



https://developers.cloudflare.com/images/transform-images/

