### PR TITLE
Add automated content moderation for posts via OpenAI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,12 @@ RollupAndCleanupPageViewsJob.perform_now                         # Manually run 
 - **Email processing**: Uses ActionMailbox with PostsMailbox to create posts from emails
 
 ### Key Features
+- **Content Moderation**: Automated post moderation using OpenAI.
+    - **Models**: `ContentModeration` (stores results), `ContentModerator` (service class), `Post::Moderatable` (concern).
+    - **Flow**: `after_commit` on Post -> `ContentModerationJob` -> OpenAI API -> Flags/Cleans.
+    - **Actions**: Flagged posts are automatically discarded (soft-deleted) and admins are notified.
+    - **Admin**: `Admin::ModerationController` for reviewing flagged content.
+    - **Batch Processing**: `ContentModerationBatchJob` catches missed posts.
 - **Email-to-blog**: Primary posting method via email (ActionMailbox)
 - **Custom domains**: Premium feature using Hatchbox API
 - **Rich text**: Uses ActionText for post content

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -114,6 +114,12 @@ Pagecord is a blogging application with features like email-to-blog posting, cus
 - **Email processing**: ActionMailbox with `PostsMailbox` for creating posts from emails.
 
 ### Key Features
+- **Content Moderation**: Automated post moderation using OpenAI.
+    - **Models**: `ContentModeration` (stores results), `ContentModerator` (service class), `Post::Moderatable` (concern).
+    - **Flow**: `after_commit` on Post -> `ContentModerationJob` -> OpenAI API -> Flags/Cleans.
+    - **Actions**: Flagged posts are automatically discarded (soft-deleted) and admins are notified.
+    - **Admin**: `Admin::ModerationController` for reviewing flagged content.
+    - **Batch Processing**: `ContentModerationBatchJob` catches missed posts.
 - **Email-to-blog**: Primary posting method via ActionMailbox.
 - **Custom Domains**: Premium feature using Hatchbox API.
 - **Rich Text**: ActionText for post content.

--- a/app/controllers/admin/moderation_controller.rb
+++ b/app/controllers/admin/moderation_controller.rb
@@ -1,0 +1,34 @@
+class Admin::ModerationController < AdminController
+  include Pagy::Backend
+
+  def index
+    @pagy, @posts = pagy(
+      Post.with_discarded
+          .moderation_flagged
+          .published
+          .joins(blog: :user)
+          .where(users: { discarded_at: nil })
+          .includes(:content_moderation, blog: :user)
+          .order("content_moderations.moderated_at DESC"),
+      limit: 25
+    )
+    @pending_count = Post.moderation_pending.count
+  end
+
+  def show
+    @post = Post.with_discarded.includes(:content_moderation, blog: :user).find(params[:id])
+  end
+
+  def dismiss
+    @post = Post.with_discarded.find(params[:id])
+    @post.undiscard if @post.discarded?
+    @post.content_moderation&.update!(status: :clean)
+    redirect_to admin_moderation_index_path, notice: "Post restored and marked as reviewed"
+  end
+
+  def discard
+    @post = Post.find(params[:id])
+    @post.discard!
+    redirect_to admin_moderation_index_path, notice: "Post discarded"
+  end
+end

--- a/app/controllers/app/pages_controller.rb
+++ b/app/controllers/app/pages_controller.rb
@@ -2,8 +2,8 @@ class App::PagesController < AppController
   include EditorPreparation
   def index
     home_page_id = Current.user.blog.home_page_id
-    @pages = Current.user.blog.pages.published.order(:title).sort_by { |p| p.id == home_page_id ? 0 : 1 }
-    @drafts = Current.user.blog.pages.draft.order(:title)
+    @pages = Current.user.blog.pages.kept.published.order(:title).sort_by { |p| p.id == home_page_id ? 0 : 1 }
+    @drafts = Current.user.blog.pages.kept.draft.order(:title)
   end
 
   def new
@@ -21,12 +21,12 @@ class App::PagesController < AppController
   end
 
   def edit
-    @page = Current.user.blog.pages.find_by!(token: params[:token])
+    @page = Current.user.blog.pages.kept.find_by!(token: params[:token])
     prepare_content_for_editor(@page)
   end
 
   def update
-    @page = Current.user.blog.pages.find_by!(token: params[:token])
+    @page = Current.user.blog.pages.kept.find_by!(token: params[:token])
 
     if @page.update(page_params)
       redirect_to app_pages_path, notice: "Page was successfully updated."
@@ -36,13 +36,13 @@ class App::PagesController < AppController
   end
 
   def destroy
-    @page = Current.user.blog.pages.find_by!(token: params[:token])
+    @page = Current.user.blog.pages.kept.find_by!(token: params[:token])
     @page.destroy!
     redirect_to app_pages_path, notice: "Page was successfully deleted."
   end
 
   def set_as_home_page
-    @page = Current.user.blog.pages.find_by!(token: params[:token])
+    @page = Current.user.blog.pages.kept.find_by!(token: params[:token])
     Current.user.blog.update!(home_page_id: @page.id)
     redirect_to app_pages_path, notice: "Home page set!"
   end

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -5,8 +5,8 @@ class App::PostsController < AppController
   rescue_from Pagy::OverflowError, with: :redirect_to_first_page
 
   def index
-    posts_query = Current.user.blog.posts.published.order(published_at: :desc)
-    drafts_query = Current.user.blog.posts.draft.order(Arel.sql("COALESCE(posts.published_at, posts.updated_at) DESC"))
+    posts_query = Current.user.blog.posts.kept.published.order(published_at: :desc)
+    drafts_query = Current.user.blog.posts.kept.draft.order(Arel.sql("COALESCE(posts.published_at, posts.updated_at) DESC"))
 
     @search_term = params[:search]
     if @search_term.present?
