### PR TITLE
Add post tags to RSS feed

### DIFF
--- a/app/views/app/feed/private_rss.rss.builder
+++ b/app/views/app/feed/private_rss.rss.builder
@@ -21,6 +21,10 @@ xml.rss version: "2.0" do
         xml.pubDate publication_time.to_formatted_s(:rfc822)
         xml.link link
         xml.guid link
+
+        post.tag_list.each do |tag|
+          xml.category tag
+        end
       end
     end
   end

--- a/app/views/blogs/posts/index.rss.builder
+++ b/app/views/blogs/posts/index.rss.builder
@@ -22,6 +22,10 @@ xml.rss version: "2.0" do
         xml.pubDate publication_time.to_formatted_s(:rfc822)
         xml.link link
         xml.guid link
+
+        post.tag_list.each do |tag|
+          xml.category tag
+        end
       end
     end
   end

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -219,6 +219,27 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_includes title, expected_time_string, "Title should include the formatted local time"
   end
 
+  test "should include tags as RSS categories in RSS feed" do
+    @blog.posts.create!(
+      title: "Tagged Post",
+      content: "Post with tags",
+      status: "published",
+      tags_string: "ruby, rails, web-development"
+    )
+
+    get rss_feed_path(@blog)
+
+    assert_response :success
+
+    doc = Nokogiri::XML(@response.body)
+    categories = doc.xpath("//item/category").map(&:text)
+
+    assert_includes categories, "ruby"
+    assert_includes categories, "rails"
+    assert_includes categories, "web-development"
+    assert_equal 3, categories.count
+  end
+
   # Custom domains
 
   test "should get index on custom domain" do


### PR DESCRIPTION
RSS supports tags by way of the `category` element. This PR updates the RSS views to include categories based on Post tags.

Ref: https://cyber.harvard.edu/rss/rss.html