### PR TITLE
Support unicode characters in tags

### DIFF
--- a/app/javascript/controllers/tags_input_controller.js
+++ b/app/javascript/controllers/tags_input_controller.js
@@ -23,9 +23,9 @@ export default class extends Controller {
         tagData.value = tagData.value.toLowerCase()
       },
 
-      // Validate tags (alphanumeric and hyphens only)
+      // Validate tags (letters including unicode, numbers, and hyphens)
       validate: (tagData) => {
-        return /^[a-zA-Z0-9-]+$/.test(tagData.value)
+        return /^[\p{L}\p{N}-]+$/u.test(tagData.value)
       },
 
       // Maximum number of tags

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -3,8 +3,8 @@
 module Taggable
   extend ActiveSupport::Concern
 
-  # Valid tag format: letters, numbers, and hyphens only
-  VALID_TAG_FORMAT = /\A[a-zA-Z0-9-]+\z/
+  # Valid tag format: letters (including unicode), numbers, and hyphens
+  VALID_TAG_FORMAT = /\A[\p{L}\p{N}-]+\z/
 
   included do
     validates :tag_list, presence: true, allow_blank: true

--- a/app/models/html/extract_tags.rb
+++ b/app/models/html/extract_tags.rb
@@ -1,6 +1,6 @@
 module Html
   class ExtractTags < Transformation
-    HASHTAG_REGEX = /#([a-zA-Z0-9-]+)(?=\p{Space}|$|#)/
+    HASHTAG_REGEX = /#([\p{L}\p{N}-]+)(?=\p{Space}|$|#)/
 
     def transform(input)
       @tags = []

--- a/test/models/concerns/taggable_test.rb
+++ b/test/models/concerns/taggable_test.rb
@@ -212,6 +212,16 @@ class TaggableTest < ActiveSupport::TestCase
     assert_equal all_tags, all_tags.sort # Should be sorted
   end
 
+  test "should allow unicode characters in tags" do
+    @post.tag_list = [ "programação", "café", "über-cool", "日本語" ]
+    assert @post.valid?
+  end
+
+  test "should parse and normalize unicode tags" do
+    @post.tags_string = "Programação, CAFÉ, über"
+    assert_equal [ "café", "programação", "über" ], @post.tag_list
+  end
+
   test "should clear tags when tags_string is empty" do
     @post.tags_string = "rails, javascript, ruby"
     assert_equal [ "javascript", "rails", "ruby" ], @post.tag_list

--- a/test/models/html/extract_tags_test.rb
+++ b/test/models/html/extract_tags_test.rb
@@ -201,6 +201,16 @@ class Html::ExtractTagsTest < ActiveSupport::TestCase
     assert_equal [], transformer.tags
   end
 
+  test "should extract unicode hashtags" do
+    html = "Wrote about my trip.\n\n#programação #café #über-cool"
+    result = @transformer.transform(html)
+
+    assert_equal [ "café", "programação", "über-cool" ], @transformer.tags
+    assert_includes result, "Wrote about my trip."
+    assert_not_includes result, "#programação"
+    assert_not_includes result, "#café"
+  end
+
   test "should extract hashtags followed by non-breaking space" do
     nbsp = "\u00A0"
     html = "This is a post about Pagecord.\n\n#pagecord#{nbsp}#rails#{nbsp}#ruby#{nbsp}"


### PR DESCRIPTION
## Summary
- Tags now accept unicode letters and numbers (e.g. programação, café, über-cool, 日本語)
- Updated regex patterns in `Taggable`, `Html::ExtractTags`, and the Tagify JS controller to use `\p{L}\p{N}` unicode property classes instead of ASCII `a-zA-Z0-9`

## Test plan
- [x] Existing tag tests pass (42 tests)
- [x] New tests for unicode tag validation, parsing, and hashtag extraction