@@ -22,7 +22,7 @@ class App::PostsController < AppController
 
     @pagy, @posts = pagy(posts_query, limit: 25)
     @drafts = @pagy.page == 1 ? drafts_query.load : []
-    @total_posts_count = Current.user.blog.posts.published.count
+    @total_posts_count = Current.user.blog.posts.kept.published.count
   end
 
   def new
@@ -30,7 +30,7 @@ class App::PostsController < AppController
   end
 
   def edit
-    @post = Current.user.blog.posts.find_by!(token: params[:token])
+    @post = Current.user.blog.posts.kept.find_by!(token: params[:token])
 
     prepare_content_for_editor(@post)
 
@@ -38,7 +38,7 @@ class App::PostsController < AppController
   end
 
   def show
-    @post = Current.user.blog.all_posts.find_by!(token: params[:token])
+    @post = Current.user.blog.all_posts.kept.find_by!(token: params[:token])
     @blog = Current.user.blog
     @user = Current.user
 
@@ -56,7 +56,7 @@ class App::PostsController < AppController
   end
 
   def update
-    @post = Current.user.blog.posts.find_by!(token: params[:token])
+    @post = Current.user.blog.posts.kept.find_by!(token: params[:token])
 
     if @post.update(post_params)
       page = session.delete(:return_to_page)
@@ -70,7 +70,7 @@ class App::PostsController < AppController
   end
 
   def destroy
-    post = Current.user.blog.posts.find_by!(token: params[:token])
+    post = Current.user.blog.posts.kept.find_by!(token: params[:token])
     post.destroy!
 
     redirect_to app_posts_path, notice: "Post was successfully deleted"

--- a/app/controllers/blogs/page_views_controller.rb
+++ b/app/controllers/blogs/page_views_controller.rb
@@ -5,7 +5,7 @@ class Blogs::PageViewsController < Blogs::BaseController
     return head :no_content if params[:referrer]&.match?(%r{pagecord\.com/app})
     return head :no_content if Current.user == @blog.user
 
-    post = @blog.all_posts.published.released.find_by(token: params[:post_token]) if params[:post_token].present?
+    post = @blog.all_posts.kept.published.released.find_by(token: params[:post_token]) if params[:post_token].present?
 
     PageView.track(blog: @blog, post: post, request: request, path: params[:path], referrer: params[:referrer])
 

--- a/app/controllers/blogs/posts_controller.rb
+++ b/app/controllers/blogs/posts_controller.rb
@@ -51,6 +51,7 @@ class Blogs::PostsController < Blogs::BaseController
   # Shows a single post or page by its slug.
   def show
     @post = @blog.all_posts
+      .kept
       .published
       .released
       .with_full_rich_text

--- a/app/controllers/blogs/sitemaps_controller.rb
+++ b/app/controllers/blogs/sitemaps_controller.rb
@@ -3,8 +3,8 @@ class Blogs::SitemapsController < Blogs::BaseController
 
   def show
     fresh_when(
-      etag: @blog.posts.maximum(:updated_at),
-      last_modified: @blog.posts.maximum(:updated_at),
+      etag: @blog.posts.kept.maximum(:updated_at),
+      last_modified: @blog.posts.kept.maximum(:updated_at),
       public: true
     )
 

--- a/app/jobs/content_moderation_batch_job.rb
+++ b/app/jobs/content_moderation_batch_job.rb
@@ -1,0 +1,23 @@
+class ContentModerationBatchJob < ApplicationJob
+  queue_as :default
+
+  DELAY_BETWEEN_POSTS = 1.second
+  MAX_POSTS_PER_RUN = 100
+  LOOKBACK_PERIOD = 2.hours
+
+  def perform
+    posts = Post.kept
+                .published
+                .where(hidden: false)
+                .where("posts.updated_at >= ?", LOOKBACK_PERIOD.ago)
+                .moderation_pending
+                .includes(:blog)
+                .limit(MAX_POSTS_PER_RUN)
+
+    Rails.logger.info "[ContentModerationBatch] Queuing #{posts.count} posts for moderation"
+
+    posts.each_with_index do |post, index|
+      ContentModerationJob.set(wait: index * DELAY_BETWEEN_POSTS).perform_later(post.id)
+    end
+  end
+end

--- a/app/jobs/content_moderation_job.rb
+++ b/app/jobs/content_moderation_job.rb
@@ -1,0 +1,41 @@
+class ContentModerationJob < ApplicationJob
+  queue_as :default
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+
+  def perform(post_id)
+    post = Post.find_by(id: post_id)
+    return unless post
+    return unless post.published? && !post.hidden? && !post.discarded?
+    return unless post.needs_moderation?
+
+    Rails.logger.info "[ContentModeration] Moderating post #{post.id} (#{post.blog.subdomain})"
+
+    moderator = ContentModerator.new(post)
+    moderator.moderate
+
+    save_moderation_result!(post, moderator.result)
+
+    if moderator.flagged?
+      Rails.logger.info "[ContentModeration] FLAGGED post #{post.id}: #{post.content_moderation.flagged_categories.join(', ')}"
+      post.discard!
+      AdminMailer.content_flagged_notification(post.id).deliver_later
+    else
+      Rails.logger.info "[ContentModeration] Clean post #{post.id}"
+    end
+  end
+
+  private
+
+    def save_moderation_result!(post, result)
+      moderation = post.content_moderation || post.build_content_moderation
+
+      moderation.update!(
+        status: result.status,
+        flags: result.flags,
+        moderated_at: Time.current,
+        fingerprint: post.moderation_fingerprint,
+        model_version: result.model_version
+      )
+    end
+end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -10,4 +10,14 @@ class AdminMailer < ApplicationMailer
       subject: "Spam Detection [#{classification}]: #{@blog.subdomain}"
     )
   end
