### PR TITLE
Tags by email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "jbuilder"
 gem "ruby-vips"
 gem "sprockets-rails"
 gem "stimulus-rails"
-gem "tailwindcss-rails", "~> 4.2.1"
+gem "tailwindcss-rails"
 gem "turbo-rails"
 
 gem "puma", ">= 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,7 +424,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
-    tailwindcss-rails (4.2.3)
+    tailwindcss-rails (4.3.0)
       railties (>= 7.0.0)
       tailwindcss-ruby (~> 4.0)
     tailwindcss-ruby (4.1.11)
@@ -518,7 +518,7 @@ DEPENDENCIES
   sidekiq
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails (~> 4.2.1)
+  tailwindcss-rails
   turbo-rails
   tzinfo-data
   web-console

--- a/app/mailboxes/posts_mailbox.rb
+++ b/app/mailboxes/posts_mailbox.rb
@@ -33,6 +33,7 @@ class PostsMailbox < ApplicationMailbox
             content: content,
             raw_content: mail.raw_source,
             attachments: parser.attachments,
+            tag_list: parser.tags,
             published_at: mail.date)
         end
       rescue => e

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -3,6 +3,9 @@
 module Taggable
   extend ActiveSupport::Concern
 
+  # Valid tag format: letters, numbers, and hyphens only
+  VALID_TAG_FORMAT = /\A[a-zA-Z0-9-]+\z/
+
   included do
     validates :tag_list, presence: true, allow_blank: true
     validate :validate_tag_format
@@ -65,6 +68,6 @@ module Taggable
   end
 
   def valid_tag_format?(tag)
-    tag.match?(/\A[a-zA-Z0-9-]+\z/)
+    tag.match?(VALID_TAG_FORMAT)
   end
 end

--- a/app/models/concerns/trimmable.rb
+++ b/app/models/concerns/trimmable.rb
@@ -42,10 +42,19 @@ module Trimmable
         if last_child.text? && last_child.text.strip.empty?
           last_child.remove # Remove empty text nodes
         elsif last_child.element?
-          if last_child.name == "br" ||
-             ([ "div", "p" ].include?(last_child.name) && last_child.children.empty? && last_child.text.strip.empty?)
+          if last_child.name == "br"
+            last_child.remove  # Remove <br> tags
+          elsif [ "div", "p" ].include?(last_child.name)
+            # First clean up inside this element
+            remove_trailing_empty_nodes(last_child)
 
-            last_child.remove  # Remove <br> tags or empty <div>/<p> elements
+            # Then check if it became empty after cleanup and remove it
+            if last_child.children.empty? && last_child.text.strip.empty?
+              last_child.remove
+            else
+              # Stop if the element has content
+              break
+            end
           else
             remove_trailing_empty_nodes(last_child)
 

--- a/app/models/html/extract_tags.rb
+++ b/app/models/html/extract_tags.rb
@@ -48,11 +48,9 @@ module Html
           hashtags = extract_hashtags_from_line(line)
 
           if hashtags.any?
