### PR TITLE
Enable iOS keyboard toolbar for all lexxy editors

### DIFF
--- a/app/views/app/home_pages/_form.html.erb
+++ b/app/views/app/home_pages/_form.html.erb
@@ -18,7 +18,7 @@
           class: "lexxy-content mt-4 focus:ring-0 focus:!border-slate-500 dark:focus:!border-slate-400",
           spellcheck: true,
           autocorrect: "on",
-          data: { controller: "lexxy", attachments: Current.user.has_premium_access?, autosave_target: "content" } %>
+          data: { controller: "lexxy ios-toolbar", attachments: Current.user.has_premium_access?, autosave_target: "content" } %>
 
       <div class="field-error"><%= home_page.errors[:content].first if home_page.errors[:content].any? %></div>
     </fieldset>

--- a/app/views/app/pages/_form.html.erb
+++ b/app/views/app/pages/_form.html.erb
@@ -76,7 +76,7 @@
         class: "lexxy-content mt-4 focus:ring-0 focus:!border-slate-500 dark:focus:!border-slate-400",
         spellcheck: true,
         autocorrect: "on",
-        data: { controller: "lexxy", attachments: Current.user.has_premium_access?, autosave_target: "content" } %>
+        data: { controller: "lexxy ios-toolbar", attachments: Current.user.has_premium_access?, autosave_target: "content" } %>
 
       <div class="field-error"><%= @page.errors[:content].first if @page.errors[:content].any? %></div>
     </fieldset>

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -97,13 +97,12 @@
     %>
 
     <fieldset>
-      <% controllers = current_features.enabled?(:lexxy_ios) ? "lexxy ios-toolbar" : "lexxy" %>
       <%= form.rich_text_area :content,
         placeholder: "Craft your draft...",
         class: "lexxy-content mt-4 focus:ring-0 focus:!border-slate-500 dark:focus:!border-slate-400",
         spellcheck: true,
         autocorrect: "on",
-        data: { controller: controllers, attachments: Current.user.has_premium_access?, autosave_target: "content" } %>
+        data: { controller: "lexxy ios-toolbar", attachments: Current.user.has_premium_access?, autosave_target: "content" } %>
 
       <div class="field-error"><%= @post.errors[:content].first if @post.errors[:content].any? %></div>
     </fieldset>

--- a/app/views/app/settings/appearance/_form.html.erb
+++ b/app/views/app/settings/appearance/_form.html.erb
@@ -18,7 +18,7 @@
           autocorrect: "on",
           attachments: false,
           autofocus: true,
-          data: { controller: "lexxy", subscribed: false } %>
+          data: { controller: "lexxy ios-toolbar", subscribed: false } %>
     </div>
 
     <div class="field-error"><%= @blog.errors[:bio].first if @blog.errors[:bio].any? %></div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,9 +1,5 @@
 env "FEATURE"
 
-feature :lexxy_ios do |blog: nil|
-  blog&.features.include?("lexxy_ios")
-end
-
 feature :analytics_referrers do |blog: nil|
   blog&.features.include?("analytics_referrers")
 end


### PR DESCRIPTION
## Summary
- Remove the `lexxy_ios` feature flag from `config/features.rb`
- Enable the `ios-toolbar` Stimulus controller on all rich text editors (posts, pages, custom home pages, bio editor)
- The controller is a no-op on non-iOS devices, so no impact to desktop/Android users

## Revert plan
To disable, change `"lexxy ios-toolbar"` back to `"lexxy"` in the four view partials.