+
+  def content_flagged_notification(post_id)
+    @post = Post.find(post_id)
+    @blog = @post.blog
+
+    mail(
+      to: "hello@pagecord.com",
+      subject: "Content Flagged: #{@blog.subdomain} - #{@post.display_title.truncate(50)}"
+    )
+  end
 end

--- a/app/models/concerns/post/moderatable.rb
+++ b/app/models/concerns/post/moderatable.rb
@@ -1,0 +1,79 @@
+module Post::Moderatable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :content_moderation, dependent: :destroy
+
+    scope :with_content_moderation, -> { includes(:content_moderation) }
+    scope :moderation_flagged, -> { joins(:content_moderation).where(content_moderations: { status: :flagged }) }
+    scope :moderation_pending, -> { left_joins(:content_moderation).where(content_moderations: { id: nil }).or(left_joins(:content_moderation).where(content_moderations: { status: [ :pending, :error ] })) }
+
+    after_commit :queue_moderation_on_publish, on: [ :create, :update ]
+  end
+
+  def moderation_text_payload
+    [ title, plain_text_content ].compact.join("\n\n").strip.presence
+  end
+
+  def moderation_image_payloads
+    moderation_images.filter_map do |attachment|
+      blob = attachment.respond_to?(:blob) ? attachment.blob : attachment
+      next unless blob.image?
+
+      base64_data = Base64.strict_encode64(blob.download)
+      content_type = blob.content_type || "image/jpeg"
+
+      {
+        type: "image_url",
+        image_url: { url: "data:#{content_type};base64,#{base64_data}" }
+      }
+    end
+  end
+
+  def needs_moderation?
+    return true if content_moderation.nil?
+    return true if content_moderation.pending? || content_moderation.error?
+    return true if content_moderation.fingerprint.blank?
+    content_moderation.fingerprint != compute_moderation_fingerprint
+  end
+
+  def moderation_fingerprint
+    compute_moderation_fingerprint
+  end
+
+  def queue_moderation_check(delay: 10.minutes)
+    ContentModerationJob.set(wait: delay).perform_later(id)
+  end
+
+  private
+
+    def queue_moderation_on_publish
+      return unless published? && !hidden? && !discarded?
+      return unless needs_moderation?
+      queue_moderation_check
+    end
+
+    def compute_moderation_fingerprint
+      content_parts = [
+        title.to_s,
+        plain_text_content.to_s,
+        moderation_image_fingerprints.join(",")
+      ]
+      Digest::SHA256.hexdigest(content_parts.join("|"))
+    end
+
+    def moderation_image_fingerprints
+      moderation_images.map do |attachment|
+        blob = attachment.respond_to?(:blob) ? attachment.blob : attachment
+        blob.checksum
+      end.sort
+    end
+
+    # Limit to 5 images to stay within OpenAI payload limits and manage memory.
+    def moderation_images
+      images = []
+      images += content_image_attachments if content.body.present?
+      images += attachments.select(&:image?)
+      images.uniq { |a| a.respond_to?(:blob) ? a.blob.id : a.id }.first(5)
+    end
+end

--- a/app/models/content_moderation.rb
+++ b/app/models/content_moderation.rb
@@ -1,0 +1,15 @@
+class ContentModeration < ApplicationRecord
+  belongs_to :post
+
+  enum :status, { pending: 0, clean: 1, flagged: 2, error: 3 }
+
+  scope :needs_review, -> { where(status: [ :pending, :error ]) }
+
+  def flagged_categories
+    flags.select { |_, v| v == true }.keys
+  end
+
+  def has_flagged_content?
+    flags.values.any? { |v| v == true }
+  end
+end

