### PR TITLE
Make custom CSS available to all premium users

### DIFF
--- a/app/controllers/app/settings/appearance_controller.rb
+++ b/app/controllers/app/settings/appearance_controller.rb
@@ -30,7 +30,7 @@ class App::Settings::AppearanceController < AppController
         permitted_params << :show_branding
       end
 
-      permitted_params << :custom_css if current_features.enabled?(:custom_css)
+      permitted_params << :custom_css if @blog.user.has_premium_access?
 
       params.require(:blog).permit(permitted_params)
     end

--- a/app/views/app/settings/appearance/_form.html.erb
+++ b/app/views/app/settings/appearance/_form.html.erb
@@ -1,4 +1,4 @@
-<% if @blog.user.has_premium_access? && current_features.enabled?(:custom_css) %>
+<% if @blog.user.has_premium_access? %>
   <% content_for :head do %>
     <link href="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/lib/codemirror.min.css" rel="stylesheet" type="text/css"/>
     <link href="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/addon/hint/show-hint.css" rel="stylesheet" type="text/css"/>
@@ -129,7 +129,7 @@
     </div>
   </div>
 
-  <% if @blog.user.has_premium_access? && current_features.enabled?(:custom_css) %>
+  <% if @blog.user.has_premium_access? %>
     <fieldset class="mt-8" id="custom-css-section" data-controller="css-editor">
       <h3 class="font-bold text-lg mb-2">Custom CSS</h3>
       <p class="mb-4">

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -72,7 +72,7 @@
       </style>
     <% end %>
 
-    <% if @blog.present? && current_features.enabled?(:custom_css) && @blog.custom_css.present? %>
+    <% if @blog.present? && @blog.user.has_premium_access? && @blog.custom_css.present? %>
       <style>
         <%= @blog.sanitized_custom_css %>
       </style>

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,9 +1,5 @@
 env "FEATURE"
 
-feature :custom_css do |blog: nil|
-  blog&.features.include?("custom_css")
-end
-
 feature :lexxy_ios do |blog: nil|
   blog&.features.include?("lexxy_ios")
 end


### PR DESCRIPTION
## Summary
- Remove the `custom_css` feature flag from `features.rb`
- Replace feature flag checks with `has_premium_access?` in controller, views, and layout
- Update tests to use subscription status instead of feature flags

Custom CSS is now available to all subscribers and users on a free trial. When trial ends without subscribing, the CSS stops rendering (but data persists in case they subscribe later).

## Test plan
- [x] Existing tests updated and passing
- [ ] Verify subscribed user can see and edit custom CSS
- [ ] Verify trial user can see and edit custom CSS
- [ ] Verify free user cannot see custom CSS section
- [ ] Verify custom CSS renders on subscribed user's blog
- [ ] Verify custom CSS does not render on free user's blog