-            # Check if line has ONLY hashtags (and maybe invalid hashtags/whitespace)
-            line_without_hashtags = line.gsub(HASHTAG_REGEX, "").strip
-
-            if line_without_hashtags.empty?
-              # Line only had hashtags (and maybe invalid tags), extract them
+            # Check if line contains ONLY hashtag-like patterns (valid and invalid)
+            if line.strip.match?(/\A\s*(#\S+\s*)+\z/)
+              # Line contains only hashtag-like patterns, extract the valid ones
               @tags.concat(hashtags)
               lines.pop
             else

--- a/app/models/html/extract_tags.rb
+++ b/app/models/html/extract_tags.rb
@@ -1,0 +1,83 @@
+module Html
+  class ExtractTags < Transformation
+    HASHTAG_REGEX = /#([a-zA-Z0-9-]+)(?=\s|$)/
+
+    def transform(input)
+      @tags = []
+
+      if input.include?("<")
+        transform_html(input)
+      else
+        transform_plaintext(input)
+      end
+    end
+
+    def tags
+      @tags || []
+    end
+
+    private
+
+      def transform_html(html)
+        document = Nokogiri::HTML.fragment(html)
+        last_element = find_last_text_element(document)
+        return html unless last_element
+
+        text = last_element.text.strip
+        return html unless text.match?(HASHTAG_REGEX)
+
+        @tags = extract_tags(text)
+        cleaned_text = remove_hashtag_lines(text)
+
+        if cleaned_text.empty?
+          last_element.remove
+        else
+          last_element.content = cleaned_text
+        end
+
+        document.to_html
+      end
+
+      def transform_plaintext(text)
+        lines = text.lines.map(&:strip)
+        tag_lines = []
+
+        # Remove empty lines from the end first
+        lines.pop while lines.last&.empty?
+
+        # Then collect hashtag lines from the end
+        while lines.any? && lines.last.match?(HASHTAG_REGEX)
+          tag_lines.unshift(lines.pop)
+        end
+
+        return text unless tag_lines.any?
+
+        @tags = tag_lines.flat_map { |line| extract_tags(line) }.uniq.sort
+        lines.join("\n").strip
+      end
+
+      def extract_tags(text)
+        # Extract potential hashtags and then validate them
+        potential_tags = text.scan(HASHTAG_REGEX).flatten
+
+        # Filter to only valid tags (letters, numbers, hyphens only)
+        valid_tags = potential_tags.select { |tag| tag.match?(/\A[a-zA-Z0-9-]+\z/) }
+
+        valid_tags.map(&:downcase).uniq.sort
+      end
+
+      def remove_hashtag_lines(text)
+        lines = text.lines.map(&:strip)
+        # Remove empty lines from the end first
+        lines.pop while lines.last&.empty?
+        # Then remove hashtag lines from the end
+        lines.pop while lines.last&.match?(HASHTAG_REGEX)
+        lines.join("\n").strip
+      end
+
+      def find_last_text_element(document)
+        # Finds last block-level element with non-empty text content
+        document.css("p, div, span, li").reverse.find { |el| el.text.strip.present? }
+      end
+  end
+end

--- a/app/models/html/extract_tags.rb
+++ b/app/models/html/extract_tags.rb
@@ -75,8 +75,8 @@ module Html
         # Extract potential hashtags and then validate them
         potential_tags = text.scan(HASHTAG_REGEX).flatten
 
-        # Filter to only valid tags (letters, numbers, hyphens only)
-        valid_tags = potential_tags.select { |tag| tag.match?(/\A[a-zA-Z0-9-]+\z/) }
+        # Filter to only valid tags using the shared validation from Taggable
+        valid_tags = potential_tags.select { |tag| tag.match?(Taggable::VALID_TAG_FORMAT) }
 
         valid_tags.map(&:downcase).uniq.sort
       end

--- a/app/models/html/extract_tags.rb
+++ b/app/models/html/extract_tags.rb
@@ -20,20 +20,35 @@ module Html
 
       def transform_html(html)
         document = Nokogiri::HTML.fragment(html)
-        last_element = find_last_text_element(document)
-        return html unless last_element
 
-        text = last_element.text.strip
-        return html unless text.match?(HASHTAG_REGEX)
+        # Work backwards through elements to find consecutive hashtag-only elements
+        elements_to_remove = []
+        all_tags = []
 
-        @tags = extract_tags(text)
-        cleaned_text = remove_hashtag_lines(text)
+        # Get all block-level elements with text content
+        elements = document.css("p, div, span, li").select { |el| el.text.strip.present? }
 
-        if cleaned_text.empty?
-          last_element.remove
-        else
-          last_element.content = cleaned_text
+        # Work backwards from the last element
+        elements.reverse_each do |element|
+          text = element.text.strip
+
+          # Check if this element contains only hashtags
+          hashtags = extract_tags(text)
+          text_without_hashtags = text.gsub(HASHTAG_REGEX, "").strip
+
+          if hashtags.any? && text_without_hashtags.empty?
+            # This element contains only hashtags
+            all_tags.concat(hashtags)
+            elements_to_remove << element
+          else
+            # Found non-hashtag content, stop processing
+            break
+          end
         end
+
+        # Remove hashtag-only elements and set tags
+        elements_to_remove.each(&:remove)
+        @tags = all_tags.uniq.sort
 
         document.to_html
       end
@@ -64,20 +79,6 @@ module Html
         valid_tags = potential_tags.select { |tag| tag.match?(/\A[a-zA-Z0-9-]+\z/) }
 
         valid_tags.map(&:downcase).uniq.sort
-      end
-
-      def remove_hashtag_lines(text)
-        lines = text.lines.map(&:strip)
-        # Remove empty lines from the end first
-        lines.pop while lines.last&.empty?
-        # Then remove hashtag lines from the end
-        lines.pop while lines.last&.match?(HASHTAG_REGEX)
-        lines.join("\n").strip
-      end
-
-      def find_last_text_element(document)
-        # Finds last block-level element with non-empty text content
-        document.css("p, div, span, li").reverse.find { |el| el.text.strip.present? }
       end
   end
 end

--- a/app/models/mail_parser.rb
+++ b/app/models/mail_parser.rb
@@ -8,16 +8,20 @@ class MailParser
     @attachments = []
     store_attachments if process_attachments
 
+    @extract_tags = Html::ExtractTags.new
+
     @html_pipeline = [
       Html::BodyExtraction.new,
       Html::MonospaceDetection.new,
       Html::ImageUnfurl.new,
       Html::InlineAttachments.new(@attachments),
+      @extract_tags,
       Html::Sanitize.new
     ]
 
     @plain_text_pipeline = [
       Html::PlainTextToHtml.new,
+      @extract_tags,
       Html::ImageUnfurl.new
     ]
   end
@@ -36,6 +40,12 @@ class MailParser
 
   def has_attachments?
     !attachments.empty?
+  end
+
+  def tags
+    # Ensure body has been parsed to extract tags
+    body if @extract_tags
+    @extract_tags&.tags || []
   end
 
   def is_blank?

--- a/test/mailboxes/posts_mailbox_test.rb
+++ b/test/mailboxes/posts_mailbox_test.rb
@@ -277,6 +277,113 @@ class PostsMailboxTest < ActionMailbox::TestCase
     assert_equal 0, post.attachments.count, "Post should have no attachments"
   end
 
+  test "should extract hashtags from plain text email and remove them from content" do
+    user = users(:joel)
+
+    assert_difference -> { user.blog.posts.count }, 1 do
+      receive_inbound_email_from_mail \
+        to: user.blog.delivery_email,
+        from: user.email,
+        reply_to: user.email,
+        subject: "Test post with tags",
+        body: "This is a post about programming.\n\n#ruby #rails #programming" do |mail|
+          mail.header["Received-SPF"] = "pass"
+      end
+    end
+
+    post = user.blog.posts.last
+    assert_equal "Test post with tags", post.title
+    assert_equal [ "programming", "rails", "ruby" ], post.tag_list
+
+    # Tags should be removed from content
+    content_text = post.content.to_plain_text.strip
+    assert_not_includes content_text, "#ruby"
+    assert_not_includes content_text, "#rails"
+    assert_not_includes content_text, "#programming"
+    assert_includes content_text, "This is a post about programming."
+  end
+
+  test "should extract hashtags from HTML email and remove them from content" do
+    user = users(:joel)
+
+    html_body = <<~HTML
+      <div>
+        <p>This is a post about web development.</p>
+        <p>I love building applications.</p>
+        <p>#javascript #html #css</p>
+      </div>
+    HTML
+
+    assert_difference -> { user.blog.posts.count }, 1 do
+      receive_inbound_email_from_mail \
+        to: user.blog.delivery_email,
+        from: user.email,
+        reply_to: user.email,
+        subject: "Web development post",
+        body: html_body do |mail|
+          mail.content_type = "text/html"
+          mail.header["Received-SPF"] = "pass"
+      end
+    end
+
+    post = user.blog.posts.last
+    assert_equal "Web development post", post.title
+    assert_equal [ "css", "html", "javascript" ], post.tag_list
+
+    # Tags should be removed from content
+    content_text = post.content.to_plain_text.strip
+    assert_not_includes content_text, "#javascript"
+    assert_not_includes content_text, "#html"
+    assert_not_includes content_text, "#css"
+    assert_includes content_text, "This is a post about web development."
+    assert_includes content_text, "I love building applications."
+  end
+
+  test "should handle emails without hashtags" do
+    user = users(:joel)
+
+    assert_difference -> { user.blog.posts.count }, 1 do
+      receive_inbound_email_from_mail \
+        to: user.blog.delivery_email,
+        from: user.email,
+        reply_to: user.email,
+        subject: "Post without tags",
+        body: "This is a regular post without any hashtags." do |mail|
+          mail.header["Received-SPF"] = "pass"
+      end
+    end
+
+    post = user.blog.posts.last
+    assert_equal "Post without tags", post.title
+    assert_equal [], post.tag_list
+    assert_includes post.content.to_plain_text, "This is a regular post without any hashtags."
+  end
+
+  test "should ignore hashtags in the middle of content" do
+    user = users(:joel)
+
+    assert_difference -> { user.blog.posts.count }, 1 do
+      receive_inbound_email_from_mail \
+        to: user.blog.delivery_email,
+        from: user.email,
+        reply_to: user.email,
+        subject: "Post with hashtags in middle",
+        body: "I was working on #ruby today and had fun.\n\nLater I switched to other things.\n\n#programming #coding" do |mail|
+          mail.header["Received-SPF"] = "pass"
+      end
+    end
+
+    post = user.blog.posts.last
+    assert_equal "Post with hashtags in middle", post.title
+    assert_equal [ "coding", "programming" ], post.tag_list
+
+    # Only hashtags at the end should be removed
+    content_text = post.content.to_plain_text.strip
+    assert_includes content_text, "#ruby today"  # This hashtag should remain
+    assert_not_includes content_text, "#programming"  # These should be removed
+    assert_not_includes content_text, "#coding"
+  end
+
   private
 
     def format_html(html)

--- a/test/models/concerns/trimmable_test.rb
+++ b/test/models/concerns/trimmable_test.rb
@@ -32,4 +32,52 @@ class TrimmableTest < ActiveSupport::TestCase
 
     assert_equal "<div><p>this is some text<br><br>this is more text</p></div>", post.content.to_s.strip
   end
+
+  test "should remove empty divs after hashtag extraction" do
+    post = posts(:two)
+    post.content = "<div>This is a test</div><div><br></div><div></div>"
+    post.save!
+
+    assert_equal "<div>This is a test</div>", post.content.to_s.strip
+  end
+
+  test "should not remove divs with actual content" do
+    post = posts(:two)
+    post.content = "<div>This is a test</div><div><span>Keep this</span></div><div>And this</div>"
+    post.save!
+
+    assert_equal "<div>This is a test</div><div><span>Keep this</span></div><div>And this</div>", post.content.to_s.strip
+  end
+
+  test "should not remove divs with images or other elements" do
+    post = posts(:two)
+    post.content = "<div>This is a test</div><div><img src='test.jpg'></div><div><br></div><div></div>"
+    post.save!
+
+    assert_equal "<div>This is a test</div><div><img src=\"test.jpg\"></div>", post.content.to_s.strip
+  end
+
+  test "should remove divs with multiple br tags" do
+    post = posts(:two)
+    post.content = "<div>This is a test</div><div><br><br><br></div><div><br></div><div></div>"
+    post.save!
+
+    assert_equal "<div>This is a test</div>", post.content.to_s.strip
+  end
+
+  test "should not remove divs with br tags followed by content" do
+    post = posts(:two)
+    post.content = "<div>This is a test</div><div><br><br>Keep this content</div><div><br></div><div></div>"
+    post.save!
+
+    assert_equal "<div>This is a test</div><div><br><br>Keep this content</div>", post.content.to_s.strip.gsub("\n", "")
+  end
+
+  test "should not remove divs with content followed by br tags" do
+    post = posts(:two)
+    post.content = "<div>This is a test</div><div>Keep this content<br><br></div><div><br></div><div></div>"
+    post.save!
+
+    assert_equal "<div>This is a test</div><div>Keep this content</div>", post.content.to_s.strip
+  end
 end

--- a/test/models/html/extract_tags_test.rb
+++ b/test/models/html/extract_tags_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class Html::ExtractTagsTest < ActiveSupport::TestCase
+  def setup
+    @transformer = Html::ExtractTags.new
+  end
+
+  test "should extract hashtags from plain text at end of content" do
+    html = "This is a post about programming.\n\n#ruby #rails #programming"
+    result = @transformer.transform(html)
+
+    assert_equal [ "programming", "rails", "ruby" ], @transformer.tags
+    assert_not_includes result, "#ruby"
+    assert_not_includes result, "#rails"
+    assert_not_includes result, "#programming"
+    assert_includes result, "This is a post about programming."
+  end
+
+  test "should extract hashtags from HTML content" do
+    html = "<p>This is a post about web development.</p><p>#javascript #html #css</p>"
+    result = @transformer.transform(html)
+
+    assert_equal [ "css", "html", "javascript" ], @transformer.tags
+    assert_not_includes result, "#javascript"
+    assert_not_includes result, "#html"
+    assert_not_includes result, "#css"
+    assert_includes result, "This is a post about web development."
+  end
+
+  test "should handle content without hashtags" do
+    html = "This is a regular post without any hashtags."
+    result = @transformer.transform(html)
+
+    assert_equal [], @transformer.tags
+    assert_equal html, result
+  end
+
+  test "should ignore hashtags in the middle of content" do
+    html = "I was working on #ruby today.\n\nLater I switched to other things.\n\n#programming #coding"
+    result = @transformer.transform(html)
+
+    assert_equal [ "coding", "programming" ], @transformer.tags
+    assert_includes result, "#ruby today"  # This hashtag should remain
+    assert_not_includes result, "#programming"  # These should be removed
+    assert_not_includes result, "#coding"
+  end
+
+  test "should handle multiple lines of hashtags at the end" do
+    html = "Here's my post content.\n\n#first #second\n#third #fourth"
+    result = @transformer.transform(html)
+
+    assert_equal [ "first", "fourth", "second", "third" ], @transformer.tags
+    assert_not_includes result, "#first"
+    assert_not_includes result, "#second"
+    assert_not_includes result, "#third"
+    assert_not_includes result, "#fourth"
+    assert_includes result, "Here's my post content."
+  end
+
+  test "should normalize tag case and sort tags" do
+    html = "Content here.\n\n#Ruby #RAILS #javascript"
+    result = @transformer.transform(html)
+
+    assert_equal [ "javascript", "rails", "ruby" ], @transformer.tags
+  end
+
+  test "should filter out invalid tag formats" do
+    html = "Content here.\n\n#valid-tag #invalid! #another-valid #invalid@tag"
+    result = @transformer.transform(html)
+
+    assert_equal [ "another-valid", "valid-tag" ], @transformer.tags
+  end
+
+  test "should remove duplicate tags" do
+    html = "Content here.\n\n#ruby #rails #ruby #javascript #rails"
+    result = @transformer.transform(html)
+
+    assert_equal [ "javascript", "rails", "ruby" ], @transformer.tags
+  end
+
+  test "should handle empty content" do
+    html = ""
+    @transformer.transform(html)
+
+    assert_equal [], @transformer.tags
+  end
+
+  test "should handle content with only hashtags" do
+    html = "#ruby #rails #programming"
+    result = @transformer.transform(html)
+
+    assert_equal [ "programming", "rails", "ruby" ], @transformer.tags
+    # Result should be empty or minimal after removing hashtags
+    assert result.strip.empty? || result.strip == "<br>" || result.strip == "<p></p>"
+  end
+
+  test "should handle hashtags with empty lines at the end" do
+    html = "Here's my content.\n\n\n#tag1 #tag2\n\n"
+    result = @transformer.transform(html)
+
+    assert_equal [ "tag1", "tag2" ], @transformer.tags
+    assert_includes result, "Here's my content."
+    assert_not_includes result, "#tag1"
+    assert_not_includes result, "#tag2"
+  end
+end

--- a/test/models/mail_parser_test.rb
+++ b/test/models/mail_parser_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class MailParserTest < ActiveSupport::TestCase
+  test "should extract tags from plain text email" do
+    mail = create_mail(
+      subject: "Test email",
+      body: "This is a post about programming.\n\n#ruby #rails #programming",
+      content_type: "text/plain"
+    )
+
+    parser = MailParser.new(mail)
+
+    assert_equal [ "programming", "rails", "ruby" ], parser.tags
+    assert_not_includes parser.body, "#ruby"
+    assert_not_includes parser.body, "#rails"
+    assert_not_includes parser.body, "#programming"
+    assert_includes parser.body, "This is a post about programming."
+  end
+
+  test "should extract tags from HTML email" do
+    mail = create_mail(
+      subject: "Test HTML email",
+      body: "<p>This is a post about web development.</p><p>#javascript #html #css</p>",
+      content_type: "text/html"
+    )
+
+    parser = MailParser.new(mail)
+
+    assert_equal [ "css", "html", "javascript" ], parser.tags
+    # Check that tags are removed from content
+    content_text = ActionText::RichText.new(body: parser.body).to_plain_text
+    assert_not_includes content_text, "#javascript"
+    assert_not_includes content_text, "#html"
+    assert_not_includes content_text, "#css"
+  end
+
+  test "should return empty array when no tags present" do
+    mail = create_mail(
+      subject: "Test email",
+      body: "This is a regular post without any hashtags.",
+      content_type: "text/plain"
+    )
+
+    parser = MailParser.new(mail)
+
+    assert_equal [], parser.tags
+    assert_includes parser.body, "This is a regular post without any hashtags."
+  end
+
+  test "should ignore hashtags in the middle of content" do
+    mail = create_mail(
+      subject: "Test email",
+      body: "I was working on #ruby today.\n\nLater I switched to other things.\n\n#programming #coding",
+      content_type: "text/plain"
+    )
+
+    parser = MailParser.new(mail)
+
+    assert_equal [ "coding", "programming" ], parser.tags
+    assert_includes parser.body, "#ruby today"  # This hashtag should remain
+  end
+
+  private
+
+  def create_mail(subject:, body:, content_type: "text/plain", from: "test@example.com", to: "recipient@example.com")
+    Mail.new do
+      from from
+      to to
+      subject subject
+      content_type content_type
+      body body
+    end
+  end
+end


### PR DESCRIPTION
Allow tags to be added to posts when posting by email. 

Tags should be in hashtag format (`#tag`) and be at the end of the email (either plain text or HTML). If they're split across multiple lines at the end then _they should still work_ but probably best to keep them on a single line if you can.