--- a/app/models/content_moderator.rb
+++ b/app/models/content_moderator.rb
@@ -1,0 +1,117 @@
+class ContentModerator
+  Result = Struct.new(:status, :flags, :model_version, keyword_init: true)
+
+  CATEGORIES = %w[
+    sexual sexual/minors harassment harassment/threatening
+    hate hate/threatening self-harm self-harm/intent
+    self-harm/instructions violence violence/graphic illicit
+    illicit/violent
+  ].freeze
+
+  MODEL = "omni-moderation-latest"
+
+  attr_reader :result
+
+  def initialize(post)
+    @post = post
+    @access_token = ENV["OPENAI_ACCESS_TOKEN"] ||
+                    Rails.application.credentials.dig(:openai_access_token)
+    @client = OpenAI::Client.new(access_token: @access_token) if @access_token.present?
+  end
+
+  def moderate
+    return error_result("Missing OpenAI access token") if @client.nil?
+    return error_result("No content to moderate") unless has_content?
+
+    response = call_moderation_api
+    parse_response(response)
+  rescue Faraday::Error, Net::OpenTimeout => e
+    Rails.logger.error("[ContentModerator] API error for post #{@post.id}: #{e.class} - #{e.message}")
+    error_result("API error: #{e.message}")
+  rescue JSON::ParserError => e
+    Rails.logger.warn("[ContentModerator] JSON parse error for post #{@post.id}: #{e.message}")
+    error_result("Failed to parse API response")
+  rescue StandardError => e
+    Rails.logger.error("[ContentModerator] Unexpected error for post #{@post.id}: #{e.class} - #{e.message}")
+    Sentry.capture_exception(e, extra: { post_id: @post.id }) if defined?(Sentry)
+    error_result("Moderation error")
+  end
+
+  def flagged?
+    result&.status == :flagged
+  end
+
+  def clean?
+    result&.status == :clean
+  end
+
+  def error?
+    result&.status == :error
+  end
+
+  private
+
+    def has_content?
+      @post.moderation_text_payload.present? || @post.moderation_image_payloads.any?
+    end
+
+    def call_moderation_api
+      inputs = build_inputs
+
+      @client.moderations(
+        parameters: {
+          model: MODEL,
+          input: inputs
+        }
+      )
+    end
+
+    def build_inputs
+      inputs = []
+
+      if @post.moderation_text_payload.present?
+        inputs << { type: "text", text: @post.moderation_text_payload }
+      end
+
+      @post.moderation_image_payloads.each do |image_payload|
+        inputs << image_payload
+      end
+
+      inputs
+    end
+
+    def parse_response(response)
+      results = response.dig("results")
+      return error_result("Empty response from API") if results.blank?
+
+      aggregated_flags = aggregate_flags(results)
+      flagged = aggregated_flags.values.any? { |v| v == true }
+
+      @result = Result.new(
+        status: flagged ? :flagged : :clean,
+        flags: aggregated_flags,
+        model_version: response.dig("model") || MODEL
+      )
+    end
+
+    def aggregate_flags(results)
+      flags = CATEGORIES.to_h { |cat| [ cat, false ] }
+
+      results.each do |result|
+        categories = result.dig("categories") || {}
+        categories.each do |category, flagged_value|
+          flags[category] = true if flagged_value && CATEGORIES.include?(category)
+        end
+      end
+
+      flags
+    end
+
+    def error_result(reason)
+      @result = Result.new(
+        status: :error,
+        flags: { error: reason },
+        model_version: nil
+      )
+    end
+end

--- a/app/models/post_digest.rb
+++ b/app/models/post_digest.rb
@@ -26,7 +26,7 @@ class PostDigest < ApplicationRecord
 
     transaction do
       digest = create!(blog: blog)
-      new_posts.each { |post| puts "creating digest post for #{post.display_title}";digest.digest_posts.create!(post: post) }
+      new_posts.each { |post| digest.digest_posts.create!(post: post) }
       digest
     end
   end

--- a/app/views/admin/moderation/index.html.erb
+++ b/app/views/admin/moderation/index.html.erb
@@ -1,0 +1,64 @@
+<div class="mb-6">
+  <div>
+    <%= pluralize(@pagy.count, "flagged post") %>. <%= pluralize(@pending_count, "post") %> pending moderation.
+  </div>
+</div>
+
+<% if @posts.any? %>
+  <div class="overflow-auto">
+    <table class="my-8 min-w-full divide-y divide-slate-300 dark:divide-slate-700">
+      <thead>
+        <tr>
+          <th class="py-4 pe-4 sm:ps-4 text-left text-sm font-semibold text-slate-900 dark:text-slate-50">Post</th>
+          <th class="py-4 pe-4 sm:ps-4 text-left text-sm font-semibold text-slate-900 dark:text-slate-50">Blog</th>
+          <th class="py-4 pe-4 sm:ps-4 text-left text-sm font-semibold text-slate-900 dark:text-slate-50">Flags</th>
+          <th class="py-4 pe-4 sm:ps-4 text-left text-sm font-semibold text-slate-900 dark:text-slate-50">Status</th>
+          <th class="py-4 pe-4 sm:ps-4 text-left text-sm font-semibold text-slate-900 dark:text-slate-50">Moderated</th>
+          <th class="py-4 sm:ps-4 text-end text-sm font-semibold text-slate-900 dark:text-slate-50">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-300 dark:divide-slate-700">
+        <% @posts.each do |post| %>
+          <tr>
+            <td class="whitespace-nowrap py-4 pe-4 sm:ps-4 text-sm font-medium text-slate-900 dark:text-slate-50">
+              <%= link_to post.display_title.truncate(40), admin_moderation_path(id: post.id), class: "hover:underline" %>
+            </td>
+            <td class="whitespace-nowrap py-4 pe-4 sm:ps-4 text-sm text-slate-500 dark:text-slate-400">
+              <%= link_to "@#{post.blog.subdomain}", blog_home_url(post.blog), target: "_blank", class: "hover:underline" %>
+            </td>
+            <td class="whitespace-nowrap py-4 pe-4 sm:ps-4 text-sm text-slate-500 dark:text-slate-400">
+              <%= post.content_moderation&.flagged_categories&.join(", ") %>
+            </td>
+            <td class="whitespace-nowrap py-4 pe-4 sm:ps-4 text-sm text-slate-500 dark:text-slate-400">
+              <%= post.discarded? ? "Discarded" : "Visible" %>
+            </td>
+            <td class="whitespace-nowrap py-4 pe-4 sm:ps-4 text-sm text-slate-500 dark:text-slate-400">
+              <%= post.content_moderation&.moderated_at&.to_formatted_s(:short) %>
+            </td>
+            <td class="whitespace-nowrap py-4 sm:ps-4 text-end text-sm">
+              <div class="flex justify-end space-x-2">
+                <% if post.discarded? %>
+                  <%= button_to "Restore", dismiss_admin_moderation_path(id: post.id),
+                      method: :post, class: "px-3 py-1 bg-green-100 hover:bg-green-200 text-green-800 rounded cursor-pointer",
+                      data: { turbo_confirm: "Restore this post?" } %>
+                <% else %>
+                  <%= button_to "Dismiss", dismiss_admin_moderation_path(id: post.id),
+                      method: :post, class: "px-3 py-1 bg-gray-100 hover:bg-gray-200 text-gray-800 rounded cursor-pointer" %>
+                  <%= button_to "Discard", discard_admin_moderation_path(id: post.id),
+                      method: :post, class: "px-3 py-1 bg-red-100 hover:bg-red-200 text-red-800 rounded cursor-pointer",
+                      data: { turbo_confirm: "Discard this post?" } %>
+                <% end %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <%= render "app/shared/pagy_nav" %>
+<% else %>
+  <div class="text-slate-500 dark:text-slate-400 py-8">
+    No flagged posts to review.
+  </div>
+<% end %>

