### PR TITLE
Add custom head HTML for analytics and integrations

### DIFF
--- a/app/assets/stylesheets/html-editor.css
+++ b/app/assets/stylesheets/html-editor.css
@@ -1,0 +1,65 @@
+/* CodeMirror HTML Editor overrides */
+[data-controller="html-editor"] .CodeMirror {
+  height: auto;
+  min-height: 10rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.875rem;
+}
+
+[data-controller="html-editor"] .CodeMirror-focused {
+  border-color: #64748b;
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-controller="html-editor"] .CodeMirror {
+    border-color: #475569;
+    background: #1e293b;
+    color: #e2e8f0;
+  }
+
+  [data-controller="html-editor"] .CodeMirror-focused {
+    border-color: #94a3b8;
+  }
+
+  [data-controller="html-editor"] .CodeMirror .CodeMirror-gutters {
+    background: #1e293b;
+    border-right-color: #334155;
+  }
+
+  [data-controller="html-editor"] .CodeMirror .CodeMirror-linenumber {
+    color: #64748b;
+  }
+
+  [data-controller="html-editor"] .CodeMirror .CodeMirror-cursor {
+    border-left-color: #e2e8f0;
+  }
+
+  [data-controller="html-editor"] .CodeMirror .CodeMirror-selected {
+    background: #334155;
+  }
+
+  [data-controller="html-editor"] .CodeMirror-focused .CodeMirror-selected {
+    background: #475569;
+  }
+
+  /* HTML/XML syntax highlighting for dark mode */
+  [data-controller="html-editor"] .CodeMirror .cm-tag { color: #e06c75; }
+  [data-controller="html-editor"] .CodeMirror .cm-attribute { color: #d19a66; }
+  [data-controller="html-editor"] .CodeMirror .cm-string { color: #98c379; }
+  [data-controller="html-editor"] .CodeMirror .cm-comment { color: #5c6370; }
+
+  /* JavaScript syntax highlighting (for inline scripts) */
+  [data-controller="html-editor"] .CodeMirror .cm-keyword { color: #c678dd; }
+  [data-controller="html-editor"] .CodeMirror .cm-atom { color: #d19a66; }
+  [data-controller="html-editor"] .CodeMirror .cm-number { color: #d19a66; }
+  [data-controller="html-editor"] .CodeMirror .cm-def { color: #61afef; }
+  [data-controller="html-editor"] .CodeMirror .cm-variable { color: #e06c75; }
+  [data-controller="html-editor"] .CodeMirror .cm-property { color: #56b6c2; }
+  [data-controller="html-editor"] .CodeMirror .cm-operator { color: #abb2bf; }
+  [data-controller="html-editor"] .CodeMirror .cm-builtin { color: #e06c75; }
+
+  /* CSS syntax highlighting (for inline styles) */
+  [data-controller="html-editor"] .CodeMirror .cm-qualifier { color: #d19a66; }
+}

--- a/app/controllers/app/settings/appearance_controller.rb
+++ b/app/controllers/app/settings/appearance_controller.rb
@@ -31,6 +31,7 @@ class App::Settings::AppearanceController < AppController
       end
 
       permitted_params << :custom_css if @blog.user.has_premium_access?
+      permitted_params << :custom_head_html if @blog.user.subscribed? && current_features.enabled?(:custom_html)
 
       params.require(:blog).permit(permitted_params)
     end

--- a/app/javascript/controllers/html_editor_controller.js
+++ b/app/javascript/controllers/html_editor_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from "@hotwired/stimulus"
+import CodeMirror from "codemirror"
+import "codemirror/mode/xml/xml"
+import "codemirror/mode/javascript/javascript"
+import "codemirror/mode/css/css"
+import "codemirror/mode/htmlmixed/htmlmixed"
+import "codemirror/addon/edit/matchbrackets"
+import "codemirror/addon/edit/closebrackets"
+import "codemirror/addon/fold/xml-fold"
+import "codemirror/addon/edit/matchtags"
+import "codemirror/addon/edit/closetag"
+
+// Connects to data-controller="html-editor"
+export default class extends Controller {
+  static targets = ["textarea"]
+
+  connect() {
+    this.initializeEditor()
+    this.setupFormSync()
+  }
+
+  disconnect() {
+    if (this.editor) {
+      this.editor.toTextArea()
+    }
+  }
+
+  initializeEditor() {
+    this.editor = CodeMirror.fromTextArea(this.textareaTarget, {
+      mode: "htmlmixed",
+      lineNumbers: true,
+      matchBrackets: true,
+      autoCloseBrackets: true,
+      matchTags: { bothTags: true },
+      autoCloseTags: true,
+      lineWrapping: true,
+      tabSize: 2,
+      viewportMargin: Infinity
+    })
+  }
+
+  setupFormSync() {
+    this.element.closest("form")?.addEventListener("submit", () => {
+      this.editor.save()
+    })
+  }
+}

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -32,6 +32,7 @@ class Blog < ApplicationRecord
   validates :subdomain, presence: true, uniqueness: true, length: { minimum: Subdomain::MIN_LENGTH, maximum: Subdomain::MAX_LENGTH }
   validate  :subdomain_valid
   validates :google_site_verification, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "can only contain letters, numbers, underscores, and hyphens" }, allow_blank: true
+  validates :custom_head_html, length: { maximum: 4096 }
 
   def has_custom_home_page?
     home_page.present?

--- a/app/views/app/settings/appearance/_form.html.erb
+++ b/app/views/app/settings/appearance/_form.html.erb
@@ -2,7 +2,7 @@
   <% content_for :head do %>
     <link href="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/lib/codemirror.min.css" rel="stylesheet" type="text/css"/>
     <link href="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/addon/hint/show-hint.css" rel="stylesheet" type="text/css"/>
-    <%= stylesheet_link_tag "css-editor" %>
+    <%= stylesheet_link_tag "css-editor", "html-editor" %>
   <% end %>
 <% end %>
 
@@ -130,22 +130,53 @@
   </div>
 
   <% if @blog.user.has_premium_access? %>
-    <fieldset class="mt-8" id="custom-css-section" data-controller="css-editor">
-      <h3 class="font-bold text-lg mb-2">Custom CSS</h3>
-      <p class="mb-4">
-        Add custom CSS to style your blog. This CSS will be inserted into the &lt;head&gt; of your blog pages.
-        You can use <code>@import</code> for Google Fonts or Bunny Fonts.
-      </p>
-
+    <div class="mt-8">
+      <h3 class="font-bold text-lg mb-2">Advanced</h3>
       <p class="mb-4 text-sm text-slate-500 italic">
-       Custom CSS is an advanced feature. Customer support for creating or debugging custom CSS is not possible - you're on your own with this one! Read <%= link_to "the help guide", "https://help.pagecord.com/custom-css", class: "underline decoration-slate-300 underline-offset-2 hover:text-slate-700 dark:hover:text-slate-300", target: "_blank" %> to get started.
+        These are advanced features.
+        Customer support for creating or debugging custom code is not possible - you're on your own here!
       </p>
 
-      <%= form.text_area :custom_css,
-          data: { css_editor_target: "textarea" } %>
+      <fieldset id="custom-css-section" data-controller="css-editor">
+        <h4 class="font-medium mb-2">Custom CSS</h4>
+        <p class="mb-4 text-sm text-slate-600 dark:text-slate-400">
+          Add custom CSS to style your blog. This will be inserted into the &lt;head&gt; of your blog pages.
+          You can use <code>@import</code> for Google Fonts or Bunny Fonts.
+        </p>
 
-      <div class="field-error"><%= @blog.errors[:custom_css].first if @blog.errors[:custom_css].any? %></div>
-    </fieldset>
+        <%= form.text_area :custom_css,
+            data: { css_editor_target: "textarea" } %>
+
+        <div class="field-error"><%= @blog.errors[:custom_css].first if @blog.errors[:custom_css].any? %></div>
+      </fieldset>
+
+      <% if current_features.enabled?(:custom_html) %>
+        <% custom_html_disabled = !@blog.user.subscribed? %>
+        <fieldset class="mt-6" id="custom-head-html-section" data-controller="html-editor">
+          <h4 class="font-medium mb-2">Custom Head HTML</h4>
+
+          <% if custom_html_disabled %>
+            <div class="mb-4">
+              <%= callout(:info) do %>
+                <%= link_to "Subscribe", app_settings_subscriptions_path, class: "underline font-medium" %> to add custom HTML to your blog.
+              <% end %>
+            </div>
+          <% end %>
+
+          <div class="<%= 'opacity-50 pointer-events-none' if custom_html_disabled %>">
+            <p class="mb-4 text-sm text-slate-600 dark:text-slate-400">
+              Add custom HTML to your blog's &lt;head&gt;. You can include &lt;script&gt; tags for
+              analytics (Plausible, Fathom, etc.), &lt;meta&gt; tags, &lt;link&gt; tags, or other elements.
+            </p>
+
+            <%= form.text_area :custom_head_html,
+                data: { html_editor_target: "textarea" } %>
+
+            <div class="field-error"><%= @blog.errors[:custom_head_html].first if @blog.errors[:custom_head_html].any? %></div>
+          </div>
+        </fieldset>
+      <% end %>
+    </div>
   <% end %>
 
   <div class="mt-12 flex items-center border-t border-t-slate-200 dark:border-slate-600 pt-4 gap-x-2">

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -77,6 +77,10 @@
         <%= @blog.sanitized_custom_css %>
       </style>
     <% end %>
+
+    <% if @blog.present? && @blog.user.subscribed? && current_features.enabled?(:custom_html) && @blog.custom_head_html.present? %>
+      <%= @blog.custom_head_html.html_safe %>
+    <% end %>
   </head>
 
   <body class="<%= font_class %>" <%= theme_data_attribute %>>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,16 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Cross-Site Scripting",
+      "fingerprint": "5db2d195a8668e75bf3083090dcdfdec68a8cea4b4680ea28fb9b0e21f77207e",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/layouts/blog.html.erb",
+      "line": 82,
+      "code": "Current.user.blog.custom_head_html",
+      "note": "Intentional: subscribers can add custom HTML (script tags, meta tags, etc.) to their own blog's head for analytics, integrations, etc. This only affects their own blog, not the main app."
+    }
+  ],
+  "updated": "2026-02-01",
+  "brakeman_version": "8.0.1"
+}

--- a/config/features.rb
+++ b/config/features.rb
@@ -3,3 +3,7 @@ env "FEATURE"
 feature :lexxy_ios do |blog: nil|
   blog&.features.include?("lexxy_ios")
 end
+
+feature :custom_html do |blog: nil|
+  blog&.features.include?("custom_html")
+end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -23,11 +23,17 @@ pin "sortablejs", to: "https://ga.jspm.io/npm:sortablejs@1.15.6/modular/sortable
 pin "@rails/request.js", to: "https://ga.jspm.io/npm:@rails/request.js@0.0.8/src/index.js", preload: "application"
 pin "stimulus-sortable", to: "https://ga.jspm.io/npm:stimulus-sortable@4.1.1/dist/stimulus-sortable.mjs", preload: "application"
 
-# CodeMirror 5 for CSS editing (app only)
+# CodeMirror 5 for CSS/HTML editing (app only)
 pin "codemirror", to: "https://ga.jspm.io/npm:codemirror@5.65.18/lib/codemirror.js", preload: "application"
 pin "codemirror/mode/css/css", to: "https://ga.jspm.io/npm:codemirror@5.65.18/mode/css/css.js", preload: "application"
+pin "codemirror/mode/javascript/javascript", to: "https://ga.jspm.io/npm:codemirror@5.65.18/mode/javascript/javascript.js", preload: "application"
+pin "codemirror/mode/xml/xml", to: "https://ga.jspm.io/npm:codemirror@5.65.18/mode/xml/xml.js", preload: "application"
+pin "codemirror/mode/htmlmixed/htmlmixed", to: "https://ga.jspm.io/npm:codemirror@5.65.18/mode/htmlmixed/htmlmixed.js", preload: "application"
 pin "codemirror/addon/edit/matchbrackets", to: "https://ga.jspm.io/npm:codemirror@5.65.18/addon/edit/matchbrackets.js", preload: "application"
 pin "codemirror/addon/edit/closebrackets", to: "https://ga.jspm.io/npm:codemirror@5.65.18/addon/edit/closebrackets.js", preload: "application"
+pin "codemirror/addon/edit/matchtags", to: "https://ga.jspm.io/npm:codemirror@5.65.18/addon/edit/matchtags.js", preload: "application"
+pin "codemirror/addon/edit/closetag", to: "https://ga.jspm.io/npm:codemirror@5.65.18/addon/edit/closetag.js", preload: "application"
+pin "codemirror/addon/fold/xml-fold", to: "https://ga.jspm.io/npm:codemirror@5.65.18/addon/fold/xml-fold.js", preload: "application"
 pin "codemirror/addon/hint/show-hint", to: "https://ga.jspm.io/npm:codemirror@5.65.18/addon/hint/show-hint.js", preload: "application"
 pin "codemirror/addon/hint/css-hint", to: "https://ga.jspm.io/npm:codemirror@5.65.18/addon/hint/css-hint.js", preload: "application"
 

--- a/db/migrate/20260201000001_add_custom_head_js_to_blogs.rb
+++ b/db/migrate/20260201000001_add_custom_head_js_to_blogs.rb
@@ -1,0 +1,9 @@
+class AddCustomHeadJsToBlogs < ActiveRecord::Migration[8.2]
+  def change
+    add_column :blogs, :custom_head_html, :text
+
+    # Remove old unused analytics columns
+    remove_column :blogs, :analytics_id, :string
+    remove_column :blogs, :analytics_service, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_01_18_133054) do
+ActiveRecord::Schema[8.2].define(version: 2026_02_01_193618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -86,11 +86,10 @@ ActiveRecord::Schema[8.2].define(version: 2026_01_18_133054) do
 
   create_table "blogs", force: :cascade do |t|
     t.boolean "allow_search_indexing", default: true, null: false
-    t.string "analytics_id"
-    t.string "analytics_service"
     t.datetime "created_at", null: false
     t.text "custom_css"
     t.string "custom_domain"
+    t.text "custom_head_html"
     t.string "custom_theme_accent_dark"
     t.string "custom_theme_accent_light"
     t.string "custom_theme_bg_dark"
@@ -282,6 +281,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_01_18_133054) do
     t.datetime "discarded_at"
     t.boolean "hidden", default: false, null: false
     t.boolean "is_page", default: false, null: false
+    t.string "locale"
     t.datetime "published_at"
     t.text "raw_content"
     t.boolean "show_in_navigation", default: true, null: false
@@ -301,6 +301,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_01_18_133054) do
     t.index ["discarded_at"], name: "index_posts_on_discarded_at"
     t.index ["hidden"], name: "index_posts_on_hidden"
     t.index ["is_page"], name: "index_posts_on_is_page"
+    t.index ["locale"], name: "index_posts_on_locale"
     t.index ["published_at"], name: "index_posts_on_published_at"
     t.index ["status"], name: "index_posts_on_status"
     t.index ["tag_list"], name: "index_posts_on_tag_list", using: :gin

--- a/test/controllers/app/settings/appearance_controller_test.rb
+++ b/test/controllers/app/settings/appearance_controller_test.rb
@@ -98,7 +98,7 @@ class App::Settings::AppearanceControllerTest < ActionDispatch::IntegrationTest
   test "should show custom css section if user has premium access" do
     get app_settings_appearance_index_url
 
-    assert_select "h3", { count: 1, text: "Custom CSS" }
+    assert_select "h4", { count: 1, text: "Custom CSS" }
     assert_select "textarea#blog_custom_css"
     assert_response :success
   end
@@ -108,7 +108,7 @@ class App::Settings::AppearanceControllerTest < ActionDispatch::IntegrationTest
 
     get app_settings_appearance_index_url
 
-    assert_select "h3", { count: 0, text: "Custom CSS" }
+    assert_select "h4", { count: 0, text: "Custom CSS" }
     assert_select "textarea#blog_custom_css", false
     assert_response :success
   end


### PR DESCRIPTION
## Summary
- Allow subscribers to add custom HTML to their blog's `<head>` section
- Enables third-party analytics (Plausible, Fathom, etc.) that require full script tags with attributes like `defer`, `data-domain`, `src`
- Also supports meta tags, link tags, and other head elements
- Gated behind `custom_html` feature flag

## Changes
- Add `custom_head_html` column to blogs table
- Add CodeMirror HTML editor with syntax highlighting (htmlmixed mode)
- Render custom HTML directly in blog head (subscriber-only + feature flag)
- Add 4KB size limit validation
- Add `custom_html` feature flag
- Update Brakeman ignore for intentional raw HTML output

## Test plan
- [ ] Enable feature flag for a blog: `Blog.find_by(subdomain: "x").features << "custom_html"`
- [ ] Add a Plausible-style script tag and verify it renders in page source
- [ ] Verify editor has HTML syntax highlighting
- [ ] Verify dark mode styling works
- [ ] Verify feature is hidden without feature flag