### PR TITLE
Open social links in a new tab/window

### DIFF
--- a/app/views/blogs/_top_nav.html.erb
+++ b/app/views/blogs/_top_nav.html.erb
@@ -12,7 +12,7 @@
     <% if @blog.social_links.present? %>
       <div class="flex gap-x-3">
       <% @blog.social_links.each do |social_link| %>
-        <%= link_to social_link_url(social_link), class: "social-link", aria: { label: "#{social_link.platform.titleize} Link" } do %>
+        <%= link_to social_link_url(social_link), class: "social-link", aria: { label: "#{social_link.platform.titleize} Link", target: "_blank" } do %>
           <%= inline_svg_tag "icons/social/#{social_link.platform.downcase}.svg", class: "w-4 h-4" %>
         <% end %>
       <% end %>


### PR DESCRIPTION
I think that opening the social links in a new tab provides a better experience by leaving the user in the page. Otherwise the visitor goes out and might never come back.

Disclaimer: I didn't setup the local environment or run any tests but the change was small enough that I thought that it might be easier to send a PR than an issue.