--- a/app/views/admin/moderation/show.html.erb
+++ b/app/views/admin/moderation/show.html.erb
@@ -1,0 +1,37 @@
+<div class="mb-6 flex flex-wrap items-center justify-between gap-4 pb-2 border-b border-slate-300 dark:border-slate-700">
+  <div>
+    <span class="text-slate-500 dark:text-slate-400">Flags:</span> <%= @post.content_moderation&.flagged_categories&.join(", ").presence || "None" %>
+    <span class="mx-2 text-slate-300 dark:text-slate-600">|</span>
+    <span class="text-slate-500 dark:text-slate-400">Status:</span> <%= @post.discarded? ? "Discarded" : "Visible" %>
+    <span class="mx-2 text-slate-300 dark:text-slate-600">|</span>
+    <%= link_to "View on blog", blog_post_url(subdomain: @post.blog.subdomain, slug: @post.slug), target: "_blank", class: "hover:underline" %>
+  </div>
+  <div class="flex space-x-2">
+    <%= link_to "← Back", admin_moderation_index_path, class: "px-3 py-1 bg-slate-100 dark:bg-slate-700 hover:bg-gray-200 text-slate-800 dark:text-slate-100 rounded" %>
+    <% if @post.discarded? %>
+      <%= button_to "Restore", dismiss_admin_moderation_path(id: @post.id),
+          method: :post, class: "px-3 py-1 bg-green-100 hover:bg-green-200 text-green-800 rounded cursor-pointer",
+          data: { turbo_confirm: "Restore this post?" } %>
+    <% else %>
+      <%= button_to "Dismiss", dismiss_admin_moderation_path(id: @post.id),
+          method: :post, class: "px-3 py-1 bg-slate-100 dark:bg-slate-700 hover:bg-gray-200 text-slate-800 dark:text-slate-100 rounded cursor-pointer" %>
+      <%= button_to "Discard", discard_admin_moderation_path(id: @post.id),
+          method: :post, class: "px-3 py-1 bg-red-100 hover:bg-red-200 text-red-800 rounded cursor-pointer",
+          data: { turbo_confirm: "Discard this post?" } %>
+    <% end %>
+  </div>
+</div>
+
+<div class="mb-4 text-sm text-slate-500 dark:text-slate-400">
+  <%= link_to "@#{@post.blog.subdomain}", blog_home_url(@post.blog), target: "_blank", class: "hover:underline" %>
+  <span class="mx-2">·</span>
+  <%= @post.content_moderation&.moderated_at&.to_formatted_s(:long) %>
+</div>
+
+<% if @post.title.present? %>
+  <h2 class="text-2xl font-bold mb-4"><%= @post.title %></h2>
+<% end %>
+
+<div class="prose dark:prose-invert max-w-none">
+  <%= @post.content.body %>
+</div>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -1,13 +1,14 @@
 <header class="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 mb-8">
   <div class="container mx-auto px-4">
-    <div class="flex items-center justify-between py-4">
+    <div class="flex flex-wrap items-center justify-between gap-y-2 py-4">
       <%= link_to app_root_path do %>
         <%= inline_svg_tag "logo.svg", class: "w-[100px] inline-flex dark:text-slate-100 text-slate-900" %>
       <% end %>
 
-      <nav class="flex space-x-4">
+      <nav class="flex flex-wrap gap-x-4 gap-y-1">
         <%= link_to "Blogs", admin_blogs_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'blogs'}" %>
         <%= link_to "Posts", admin_posts_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'posts'}" %>
+        <%= link_to "Moderation", admin_moderation_index_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'moderation'}" %>
         <%= link_to "Analytics", admin_analytics_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'analytics'}" %>
       </nav>
     </div>

--- a/app/views/admin_mailer/content_flagged_notification.html.erb
+++ b/app/views/admin_mailer/content_flagged_notification.html.erb
@@ -1,0 +1,20 @@
+<p>A post has been flagged by content moderation.</p>
+
+<div style="background-color: #F3F4F6; padding: 15px; border-radius: 5px; margin: 20px 0;">
+  <p>
+    <strong>Blog:</strong> <%= @blog.subdomain %>
+  </p>
+  <p>
+    <strong>Post:</strong> <%= @post.display_title %>
+  </p>
+  <p>
+    <strong>Flagged Categories:</strong> <%= @post.content_moderation&.flagged_categories&.join(", ") || "Unknown" %>
+  </p>
+  <p>
+    <strong>Moderated At:</strong> <%= @post.content_moderation&.moderated_at&.to_fs(:long) %>
+  </p>
+</div>
+
+<p>
+  Please review and take action if necessary.
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,12 @@ Rails.application.routes.draw do
         post :restore
       end
     end
+    resources :moderation, only: [ :index, :show ] do
+      member do
+        post :dismiss
+        post :discard
+      end
+    end
   end
 
   constraints(->(request) { !DomainConstraints.default_domain?(request) }) do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -62,6 +62,10 @@ every :day, at: "5:30 am" do
   runner "SpamDetectionJob.perform_later"
 end
 
+every 1.hour do
+  runner "ContentModerationBatchJob.perform_later"
+end
+
 every 1.week, at: "6:00 am" do
   rake "posts:clear_old_raw_content"
 end

--- a/db/migrate/20260106175242_create_content_moderations.rb
+++ b/db/migrate/20260106175242_create_content_moderations.rb
@@ -1,0 +1,16 @@
+class CreateContentModerations < ActiveRecord::Migration[8.2]
+  def change
+    create_table :content_moderations do |t|
+      t.references :post, null: false, foreign_key: true, index: { unique: true }
+      t.integer :status, default: 0, null: false
+      t.jsonb :flags, default: {}
+      t.datetime :moderated_at
+      t.string :fingerprint
+      t.string :model_version
+
+      t.timestamps
+    end
+
+    add_index :content_moderations, :status
+  end
+end

--- a/db/migrate/20260106180831_add_discarded_at_to_posts.rb
+++ b/db/migrate/20260106180831_add_discarded_at_to_posts.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToPosts < ActiveRecord::Migration[8.2]
+  def change
+    add_column :posts, :discarded_at, :datetime
+    add_index :posts, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2025_12_19_084849) do
+ActiveRecord::Schema[8.2].define(version: 2026_01_06_180831) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -123,6 +123,19 @@ ActiveRecord::Schema[8.2].define(version: 2025_12_19_084849) do
     t.index ["home_page_id"], name: "index_blogs_on_home_page_id"
     t.index ["subdomain"], name: "index_blogs_on_subdomain", unique: true
     t.index ["user_id"], name: "index_blogs_on_user_id"
+  end
+
+  create_table "content_moderations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "fingerprint"
+    t.jsonb "flags", default: {}
+    t.string "model_version"
+    t.datetime "moderated_at"
+    t.bigint "post_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_content_moderations_on_post_id", unique: true
+    t.index ["status"], name: "index_content_moderations_on_status"
   end
 
   create_table "custom_domain_changes", force: :cascade do |t|
@@ -265,6 +278,7 @@ ActiveRecord::Schema[8.2].define(version: 2025_12_19_084849) do
     t.bigint "blog_id", null: false
     t.string "canonical_url"
     t.datetime "created_at", null: false
+    t.datetime "discarded_at"
     t.boolean "hidden", default: false, null: false
     t.boolean "is_page", default: false, null: false
     t.datetime "published_at"
@@ -283,6 +297,7 @@ ActiveRecord::Schema[8.2].define(version: 2025_12_19_084849) do
     t.index ["blog_id", "status", "published_at"], name: "index_posts_published_lookup", order: { published_at: :desc }, where: "(status = 1)"
     t.index ["blog_id", "status"], name: "index_posts_search_filter", where: "(status = ANY (ARRAY[0, 1]))"
     t.index ["blog_id"], name: "index_posts_on_blog_id_published_count_only", where: "((is_page = false) AND (status = 1))"
+    t.index ["discarded_at"], name: "index_posts_on_discarded_at"
     t.index ["hidden"], name: "index_posts_on_hidden"
     t.index ["is_page"], name: "index_posts_on_is_page"
     t.index ["published_at"], name: "index_posts_on_published_at"
@@ -367,6 +382,7 @@ ActiveRecord::Schema[8.2].define(version: 2025_12_19_084849) do
   add_foreign_key "blog_exports", "blogs"
   add_foreign_key "blogs", "posts", column: "home_page_id", on_delete: :nullify
   add_foreign_key "blogs", "users"
+  add_foreign_key "content_moderations", "posts"
   add_foreign_key "custom_domain_changes", "blogs"
   add_foreign_key "digest_posts", "post_digests"
   add_foreign_key "digest_posts", "posts"

--- a/test/fixtures/content_moderations.yml
+++ b/test/fixtures/content_moderations.yml
@@ -1,0 +1,40 @@
+# Content moderations for testing the admin panel
+# Using innocuous flag categories for demonstration purposes
+
+flagged_spam:
+  post: three
+  status: flagged
+  flags:
+    spam: true
+    harassment: false
+    violence: false
+  moderated_at: <%= 2.hours.ago %>
+  fingerprint: <%= Digest::SHA256.hexdigest("fixture_spam") %>
+  model_version: omni-moderation-2024-09-26
+
+flagged_policy:
+  post: four
+  status: flagged
+  flags:
+    illicit: true
+    spam: false
+  moderated_at: <%= 1.hour.ago %>
+  fingerprint: <%= Digest::SHA256.hexdigest("fixture_policy") %>
+  model_version: omni-moderation-2024-09-26
+
+clean_post:
+  post: two
+  status: clean
+  flags:
+    spam: false
+    harassment: false
+    violence: false
+  moderated_at: <%= 3.hours.ago %>
+  fingerprint: <%= Digest::SHA256.hexdigest("fixture_clean") %>
+  model_version: omni-moderation-2024-09-26
+
+pending_moderation:
+  post: photography_and_tech
+  status: pending
+  flags: {}
+  model_version: omni-moderation-2024-09-26

--- a/test/jobs/content_moderation_job_test.rb
+++ b/test/jobs/content_moderation_job_test.rb
@@ -1,0 +1,112 @@
+require "test_helper"
+require "mocha/minitest"
+
+class ContentModerationJobTest < ActiveJob::TestCase
+  setup do
+    @original_token = ENV["OPENAI_ACCESS_TOKEN"]
+    ENV["OPENAI_ACCESS_TOKEN"] = "test_token"
+    @post = posts(:one)
+    @post.update!(text_summary: "Test content")
+  end
+
+  teardown do
+    ENV["OPENAI_ACCESS_TOKEN"] = @original_token
+  end
+
+  test "skips non-existent posts" do
+    ContentModerator.any_instance.expects(:moderate).never
+    ContentModerationJob.perform_now(999999)
+  end
+
+  test "skips draft posts" do
+    @post.update!(status: :draft)
+    ContentModerator.any_instance.expects(:moderate).never
+    ContentModerationJob.perform_now(@post.id)
+  end
+
+  test "skips hidden posts" do
+    @post.update!(hidden: true)
+    ContentModerator.any_instance.expects(:moderate).never
+    ContentModerationJob.perform_now(@post.id)
+  end
+
+  test "skips discarded posts" do
+    @post.discard!
+    ContentModerator.any_instance.expects(:moderate).never
+    ContentModerationJob.perform_now(@post.id)
+  end
+
+  test "skips posts that dont need moderation" do
+    fingerprint = @post.moderation_fingerprint
+    @post.create_content_moderation!(status: :clean, fingerprint: fingerprint)
+    ContentModerator.any_instance.expects(:moderate).never
+    ContentModerationJob.perform_now(@post.id)
+  end
+
+  test "moderates post and creates clean content_moderation" do
+    result = ContentModerator::Result.new(
+      status: :clean,
+      flags: { "sexual" => false },
+      model_version: "test"
+    )
+    ContentModerator.any_instance.stubs(:moderate)
+    ContentModerator.any_instance.stubs(:result).returns(result)
+    ContentModerator.any_instance.stubs(:flagged?).returns(false)
+
+    ContentModerationJob.perform_now(@post.id)
+
+    @post.reload
+    assert_not_nil @post.content_moderation
+    assert @post.content_moderation.clean?
+    assert_not_nil @post.content_moderation.moderated_at
+    assert_not_nil @post.content_moderation.fingerprint
+  end
+
+  test "moderates post and creates flagged content_moderation and discards post" do
+    result = ContentModerator::Result.new(
+      status: :flagged,
+      flags: { "sexual" => true },
+      model_version: "test"
+    )
+    ContentModerator.any_instance.stubs(:moderate)
+    ContentModerator.any_instance.stubs(:result).returns(result)
+    ContentModerator.any_instance.stubs(:flagged?).returns(true)
+
+    ContentModerationJob.perform_now(@post.id)
+
+    @post.reload
+    assert_not_nil @post.content_moderation
+    assert @post.content_moderation.flagged?
+    assert @post.discarded?
+  end
+
+  test "sends admin notification when post is flagged" do
+    result = ContentModerator::Result.new(
+      status: :flagged,
+      flags: { "sexual" => true },
+      model_version: "test"
+    )
+    ContentModerator.any_instance.stubs(:moderate)
+    ContentModerator.any_instance.stubs(:result).returns(result)
+    ContentModerator.any_instance.stubs(:flagged?).returns(true)
+
+    assert_enqueued_with(job: ActionMailer::MailDeliveryJob) do
+      ContentModerationJob.perform_now(@post.id)
+    end
+  end
+
+  test "does not send admin notification for clean posts" do
+    result = ContentModerator::Result.new(
+      status: :clean,
+      flags: {},
+      model_version: "test"
+    )
+    ContentModerator.any_instance.stubs(:moderate)
+    ContentModerator.any_instance.stubs(:result).returns(result)
+    ContentModerator.any_instance.stubs(:flagged?).returns(false)
+
+    assert_no_enqueued_jobs(only: ActionMailer::MailDeliveryJob) do
+      ContentModerationJob.perform_now(@post.id)
+    end
+  end
+end

--- a/test/models/concerns/post/moderatable_test.rb
+++ b/test/models/concerns/post/moderatable_test.rb
@@ -1,0 +1,129 @@
+require "test_helper"
+require "mocha/minitest"
+
+class Post::ModeratableTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  setup do
+    @post = posts(:one)
+    @post.update!(text_summary: "Test content for moderation")
+  end
+
+  test "needs_moderation? returns true when no content_moderation exists" do
+    assert_nil @post.content_moderation
+    assert @post.needs_moderation?
+  end
+
+  test "needs_moderation? returns true for pending content_moderation" do
+    @post.create_content_moderation!(status: :pending)
+    assert @post.needs_moderation?
+  end
+
+  test "needs_moderation? returns true for error content_moderation" do
+    @post.create_content_moderation!(status: :error)
+    assert @post.needs_moderation?
+  end
+
+  test "needs_moderation? returns true when fingerprint is blank" do
+    @post.create_content_moderation!(status: :clean, fingerprint: nil)
+    assert @post.needs_moderation?
+  end
+
+  test "needs_moderation? returns true when fingerprint changed" do
+    @post.create_content_moderation!(status: :clean, fingerprint: "old_fingerprint")
+    assert @post.needs_moderation?
+  end
+
+  test "needs_moderation? returns false when fingerprint matches" do
+    fingerprint = @post.moderation_fingerprint
+    @post.create_content_moderation!(status: :clean, fingerprint: fingerprint)
+    refute @post.needs_moderation?
+  end
+
+  test "moderation_text_payload combines title and text" do
+    @post.update!(title: "Test Title", text_summary: "Test content")
+    payload = @post.moderation_text_payload
+    assert_includes payload, "Test Title"
+  end
+
+  test "moderation_text_payload returns nil when no title and no text content" do
+    @post.stubs(:plain_text_content).returns("")
+    @post.title = nil
+    assert_nil @post.moderation_text_payload
+  end
+
+  test "moderation_flagged scope returns flagged posts" do
+    @post.create_content_moderation!(status: :flagged)
+    assert_includes Post.moderation_flagged, @post
+  end
+
+  test "moderation_flagged scope excludes clean posts" do
+    @post.create_content_moderation!(status: :clean)
+    refute_includes Post.moderation_flagged, @post
+  end
+
+  test "moderation_pending scope includes posts without content_moderation" do
+    assert_nil @post.content_moderation
+    assert_includes Post.moderation_pending, @post
+  end
+
+  test "moderation_pending scope includes posts with pending status" do
+    @post.create_content_moderation!(status: :pending)
+    assert_includes Post.moderation_pending, @post
+  end
+
+  test "moderation_pending scope includes posts with error status" do
+    @post.create_content_moderation!(status: :error)
+    assert_includes Post.moderation_pending, @post
+  end
+
+  test "moderation_pending scope excludes clean posts" do
+    @post.create_content_moderation!(status: :clean, fingerprint: @post.moderation_fingerprint)
+    refute_includes Post.moderation_pending, @post
+  end
+
+  test "fingerprint changes when title changes" do
+    original_fingerprint = @post.moderation_fingerprint
+    @post.title = "New Title"
+    new_fingerprint = @post.moderation_fingerprint
+    refute_equal original_fingerprint, new_fingerprint
+  end
+
+  test "fingerprint changes when plain_text_content changes" do
+    original_fingerprint = @post.moderation_fingerprint
+    @post.stubs(:plain_text_content).returns("Completely different content")
+    new_fingerprint = @post.moderation_fingerprint
+    refute_equal original_fingerprint, new_fingerprint
+  end
+
+  test "queues moderation on publish" do
+    @post.update!(status: :draft)
+    assert_enqueued_with(job: ContentModerationJob) do
+      @post.publish!
+    end
+  end
+
+  test "does not queue moderation for draft posts" do
+    @post.update!(status: :draft)
+    assert_no_enqueued_jobs(only: ContentModerationJob) do
+      @post.save!
+    end
+  end
+
+  test "does not queue moderation for hidden posts" do
+    @post.update!(hidden: true, status: :draft)
+    assert_no_enqueued_jobs(only: ContentModerationJob) do
+      @post.publish!
+    end
+  end
+
+  test "does not queue moderation for discarded posts" do
+    # Ensure post is already moderated to isolate the discard check
+    @post.create_content_moderation!(status: :clean, fingerprint: @post.moderation_fingerprint)
+    @post.discard!
+
+    # When a discarded post is saved, it should not queue moderation
+    assert_no_enqueued_jobs(only: ContentModerationJob) do
+      @post.update!(title: "Updated title")
+    end
+  end
+end

--- a/test/models/content_moderation_test.rb
+++ b/test/models/content_moderation_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class ContentModerationTest < ActiveSupport::TestCase
+  setup do
+    @post = posts(:one)
+    @moderation = @post.create_content_moderation!(
+      status: :flagged,
+      flags: { "sexual" => true, "violence" => false, "hate" => true }
+    )
+  end
+
+  test "belongs to post" do
+    assert_equal @post, @moderation.post
+  end
+
+  test "flagged_categories returns only flagged ones" do
+    assert_equal [ "hate", "sexual" ], @moderation.flagged_categories.sort
+  end
+
+  test "flagged_categories returns empty array when no flags" do
+    @moderation.update!(flags: { "sexual" => false, "violence" => false })
+    assert_equal [], @moderation.flagged_categories
+  end
+
+  test "has_flagged_content? returns true when any flag is true" do
+    assert @moderation.has_flagged_content?
+  end
+
+  test "has_flagged_content? returns false when all flags are false" do
+    @moderation.update!(flags: { "sexual" => false, "violence" => false })
+    refute @moderation.has_flagged_content?
+  end
+
+  test "status enum works correctly" do
+    @moderation.update!(status: :pending)
+    assert @moderation.pending?
+
+    @moderation.update!(status: :clean)
+    assert @moderation.clean?
+
+    @moderation.update!(status: :flagged)
+    assert @moderation.flagged?
+
+    @moderation.update!(status: :error)
+    assert @moderation.error?
+  end
+
+  test "needs_review scope includes pending and error" do
+    @moderation.update!(status: :pending)
+    assert_includes ContentModeration.needs_review, @moderation
+
+    @moderation.update!(status: :error)
+    assert_includes ContentModeration.needs_review, @moderation
+
+    @moderation.update!(status: :clean)
+    refute_includes ContentModeration.needs_review, @moderation
+
+    @moderation.update!(status: :flagged)
+    refute_includes ContentModeration.needs_review, @moderation
+  end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -133,7 +133,7 @@ class PostTest < ActiveSupport::TestCase
 
   test "pages should not trigger open graph image job" do
     blog = blogs(:joel)
-    assert_no_enqueued_jobs do
+    assert_no_enqueued_jobs(only: GenerateOpenGraphImageJob) do
       blog.posts.create!(title: "Test OpenGraph Page", content: "Page content", is_page: true)
     end
   end


### PR DESCRIPTION
- Implement ContentModerator service to interface with OpenAI's moderation API.
- Add Post::Moderatable concern to handle automated flagging on publish.
- Flagged posts are automatically soft-deleted (discarded) and trigger an admin notification.
- Include Admin::ModerationController for manual review and restoration of flagged content.
- Implement ContentModerationBatchJob as a safety net for missed posts.
- Limit image moderation to 5 images per post to stay within API payload constraints.
- Document the moderation workflow in CLAUDE.md and GEMINI.md.