### PR TITLE
Add SES newsletter delivery (experimental)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem "ruby-openai", "~> 8.3"
 
 # everything else
 gem "aws-sdk-s3"
+gem "aws-sdk-sesv2"
+gem "aws-sdk-sns"
+gem "aws-sdk-sqs"
 gem "bcrypt", "~> 3.1.7"
 gem "discard", "~> 1.2"
 gem "redcarpet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,15 @@ GEM
       aws-sdk-core (~> 3, >= 3.241.4)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
+    aws-sdk-sesv2 (1.95.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sns (1.112.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sqs (1.111.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
@@ -545,6 +554,9 @@ DEPENDENCIES
   actionpack-page_caching
   appsignal
   aws-sdk-s3
+  aws-sdk-sesv2
+  aws-sdk-sns
+  aws-sdk-sqs
   bcrypt (~> 3.1.7)
   bootsnap
   brakeman

--- a/app/controllers/admin/suppressed_emails_controller.rb
+++ b/app/controllers/admin/suppressed_emails_controller.rb
@@ -1,0 +1,19 @@
+class Admin::SuppressedEmailsController < AdminController
+  include Pagy::Method
+
+  def index
+    scope = Email::Suppression.order(suppressed_at: :desc)
+    scope = scope.where(reason: params[:reason]) if params[:reason].in?(%w[bounce complaint])
+
+    @pagy, @suppressions = pagy(scope, limit: 25)
+    @total_count = Email::Suppression.count
+    @bounce_count = Email::Suppression.bounces.count
+    @complaint_count = Email::Suppression.complaints.count
+  end
+
+  def destroy
+    suppression = Email::Suppression.find(params[:id])
+    suppression.destroy!
+    redirect_to admin_suppressed_emails_path, notice: "#{suppression.email} has been unsuppressed"
+  end
+end

--- a/app/jobs/email/process_bounces_job.rb
+++ b/app/jobs/email/process_bounces_job.rb
@@ -1,0 +1,89 @@
+class Email::ProcessBouncesJob < ApplicationJob
+  queue_as :low
+
+  QUEUE_URL = ENV["AWS_SES_BOUNCE_QUEUE_URL"]
+  WAIT_TIME_SECONDS = 5
+  MAX_MESSAGES = 10
+
+  def perform
+    return unless QUEUE_URL.present?
+
+    loop do
+      response = sqs_client.receive_message(
+        queue_url: QUEUE_URL,
+        max_number_of_messages: MAX_MESSAGES,
+        wait_time_seconds: WAIT_TIME_SECONDS
+      )
+
+      break if response.messages.empty?
+
+      response.messages.each do |sqs_message|
+        process_message(sqs_message)
+        sqs_client.delete_message(queue_url: QUEUE_URL, receipt_handle: sqs_message.receipt_handle)
+      end
+    end
+  end
+
+  private
+
+    def process_message(sqs_message)
+      body = JSON.parse(sqs_message.body)
+      sns_message = JSON.parse(body["Message"])
+
+      notification_type = sns_message["notificationType"]
+
+      case notification_type
+      when "Bounce"
+        process_bounce(sns_message)
+      when "Complaint"
+        process_complaint(sns_message)
+      else
+        Rails.logger.info "Ignoring SES notification type: #{notification_type}"
+      end
+    rescue JSON::ParserError => e
+      Rails.logger.error "Failed to parse SES bounce notification: #{e.message}"
+    end
+
+    def process_bounce(notification)
+      bounce = notification["bounce"]
+      return unless bounce["bounceType"] == "Permanent"
+
+      bounce["bouncedRecipients"].each do |recipient|
+        email = recipient["emailAddress"]
+        Email::Suppression.suppress!(
+          email,
+          reason: "bounce",
+          bounce_type: bounce["bounceType"],
+          diagnostic_code: recipient["diagnosticCode"]
+        )
+
+        update_event_status(notification, "bounced")
+      end
+    end
+
+    def process_complaint(notification)
+      notification["complaint"]["complainedRecipients"].each do |recipient|
+        Email::Suppression.suppress!(recipient["emailAddress"], reason: "complaint")
+      end
+
+      update_event_status(notification, "complained")
+    end
+
+    def update_event_status(notification, status)
+      message_id = notification.dig("mail", "messageId")
+      return unless message_id
+
+      event = Email::Event.find_by(message_id: message_id)
+      event&.update!(status: status)
+    end
+
+    def sqs_client
+      @sqs_client ||= Aws::SQS::Client.new(
+        region: ENV.fetch("AWS_SES_REGION", "eu-west-2"),
+        credentials: Aws::Credentials.new(
+          ENV["AWS_SES_ACCESS_KEY_ID"],
+          ENV["AWS_SES_SECRET_ACCESS_KEY"]
+        )
+      )
+    end
+end

--- a/app/jobs/post_digest/delivery_job.rb
+++ b/app/jobs/post_digest/delivery_job.rb
@@ -3,6 +3,7 @@ class PostDigest::DeliveryJob < ApplicationJob
 
   retry_on Postmark::UnexpectedHttpResponseError, wait: :polynomially_longer, attempts: 5
   retry_on Postmark::TimeoutError, wait: :polynomially_longer, attempts: 5
+  retry_on Aws::SESV2::Errors::ServiceError, wait: :polynomially_longer, attempts: 5
   retry_on Net::OpenTimeout, Net::ReadTimeout, wait: :polynomially_longer, attempts: 5
 
   def perform(post_digest_id)
@@ -10,12 +11,18 @@ class PostDigest::DeliveryJob < ApplicationJob
 
     if !Rails.env.production?
       deliver_via_mailer(digest)
+    elsif ses_enabled?(digest.blog)
+      PostDigest::SesDelivery.deliver_with_failover(digest)
     else
       PostDigest::PostmarkDelivery.new(digest).deliver_all
     end
   end
 
   private
+
+    def ses_enabled?(blog)
+      Rails.features.for(blog: blog).enabled?(:ses_newsletter_delivery)
+    end
 
     def deliver_via_mailer(digest)
       action = digest.individual? ? :individual : :weekly_digest

--- a/app/models/email/event.rb
+++ b/app/models/email/event.rb
@@ -1,0 +1,9 @@
+class Email::Event < ApplicationRecord
+  self.table_name = "email_events"
+
+  belongs_to :post_digest_delivery
+
+  validates :message_id, presence: true
+  validates :provider, presence: true, inclusion: { in: %w[ses postmark] }
+  validates :status, inclusion: { in: %w[sent delivered bounced complained] }
+end

--- a/app/models/email/suppression.rb
+++ b/app/models/email/suppression.rb
@@ -1,0 +1,23 @@
+class Email::Suppression < ApplicationRecord
+  self.table_name = "email_suppressions"
+
+  validates :email, presence: true
+  validates :reason, presence: true, inclusion: { in: %w[bounce complaint] }
+  validates :suppressed_at, presence: true
+
+  scope :bounces, -> { where(reason: "bounce") }
+  scope :complaints, -> { where(reason: "complaint") }
+
+  def self.suppressed?(email)
+    exists?(email: email.to_s.strip.downcase)
+  end
+
+  def self.suppress!(email, reason:, bounce_type: nil, diagnostic_code: nil)
+    create_or_find_by!(email: email.to_s.strip.downcase) do |suppression|
+      suppression.reason = reason
+      suppression.bounce_type = bounce_type
+      suppression.diagnostic_code = diagnostic_code
+      suppression.suppressed_at = Time.current
+    end
+  end
+end

--- a/app/models/post_digest/ses_delivery.rb
+++ b/app/models/post_digest/ses_delivery.rb
@@ -1,0 +1,101 @@
+class PostDigest::SesDelivery
+  BATCH_SIZE = 50
+  MAX_SENDS_PER_SECOND = ENV.fetch("SES_MAX_SENDS_PER_SECOND", 14).to_i
+  PRIMARY_REGION = ENV.fetch("AWS_SES_REGION", "eu-west-2")
+  FAILOVER_REGION = "eu-west-1"
+
+  class ServiceError < StandardError; end
+
+  def initialize(digest, region: PRIMARY_REGION)
+    @digest = digest
+    @client = build_client(region)
+    @sends_this_second = 0
+    @second_started_at = nil
+  end
+
+  def deliver_all
+    pending_subscribers.find_in_batches(batch_size: BATCH_SIZE) do |subscribers|
+      deliver_batch(subscribers)
+    end
+    @digest.update!(delivered_at: Time.current)
+  end
+
+  def self.deliver_with_failover(digest)
+    new(digest, region: PRIMARY_REGION).deliver_all
+  rescue Aws::SESV2::Errors::ServiceError, Seahorse::Client::NetworkingError => e
+    Rails.logger.warn "SES primary region failed (#{e.class}: #{e.message}), retrying with #{FAILOVER_REGION}"
+    new(digest, region: FAILOVER_REGION).deliver_all
+  end
+
+  private
+
+    def pending_subscribers
+      suppressed_emails = Email::Suppression.pluck(:email)
+
+      scope = @digest.blog.email_subscribers.confirmed
+        .where.not(id: @digest.deliveries.select(:email_subscriber_id))
+
+      scope = scope.where.not(email: suppressed_emails) if suppressed_emails.any?
+      scope
+    end
+
+    def deliver_batch(subscribers)
+      subscribers.each do |subscriber|
+        throttle!
+        message = build_email(subscriber)
+        send_and_record(message, subscriber)
+      end
+    end
+
+    def build_email(subscriber)
+      action = @digest.individual? ? :individual : :weekly_digest
+      message = PostDigestMailer.with(digest: @digest, subscriber: subscriber).public_send(action)
+      message.from = "#{@digest.blog.display_name} <digest@send.pagecord.com>"
+      Premailer::Rails::Hook.delivering_email(message)
+      message
+    end
+
+    def send_and_record(message, subscriber)
+      response = @client.send_email(
+        content: { raw: { data: message.to_s } },
+        from_email_address: message.from.first
+      )
+
+      delivery = @digest.deliveries.create!(email_subscriber: subscriber, delivered_at: Time.current)
+      Email::Event.create!(
+        message_id: response.message_id,
+        provider: "ses",
+        post_digest_delivery: delivery
+      )
+    rescue Aws::SESV2::Errors::MessageRejected => e
+      Rails.logger.error "SES rejected message for subscriber #{subscriber.id}: #{e.message}"
+    end
+
+    def throttle!
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      if @second_started_at.nil? || (now - @second_started_at) >= 1.0
+        @second_started_at = now
+        @sends_this_second = 0
+      end
+
+      @sends_this_second += 1
+
+      if @sends_this_second > MAX_SENDS_PER_SECOND
+        sleep_time = 1.0 - (now - @second_started_at)
+        sleep(sleep_time) if sleep_time > 0
+        @second_started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @sends_this_second = 1
+      end
+    end
+
+    def build_client(region)
+      Aws::SESV2::Client.new(
+        region: region,
+        credentials: Aws::Credentials.new(
+          ENV["AWS_SES_ACCESS_KEY_ID"],
+          ENV["AWS_SES_SECRET_ACCESS_KEY"]
+        )
+      )
+    end
+end

--- a/app/models/post_digest_delivery.rb
+++ b/app/models/post_digest_delivery.rb
@@ -1,6 +1,7 @@
 class PostDigestDelivery < ApplicationRecord
   belongs_to :post_digest
   belongs_to :email_subscriber
+  has_one :email_event, class_name: "Email::Event", dependent: :destroy
 
   validates :email_subscriber_id, uniqueness: { scope: :post_digest_id }
 end

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -9,6 +9,7 @@
         <%= link_to "Blogs", admin_blogs_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'blogs'}" %>
         <%= link_to "Posts", admin_posts_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'posts'}" %>
         <%= link_to "Moderation", admin_moderation_root_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name.in?(%w[content spam])}" %>
+        <%= link_to "Emails", admin_suppressed_emails_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'suppressed_emails'}" %>
         <%= link_to "Analytics", admin_analytics_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'analytics'}" %>
       </nav>
     </div>

--- a/app/views/admin/suppressed_emails/index.html.erb
+++ b/app/views/admin/suppressed_emails/index.html.erb
@@ -1,0 +1,75 @@
+<%= render "admin/shared/header" %>
+
+<div class="container mx-auto px-4">
+  <div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-x-auto">
+    <div class="bg-slate-50 dark:bg-slate-700/50 border-b border-slate-200 dark:border-slate-700 px-6 py-4 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <span class="text-lg font-bold text-slate-900 dark:text-slate-50"><%= @total_count %></span>
+        <span class="text-sm text-slate-500 dark:text-slate-400">suppressed <%= "email".pluralize(@total_count) %></span>
+      </div>
+    </div>
+
+    <div class="border-b border-slate-200 dark:border-slate-700 px-6 py-2 flex gap-4">
+      <%= link_to "All (#{@total_count})",
+          admin_suppressed_emails_path,
+          class: "text-sm font-medium #{params[:reason].blank? ? 'text-blue-600 dark:text-blue-400 underline' : 'text-slate-500 dark:text-slate-400 hover:underline'}" %>
+      <%= link_to "Bounces (#{@bounce_count})",
+          admin_suppressed_emails_path(reason: "bounce"),
+          class: "text-sm font-medium #{params[:reason] == 'bounce' ? 'text-blue-600 dark:text-blue-400 underline' : 'text-slate-500 dark:text-slate-400 hover:underline'}" %>
+      <%= link_to "Complaints (#{@complaint_count})",
+          admin_suppressed_emails_path(reason: "complaint"),
+          class: "text-sm font-medium #{params[:reason] == 'complaint' ? 'text-blue-600 dark:text-blue-400 underline' : 'text-slate-500 dark:text-slate-400 hover:underline'}" %>
+    </div>
+
+    <% if @suppressions.any? %>
+      <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+        <thead>
+          <tr>
+            <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Email</th>
+            <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Reason</th>
+            <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Bounce Type</th>
+            <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Diagnostic</th>
+            <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Suppressed</th>
+            <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+          <% @suppressions.each do |suppression| %>
+            <tr>
+              <td class="whitespace-nowrap py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-50">
+                <%= suppression.email %>
+              </td>
+              <td class="whitespace-nowrap py-3 px-6 text-sm">
+                <span class="px-2.5 py-1 rounded-full text-xs font-medium <%= suppression.reason == 'bounce' ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' %>">
+                  <%= suppression.reason.titleize %>
+                </span>
+              </td>
+              <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400">
+                <%= suppression.bounce_type || "—" %>
+              </td>
+              <td class="py-3 px-6 text-sm text-slate-500 dark:text-slate-400 max-w-md truncate">
+                <%= suppression.diagnostic_code.to_s.truncate(60) %>
+              </td>
+              <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400">
+                <%= suppression.suppressed_at.to_formatted_s(:short) %>
+              </td>
+              <td class="whitespace-nowrap py-3 px-6 text-end text-sm">
+                <%= button_to "Unsuppress",
+                    admin_suppressed_email_path(suppression),
+                    method: :delete,
+                    class: "btn-secondary py-1",
+                    data: { turbo_confirm: "Unsuppress #{suppression.email}?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <%= render "app/shared/pagy_nav" %>
+    <% else %>
+      <div class="px-6 py-8 text-center text-sm text-slate-500 dark:text-slate-400">
+        No suppressed emails found.
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -7,3 +7,7 @@ end
 feature :individual_email_delivery do |blog: nil|
   blog&.features.include?("individual_email_delivery")
 end
+
+feature :ses_newsletter_delivery do |blog: nil|
+  blog&.features.include?("ses_newsletter_delivery")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
     resources :blogs, only: [ :index ]
     resources :analytics, only: [ :index ]
     resources :posts, only: [ :index ]
+    resources :suppressed_emails, only: [ :index, :destroy ]
     resources :users, only: [ :show, :destroy, :new, :create, :update ] do
       member do
         post :restore

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -94,6 +94,10 @@ every 1.month, at: "2:00 am" do
   runner "SendUnengagedFollowUpEmailsJob.perform_later"
 end
 
+every 5.minutes do
+  runner "Email::ProcessBouncesJob.perform_later"
+end
+
 # every hour on a Tuesday
 every "0 * * * 2" do
   rake "post_digests:deliver"

--- a/db/migrate/20260226101545_create_email_suppressions.rb
+++ b/db/migrate/20260226101545_create_email_suppressions.rb
@@ -1,0 +1,13 @@
+class CreateEmailSuppressions < ActiveRecord::Migration[8.2]
+  def change
+    create_table :email_suppressions do |t|
+      t.string :email, null: false
+      t.string :reason, null: false
+      t.string :bounce_type
+      t.string :diagnostic_code
+      t.datetime :suppressed_at, null: false
+      t.timestamps
+    end
+    add_index :email_suppressions, :email, unique: true
+  end
+end

--- a/db/migrate/20260226101549_create_email_events.rb
+++ b/db/migrate/20260226101549_create_email_events.rb
@@ -1,0 +1,12 @@
+class CreateEmailEvents < ActiveRecord::Migration[8.2]
+  def change
+    create_table :email_events do |t|
+      t.string :message_id, null: false
+      t.string :provider, null: false
+      t.references :post_digest_delivery, null: false, foreign_key: true
+      t.string :status, default: "sent"
+      t.timestamps
+    end
+    add_index :email_events, :message_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_02_23_124623) do
+ActiveRecord::Schema[8.2].define(version: 2026_02_26_101549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -88,6 +88,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_23_124623) do
     t.boolean "allow_search_indexing", default: true, null: false
     t.string "analytics_id"
     t.string "analytics_service"
+    t.string "cloudflare_custom_hostname_id"
     t.datetime "created_at", null: false
     t.text "custom_css"
     t.string "custom_domain"
@@ -120,6 +121,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_23_124623) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.string "width", default: "standard", null: false
+    t.index ["cloudflare_custom_hostname_id"], name: "index_blogs_on_cloudflare_custom_hostname_id", unique: true, where: "(cloudflare_custom_hostname_id IS NOT NULL)"
     t.index ["custom_domain"], name: "index_blogs_on_custom_domain", unique: true, where: "(custom_domain IS NOT NULL)"
     t.index ["home_page_id"], name: "index_blogs_on_home_page_id"
     t.index ["subdomain"], name: "index_blogs_on_subdomain", unique: true
@@ -169,6 +171,17 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_23_124623) do
     t.index ["user_id"], name: "index_email_change_requests_on_user_id"
   end
 
+  create_table "email_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "message_id", null: false
+    t.bigint "post_digest_delivery_id", null: false
+    t.string "provider", null: false
+    t.string "status", default: "sent"
+    t.datetime "updated_at", null: false
+    t.index ["message_id"], name: "index_email_events_on_message_id", unique: true
+    t.index ["post_digest_delivery_id"], name: "index_email_events_on_post_digest_delivery_id"
+  end
+
   create_table "email_subscribers", force: :cascade do |t|
     t.bigint "blog_id", null: false
     t.datetime "confirmed_at"
@@ -178,6 +191,17 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_23_124623) do
     t.string "token", null: false
     t.datetime "updated_at", null: false
     t.index ["blog_id", "email"], name: "index_email_subscribers_on_blog_id_and_email", unique: true
+  end
+
+  create_table "email_suppressions", force: :cascade do |t|
+    t.string "bounce_type"
+    t.datetime "created_at", null: false
+    t.string "diagnostic_code"
+    t.string "email", null: false
+    t.string "reason", null: false
+    t.datetime "suppressed_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_email_suppressions_on_email", unique: true
   end
 
   create_table "navigation_items", force: :cascade do |t|
@@ -419,6 +443,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_02_23_124623) do
   add_foreign_key "digest_posts", "post_digests"
   add_foreign_key "digest_posts", "posts"
   add_foreign_key "email_change_requests", "users"
+  add_foreign_key "email_events", "post_digest_deliveries"
   add_foreign_key "email_subscribers", "blogs"
   add_foreign_key "navigation_items", "blogs"
   add_foreign_key "navigation_items", "posts"

--- a/docs/ses-newsletter-delivery.md
+++ b/docs/ses-newsletter-delivery.md
@@ -1,0 +1,249 @@
+# SES Newsletter Delivery
+
+Migrates outbound newsletter delivery from Postmark to Amazon SES for cost reduction (~10x cheaper at scale). Runs in parallel with Postmark during warm-up, feature-flagged per blog.
+
+**Scope:** Outbound newsletters only. Postmark stays for Action Mailbox inbound (`newsletters.pagecord.com`). MailPace stays for transactional email. SES sends from `send.pagecord.com`.
+
+## Architecture
+
+```
+Blog (feature flag: ses_newsletter_delivery)
+  │
+  ├── PostDigest::DeliveryJob
+  │     ├── PostDigest::PostmarkDelivery  (default path)
+  │     └── PostDigest::SesDelivery       (when flag enabled)
+  │           ├── Filters out Email::Suppression addresses
+  │           ├── Sends via Aws::SESV2::Client (per-message)
+  │           ├── Creates PostDigestDelivery + Email::Event records
+  │           └── Failover: eu-west-2 → eu-west-1
+  │
+  └── Email::ProcessBouncesJob (every 5 min)
+        ├── Polls SQS queue (long poll, 5s)
+        ├── Parses SNS → SES notification JSON
+        ├── Permanent bounce → Email::Suppression + update Email::Event
+        ├── Complaint → Email::Suppression + update Email::Event
+        └── Transient bounce → ignored (logged)
+```
+
+## Data Model
+
+### `email_suppressions`
+
+Prevents future sends to bounced/complained addresses. The `EmailSubscriber` record stays intact — only the suppression list blocks delivery. Admins can unsuppress to retry.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `email` | string | Downcased email address (unique index) |
+| `reason` | string | `"bounce"` or `"complaint"` |
+| `bounce_type` | string | `"Permanent"` / `"Transient"` (bounces only) |
+| `diagnostic_code` | string | Raw SMTP diagnostic from the MTA |
+| `suppressed_at` | datetime | When the suppression was recorded |
+
+### `email_events`
+
+Correlates SES message IDs back to specific deliveries for bounce processing.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `message_id` | string | SES message ID (unique index) |
+| `provider` | string | `"ses"` or `"postmark"` |
+| `post_digest_delivery_id` | reference | FK to `post_digest_deliveries` |
+| `status` | string | `"sent"`, `"delivered"`, `"bounced"`, `"complained"` |
+
+## Feature Flag
+
+The `ses_newsletter_delivery` flag is per-blog, stored in the `blogs.features` PG array column. Enable via Rails console:
+
+```ruby
+blog = Blog.find_by(subdomain: "yourblog")
+blog.update!(features: blog.features + ["ses_newsletter_delivery"])
+```
+
+When enabled, `PostDigest::DeliveryJob` routes to `PostDigest::SesDelivery` instead of `PostDigest::PostmarkDelivery`. When disabled (or absent), Postmark is used as before.
+
+## Environment Variables
+
+Set these on Hatchbox before enabling the feature flag:
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_SES_ACCESS_KEY_ID` | IAM credentials for SES/SQS/SNS |
+| `AWS_SES_SECRET_ACCESS_KEY` | IAM credentials for SES/SQS/SNS |
+| `AWS_SES_REGION` | Primary region (default: `eu-west-2`) |
+| `AWS_SES_BOUNCE_QUEUE_URL` | SQS queue URL for bounce notifications |
+| `SES_MAX_SENDS_PER_SECOND` | Rate limit safety net (default: `14`) |
+
+## Setup
+
+### 1. Provision AWS Resources
+
+```bash
+rake ses:provision
+```
+
+This creates:
+- SES domain identities in both regions (`send.pagecord.com`)
+- SNS topics for bounce/complaint notifications in both regions
+- SQS queue with DLQ in primary region
+- SNS→SQS subscriptions (including cross-region for failover)
+- SES configuration sets and event destinations
+
+The task outputs DNS records and env vars to set manually.
+
+### 2. Add DNS Records
+
+The `ses:provision` task prints the exact records. Typically:
+
+**DKIM** — 3 CNAME records (provided by SES):
+```
+<token1>._domainkey.send.pagecord.com CNAME <token1>.dkim.amazonses.com
+<token2>._domainkey.send.pagecord.com CNAME <token2>.dkim.amazonses.com
+<token3>._domainkey.send.pagecord.com CNAME <token3>.dkim.amazonses.com
+```
+
+**SPF:**
+```
+send.pagecord.com TXT "v=spf1 include:amazonses.com ~all"
+```
+
+**DMARC:**
+```
+_dmarc.send.pagecord.com TXT "v=DMARC1; p=none; rua=mailto:dmarc-reports@pagecord.com"
+```
+
+**Custom MAIL FROM:**
+```
+bounce.send.pagecord.com MX 10 feedback-smtp.eu-west-2.amazonses.com
+bounce.send.pagecord.com TXT "v=spf1 include:amazonses.com ~all"
+```
+
+### 3. Verify Setup
+
+```bash
+rake ses:status
+```
+
+Check that the domain is verified, DKIM is signing, and production access is enabled.
+
+### 4. Request Production Access
+
+SES starts in sandbox mode (can only send to verified addresses). Request production access through the AWS console on day 1.
+
+### 5. Enable on Test Blog
+
+```ruby
+blog = Blog.find_by(subdomain: "yourblog")
+blog.update!(features: blog.features + ["ses_newsletter_delivery"])
+```
+
+### 6. Gradual Rollout
+
+| Days | Blogs on SES | Notes |
+|------|-------------|-------|
+| 1-3 | Your own blog only | Verify delivery, headers, bounce simulator |
+| 4-7 | ~10% of blogs | Monitor SES dashboard bounce/complaint rates |
+| 8-10 | ~50% of blogs | |
+| 11+ | All blogs | Stable — remove Postmark path later |
+
+## Admin UI
+
+Visit `/admin/suppressed_emails` to:
+- View all suppressed emails with reason, bounce type, and diagnostic info
+- Filter by bounces or complaints
+- Unsuppress an email to allow future deliveries
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `app/models/email/suppression.rb` | Suppression list model |
+| `app/models/email/event.rb` | Per-delivery event tracking |
+| `app/models/post_digest/ses_delivery.rb` | SES delivery (mirrors PostmarkDelivery) |
+| `app/jobs/post_digest/delivery_job.rb` | Dispatch job (feature flag branch) |
+| `app/jobs/email/process_bounces_job.rb` | SQS polling for bounces/complaints |
+| `app/controllers/admin/suppressed_emails_controller.rb` | Admin suppression management |
+| `lib/tasks/ses.rake` | Provisioning and status rake tasks |
+| `config/features.rb` | Feature flag definition |
+
+## Troubleshooting
+
+### Emails not sending via SES
+
+1. **Check feature flag is enabled** for the blog:
+   ```ruby
+   blog.features.include?("ses_newsletter_delivery")
+   # => true
+   ```
+
+2. **Check env vars are set:**
+   ```ruby
+   ENV["AWS_SES_ACCESS_KEY_ID"].present?
+   ENV["AWS_SES_SECRET_ACCESS_KEY"].present?
+   ENV["AWS_SES_REGION"].present?
+   ```
+
+3. **Check SES is out of sandbox:**
+   ```bash
+   rake ses:status
+   # Look for "Production access: true"
+   ```
+
+4. **Check Sidekiq logs** for the `:newsletters` queue — look for `Aws::SESV2::Errors` messages.
+
+### Bounces not being processed
+
+1. **Check `AWS_SES_BOUNCE_QUEUE_URL` is set.** The job silently returns if this is nil.
+
+2. **Check the SQS queue has messages:**
+   ```ruby
+   sqs = Aws::SQS::Client.new(region: ENV["AWS_SES_REGION"], credentials: Aws::Credentials.new(ENV["AWS_SES_ACCESS_KEY_ID"], ENV["AWS_SES_SECRET_ACCESS_KEY"]))
+   attrs = sqs.get_queue_attributes(queue_url: ENV["AWS_SES_BOUNCE_QUEUE_URL"], attribute_names: ["ApproximateNumberOfMessages"])
+   attrs.attributes["ApproximateNumberOfMessages"]
+   ```
+
+3. **Check the SNS→SQS subscription is confirmed.** Cross-region subscriptions require confirmation — verify in the AWS console under SNS > Subscriptions.
+
+4. **Check the DLQ** (`pagecord-ses-bounces-dlq`) for messages that failed processing 5 times.
+
+5. **Check Sidekiq logs** for the `:low` queue — the job runs every 5 minutes via cron.
+
+### Subscriber still receiving emails after bounce
+
+The `Email::Suppression` record must exist with a matching (downcased) email. Check:
+
+```ruby
+Email::Suppression.suppressed?("user@example.com")
+```
+
+If `false`, the bounce may have been transient (only permanent bounces create suppressions) or the `ProcessBouncesJob` hasn't run yet.
+
+### SES region failover
+
+`PostDigest::SesDelivery.deliver_with_failover` tries `eu-west-2` first. If it gets an `Aws::SESV2::Errors::ServiceError` or `Seahorse::Client::NetworkingError`, it retries the entire delivery with `eu-west-1`. Both regions need the domain identity verified and DNS records in place (the `ses:provision` task sets up both).
+
+### Unsuppressing an email
+
+Via admin UI: `/admin/suppressed_emails` → click "Unsuppress".
+
+Via console:
+```ruby
+Email::Suppression.find_by(email: "user@example.com")&.destroy
+```
+
+This only removes the suppression — if the underlying issue isn't resolved (e.g., mailbox still doesn't exist), the address will be re-suppressed on the next bounce.
+
+### Rate limiting
+
+SES has account-level send rate limits (starts at 1/sec in sandbox, typically 14/sec in production). The `SES_MAX_SENDS_PER_SECOND` env var (default 14) throttles sends. If you see `Aws::SESV2::Errors::TooManyRequestsException`, lower this value.
+
+At current volume (<5K newsletters), rate limiting won't activate.
+
+### Testing with SES simulator addresses
+
+SES provides simulator addresses that don't affect your bounce/complaint rates:
+
+- `success@simulator.amazonses.com` — successful delivery
+- `bounce@simulator.amazonses.com` — hard bounce
+- `complaint@simulator.amazonses.com` — complaint
+
+Use these during the warm-up phase to verify the full pipeline without affecting real addresses.

--- a/lib/tasks/ses.rake
+++ b/lib/tasks/ses.rake
@@ -1,0 +1,226 @@
+namespace :ses do
+  desc "Provision SES, SNS, and SQS resources for email delivery"
+  task provision: :environment do
+    primary_region = ENV.fetch("AWS_SES_REGION", "eu-west-2")
+    failover_region = "eu-west-1"
+    domain = "send.pagecord.com"
+    mail_from_subdomain = "bounce"
+    credentials = Aws::Credentials.new(
+      ENV.fetch("AWS_SES_ACCESS_KEY_ID"),
+      ENV.fetch("AWS_SES_SECRET_ACCESS_KEY")
+    )
+
+    ses_primary = Aws::SESV2::Client.new(region: primary_region, credentials: credentials)
+    ses_failover = Aws::SESV2::Client.new(region: failover_region, credentials: credentials)
+    sns_primary = Aws::SNS::Client.new(region: primary_region, credentials: credentials)
+    sns_failover = Aws::SNS::Client.new(region: failover_region, credentials: credentials)
+    sqs_client = Aws::SQS::Client.new(region: primary_region, credentials: credentials)
+
+    puts "=== Step 1: Verify domain identity in #{primary_region} ==="
+    begin
+      ses_primary.create_email_identity(email_identity: domain)
+      puts "  Created email identity for #{domain}"
+    rescue Aws::SESV2::Errors::AlreadyExistsException
+      puts "  Email identity already exists for #{domain}"
+    end
+
+    puts "\n=== Step 2: Verify domain identity in #{failover_region} ==="
+    begin
+      ses_failover.create_email_identity(email_identity: domain)
+      puts "  Created email identity for #{domain} in #{failover_region}"
+    rescue Aws::SESV2::Errors::AlreadyExistsException
+      puts "  Email identity already exists for #{domain} in #{failover_region}"
+    end
+
+    puts "\n=== Step 3: Configure MAIL FROM domain ==="
+    [ ses_primary, ses_failover ].each_with_index do |ses, i|
+      region = i == 0 ? primary_region : failover_region
+      begin
+        ses.put_email_identity_mail_from_attributes(
+          email_identity: domain,
+          mail_from_domain: "#{mail_from_subdomain}.#{domain}"
+        )
+        puts "  Configured MAIL FROM #{mail_from_subdomain}.#{domain} in #{region}"
+      rescue => e
+        puts "  Warning: Could not set MAIL FROM in #{region}: #{e.message}"
+      end
+    end
+
+    puts "\n=== Step 4: Create SNS topic in #{primary_region} ==="
+    primary_topic = sns_primary.create_topic(name: "pagecord-ses-notifications")
+    primary_topic_arn = primary_topic.topic_arn
+    puts "  Topic ARN: #{primary_topic_arn}"
+
+    puts "\n=== Step 5: Configure SES event destination in #{primary_region} ==="
+    begin
+      ses_primary.create_configuration_set(configuration_set_name: "pagecord-newsletters")
+      puts "  Created configuration set: pagecord-newsletters"
+    rescue Aws::SESV2::Errors::AlreadyExistsException
+      puts "  Configuration set already exists"
+    end
+
+    begin
+      ses_primary.create_configuration_set_event_destination(
+        configuration_set_name: "pagecord-newsletters",
+        event_destination_name: "bounces-and-complaints",
+        event_destination: {
+          enabled: true,
+          matching_event_types: %w[BOUNCE COMPLAINT],
+          sns_destination: { topic_arn: primary_topic_arn }
+        }
+      )
+      puts "  Created event destination for bounces and complaints"
+    rescue Aws::SESV2::Errors::AlreadyExistsException
+      puts "  Event destination already exists"
+    end
+
+    puts "\n=== Step 6: Create SQS queue with DLQ in #{primary_region} ==="
+    dlq = sqs_client.create_queue(queue_name: "pagecord-ses-bounces-dlq")
+    dlq_url = dlq.queue_url
+    dlq_attrs = sqs_client.get_queue_attributes(queue_url: dlq_url, attribute_names: [ "QueueArn" ])
+    dlq_arn = dlq_attrs.attributes["QueueArn"]
+    puts "  DLQ URL: #{dlq_url}"
+
+    redrive_policy = { deadLetterTargetArn: dlq_arn, maxReceiveCount: 5 }.to_json
+    queue = sqs_client.create_queue(
+      queue_name: "pagecord-ses-bounces",
+      attributes: { "RedrivePolicy" => redrive_policy }
+    )
+    queue_url = queue.queue_url
+    queue_attrs = sqs_client.get_queue_attributes(queue_url: queue_url, attribute_names: [ "QueueArn" ])
+    queue_arn = queue_attrs.attributes["QueueArn"]
+    puts "  Queue URL: #{queue_url}"
+
+    # Allow SNS to send messages to SQS
+    policy = {
+      Version: "2012-10-17",
+      Statement: [ {
+        Effect: "Allow",
+        Principal: { Service: "sns.amazonaws.com" },
+        Action: "sqs:SendMessage",
+        Resource: queue_arn,
+        Condition: { ArnLike: { "aws:SourceArn" => "arn:aws:sns:*:*:pagecord-ses-notifications" } }
+      } ]
+    }.to_json
+    sqs_client.set_queue_attributes(queue_url: queue_url, attributes: { "Policy" => policy })
+    puts "  Set SQS policy to allow SNS"
+
+    puts "\n=== Step 7: Subscribe SQS queue to primary SNS topic ==="
+    sns_primary.subscribe(
+      topic_arn: primary_topic_arn,
+      protocol: "sqs",
+      endpoint: queue_arn
+    )
+    puts "  Subscribed SQS to primary SNS topic"
+
+    puts "\n=== Step 8: Create SNS topic in #{failover_region} ==="
+    failover_topic = sns_failover.create_topic(name: "pagecord-ses-notifications")
+    failover_topic_arn = failover_topic.topic_arn
+    puts "  Topic ARN: #{failover_topic_arn}"
+
+    puts "\n=== Step 9: Configure SES event destination in #{failover_region} ==="
+    begin
+      ses_failover.create_configuration_set(configuration_set_name: "pagecord-newsletters")
+      puts "  Created configuration set in #{failover_region}"
+    rescue Aws::SESV2::Errors::AlreadyExistsException
+      puts "  Configuration set already exists in #{failover_region}"
+    end
+
+    begin
+      ses_failover.create_configuration_set_event_destination(
+        configuration_set_name: "pagecord-newsletters",
+        event_destination_name: "bounces-and-complaints",
+        event_destination: {
+          enabled: true,
+          matching_event_types: %w[BOUNCE COMPLAINT],
+          sns_destination: { topic_arn: failover_topic_arn }
+        }
+      )
+      puts "  Created event destination in #{failover_region}"
+    rescue Aws::SESV2::Errors::AlreadyExistsException
+      puts "  Event destination already exists in #{failover_region}"
+    end
+
+    puts "\n=== Step 10: Subscribe primary SQS to failover SNS topic (cross-region) ==="
+    sns_failover.subscribe(
+      topic_arn: failover_topic_arn,
+      protocol: "sqs",
+      endpoint: queue_arn
+    )
+    puts "  Subscribed primary SQS to failover SNS topic"
+
+    # Get DKIM tokens
+    puts "\n=== DNS Records Required ==="
+    identity = ses_primary.get_email_identity(email_identity: domain)
+    dkim_tokens = identity.dkim_attributes.tokens
+
+    puts "\nDKIM (3 CNAME records):"
+    dkim_tokens.each do |token|
+      puts "  #{token}._domainkey.#{domain} CNAME #{token}.dkim.amazonses.com"
+    end
+
+    puts "\nSPF:"
+    puts "  #{domain} TXT \"v=spf1 include:amazonses.com ~all\""
+
+    puts "\nDMARC:"
+    puts "  _dmarc.#{domain} TXT \"v=DMARC1; p=none; rua=mailto:dmarc-reports@pagecord.com\""
+
+    puts "\nCustom MAIL FROM:"
+    puts "  #{mail_from_subdomain}.#{domain} MX 10 feedback-smtp.#{primary_region}.amazonses.com"
+    puts "  #{mail_from_subdomain}.#{domain} TXT \"v=spf1 include:amazonses.com ~all\""
+
+    puts "\n=== Environment Variables ==="
+    puts "AWS_SES_ACCESS_KEY_ID=<already set>"
+    puts "AWS_SES_SECRET_ACCESS_KEY=<already set>"
+    puts "AWS_SES_REGION=#{primary_region}"
+    puts "AWS_SES_BOUNCE_QUEUE_URL=#{queue_url}"
+    puts "SES_MAX_SENDS_PER_SECOND=14"
+
+    puts "\nDone! Add the DNS records above and set the environment variables."
+  end
+
+  desc "Check SES domain verification and sending status"
+  task status: :environment do
+    region = ENV.fetch("AWS_SES_REGION", "eu-west-2")
+    domain = "send.pagecord.com"
+    credentials = Aws::Credentials.new(
+      ENV.fetch("AWS_SES_ACCESS_KEY_ID"),
+      ENV.fetch("AWS_SES_SECRET_ACCESS_KEY")
+    )
+
+    ses = Aws::SESV2::Client.new(region: region, credentials: credentials)
+
+    puts "=== SES Status for #{domain} (#{region}) ==="
+
+    begin
+      identity = ses.get_email_identity(email_identity: domain)
+      puts "  Verified: #{identity.verified_for_sending_status}"
+      puts "  DKIM status: #{identity.dkim_attributes.status}"
+      puts "  DKIM signing: #{identity.dkim_attributes.signing_enabled}"
+
+      if identity.mail_from_attributes
+        puts "  MAIL FROM domain: #{identity.mail_from_attributes.mail_from_domain}"
+        puts "  MAIL FROM status: #{identity.mail_from_attributes.mail_from_domain_status}"
+      end
+    rescue Aws::SESV2::Errors::NotFoundException
+      puts "  Domain identity not found. Run `rake ses:provision` first."
+      next
+    end
+
+    puts "\n=== Account Sending Status ==="
+    account = ses.get_account
+    puts "  Production access: #{!account.production_access_enabled.nil? && account.production_access_enabled}"
+    puts "  Sending enabled: #{account.send_quota.nil? ? 'unknown' : 'yes'}"
+
+    if account.send_quota
+      puts "  Max send rate: #{account.send_quota.max_send_rate}/sec"
+      puts "  Max 24hr send: #{account.send_quota.max_24_hour_send}"
+      puts "  Sent last 24hr: #{account.send_quota.sent_last_24_hours}"
+    end
+
+    puts "\n=== Suppression Stats ==="
+    puts "  Total suppressions: #{Email::Suppression.count}"
+    puts "  Bounces: #{Email::Suppression.bounces.count}"
+    puts "  Complaints: #{Email::Suppression.complaints.count}"
+  end
+end

--- a/test/controllers/admin/suppressed_emails_controller_test.rb
+++ b/test/controllers/admin/suppressed_emails_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Admin::SuppressedEmailsControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  setup do
+    @admin_user = users(:joel)
+    login_as @admin_user
+  end
+
+  test "should get index" do
+    get admin_suppressed_emails_url
+    assert_response :success
+    assert_select "table"
+  end
+
+  test "should filter by bounce reason" do
+    get admin_suppressed_emails_url(reason: "bounce")
+    assert_response :success
+    assert_includes @response.body, "bounced@example.com"
+    assert_not_includes @response.body, "complained@example.com"
+  end
+
+  test "should filter by complaint reason" do
+    get admin_suppressed_emails_url(reason: "complaint")
+    assert_response :success
+    assert_includes @response.body, "complained@example.com"
+    assert_not_includes @response.body, "bounced@example.com"
+  end
+
+  test "should destroy suppression" do
+    suppression = email_suppressions(:bounced)
+
+    assert_difference "Email::Suppression.count", -1 do
+      delete admin_suppressed_email_url(suppression)
+    end
+
+    assert_redirected_to admin_suppressed_emails_path
+  end
+
+  test "should require admin access" do
+    non_admin = users(:vivian)
+    login_as non_admin
+
+    get admin_suppressed_emails_url
+    assert_redirected_to root_path
+  end
+end

--- a/test/fixtures/email_events.yml
+++ b/test/fixtures/email_events.yml
@@ -1,0 +1,1 @@
+# empty — email events are created dynamically in tests

--- a/test/fixtures/email_suppressions.yml
+++ b/test/fixtures/email_suppressions.yml
@@ -1,0 +1,15 @@
+bounced:
+  email: bounced@example.com
+  reason: bounce
+  bounce_type: Permanent
+  diagnostic_code: "smtp;550 5.1.1 The email account does not exist"
+  suppressed_at: <%= 1.day.ago %>
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+
+complained:
+  email: complained@example.com
+  reason: complaint
+  suppressed_at: <%= 2.days.ago %>
+  created_at: <%= 2.days.ago %>
+  updated_at: <%= 2.days.ago %>

--- a/test/jobs/email/process_bounces_job_test.rb
+++ b/test/jobs/email/process_bounces_job_test.rb
@@ -1,0 +1,132 @@
+require "test_helper"
+require "mocha/minitest"
+
+class Email::ProcessBouncesJobTest < ActiveJob::TestCase
+  setup do
+    @delivery = post_digest_deliveries(:one)
+    @event = Email::Event.create!(
+      message_id: "ses-test-msg-001",
+      provider: "ses",
+      post_digest_delivery: @delivery
+    )
+
+    @mock_sqs = mock("sqs_client")
+    Aws::SQS::Client.stubs(:new).returns(@mock_sqs)
+
+    stub_const(Email::ProcessBouncesJob, :QUEUE_URL, "https://sqs.eu-west-2.amazonaws.com/123/test-queue")
+  end
+
+  test "processes permanent bounce and creates suppression" do
+    bounce_notification = build_sqs_message(
+      notificationType: "Bounce",
+      bounce: {
+        bounceType: "Permanent",
+        bouncedRecipients: [
+          { emailAddress: "bounced-new@example.com", diagnosticCode: "smtp;550 User unknown" }
+        ]
+      },
+      mail: { messageId: "ses-test-msg-001" }
+    )
+
+    expect_receive_then_empty(bounce_notification)
+    @mock_sqs.expects(:delete_message).once
+
+    assert_difference "Email::Suppression.count", 1 do
+      Email::ProcessBouncesJob.perform_now
+    end
+
+    suppression = Email::Suppression.find_by(email: "bounced-new@example.com")
+    assert_equal "bounce", suppression.reason
+    assert_equal "Permanent", suppression.bounce_type
+    assert_equal "smtp;550 User unknown", suppression.diagnostic_code
+    assert_equal "bounced", @event.reload.status
+  end
+
+  test "processes complaint and creates suppression" do
+    complaint_notification = build_sqs_message(
+      notificationType: "Complaint",
+      complaint: {
+        complainedRecipients: [
+          { emailAddress: "complainer@example.com" }
+        ]
+      },
+      mail: { messageId: "ses-test-msg-001" }
+    )
+
+    expect_receive_then_empty(complaint_notification)
+    @mock_sqs.expects(:delete_message).once
+
+    assert_difference "Email::Suppression.count", 1 do
+      Email::ProcessBouncesJob.perform_now
+    end
+
+    suppression = Email::Suppression.find_by(email: "complainer@example.com")
+    assert_equal "complaint", suppression.reason
+    assert_equal "complained", @event.reload.status
+  end
+
+  test "ignores transient bounces" do
+    transient_notification = build_sqs_message(
+      notificationType: "Bounce",
+      bounce: {
+        bounceType: "Transient",
+        bouncedRecipients: [
+          { emailAddress: "transient@example.com" }
+        ]
+      },
+      mail: { messageId: "ses-test-msg-001" }
+    )
+
+    expect_receive_then_empty(transient_notification)
+    @mock_sqs.expects(:delete_message).once
+
+    assert_no_difference "Email::Suppression.count" do
+      Email::ProcessBouncesJob.perform_now
+    end
+  end
+
+  test "skips when queue URL is not configured" do
+    stub_const(Email::ProcessBouncesJob, :QUEUE_URL, nil)
+    # Should not call SQS at all
+    Aws::SQS::Client.expects(:new).never
+    Email::ProcessBouncesJob.perform_now
+  end
+
+  test "handles malformed JSON gracefully" do
+    bad_message = OpenStruct.new(
+      body: "not valid json",
+      receipt_handle: "receipt-123"
+    )
+
+    response_with_messages = OpenStruct.new(messages: [ bad_message ])
+    empty_response = OpenStruct.new(messages: [])
+
+    @mock_sqs.expects(:receive_message).twice.returns(response_with_messages, empty_response)
+    @mock_sqs.expects(:delete_message).once
+
+    assert_nothing_raised do
+      Email::ProcessBouncesJob.perform_now
+    end
+  end
+
+  private
+
+    def build_sqs_message(**notification)
+      sns_body = { "Message" => notification.deep_stringify_keys.to_json }
+      OpenStruct.new(
+        body: sns_body.to_json,
+        receipt_handle: "receipt-#{SecureRandom.hex(4)}"
+      )
+    end
+
+    def expect_receive_then_empty(message)
+      response_with_messages = OpenStruct.new(messages: [ message ])
+      empty_response = OpenStruct.new(messages: [])
+      @mock_sqs.expects(:receive_message).twice.returns(response_with_messages, empty_response)
+    end
+
+    def stub_const(klass, const_name, value)
+      klass.send(:remove_const, const_name) if klass.const_defined?(const_name)
+      klass.const_set(const_name, value)
+    end
+end

--- a/test/models/email/event_test.rb
+++ b/test/models/email/event_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class Email::EventTest < ActiveSupport::TestCase
+  setup do
+    @delivery = post_digest_deliveries(:one)
+  end
+
+  test "belongs to post_digest_delivery" do
+    event = Email::Event.create!(
+      message_id: "ses-abc123",
+      provider: "ses",
+      post_digest_delivery: @delivery
+    )
+    assert_equal @delivery, event.post_digest_delivery
+  end
+
+  test "validates provider inclusion" do
+    event = Email::Event.new(
+      message_id: "ses-abc123",
+      provider: "invalid",
+      post_digest_delivery: @delivery
+    )
+    refute event.valid?
+    assert event.errors[:provider].present?
+  end
+
+  test "validates status inclusion" do
+    event = Email::Event.new(
+      message_id: "ses-abc123",
+      provider: "ses",
+      post_digest_delivery: @delivery,
+      status: "invalid"
+    )
+    refute event.valid?
+    assert event.errors[:status].present?
+  end
+
+  test "validates message_id presence" do
+    event = Email::Event.new(
+      message_id: nil,
+      provider: "ses",
+      post_digest_delivery: @delivery
+    )
+    refute event.valid?
+    assert event.errors[:message_id].present?
+  end
+
+  test "default status is sent" do
+    event = Email::Event.create!(
+      message_id: "ses-def456",
+      provider: "ses",
+      post_digest_delivery: @delivery
+    )
+    assert_equal "sent", event.status
+  end
+end

--- a/test/models/email/suppression_test.rb
+++ b/test/models/email/suppression_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Email::SuppressionTest < ActiveSupport::TestCase
+  test "suppressed? returns true for existing suppression" do
+    assert Email::Suppression.suppressed?("bounced@example.com")
+  end
+
+  test "suppressed? returns false for unknown email" do
+    refute Email::Suppression.suppressed?("clean@example.com")
+  end
+
+  test "suppressed? is case-insensitive and strips whitespace" do
+    assert Email::Suppression.suppressed?("  BOUNCED@example.com  ")
+  end
+
+  test "suppress! creates a new suppression" do
+    assert_difference "Email::Suppression.count", 1 do
+      Email::Suppression.suppress!("new-bounce@example.com", reason: "bounce", bounce_type: "Permanent")
+    end
+
+    suppression = Email::Suppression.last
+    assert_equal "new-bounce@example.com", suppression.email
+    assert_equal "bounce", suppression.reason
+    assert_equal "Permanent", suppression.bounce_type
+    assert suppression.suppressed_at.present?
+  end
+
+  test "suppress! is idempotent for same email" do
+    assert_no_difference "Email::Suppression.count" do
+      Email::Suppression.suppress!("bounced@example.com", reason: "complaint")
+    end
+  end
+
+  test "suppress! downcases email" do
+    suppression = Email::Suppression.suppress!("UPPER@EXAMPLE.COM", reason: "bounce")
+    assert_equal "upper@example.com", suppression.email
+  end
+
+  test "bounces scope returns only bounces" do
+    bounces = Email::Suppression.bounces
+    assert bounces.all? { |s| s.reason == "bounce" }
+    assert bounces.exists?(email: "bounced@example.com")
+    refute bounces.exists?(email: "complained@example.com")
+  end
+
+  test "complaints scope returns only complaints" do
+    complaints = Email::Suppression.complaints
+    assert complaints.all? { |s| s.reason == "complaint" }
+    assert complaints.exists?(email: "complained@example.com")
+    refute complaints.exists?(email: "bounced@example.com")
+  end
+
+  test "validates reason inclusion" do
+    suppression = Email::Suppression.new(email: "test@example.com", reason: "invalid", suppressed_at: Time.current)
+    refute suppression.valid?
+    assert suppression.errors[:reason].present?
+  end
+end

--- a/test/models/post_digest/ses_delivery_test.rb
+++ b/test/models/post_digest/ses_delivery_test.rb
@@ -1,0 +1,122 @@
+require "test_helper"
+require "mocha/minitest"
+
+class PostDigest::SesDeliveryTest < ActiveSupport::TestCase
+  setup do
+    @blog = blogs(:joel)
+    @subscriber = email_subscribers(:one)
+    @post = @blog.posts.create!(title: "SES Test Post", content: "Content")
+    @digest = PostDigest.generate_weekly_digest_for(@blog)
+
+    @mock_client = mock("ses_client")
+    Aws::SESV2::Client.stubs(:new).returns(@mock_client)
+  end
+
+  test "BATCH_SIZE is 50" do
+    assert_equal 50, PostDigest::SesDelivery::BATCH_SIZE
+  end
+
+  test "deliver_all creates delivery and event records" do
+    @mock_client.expects(:send_email).returns(
+      OpenStruct.new(message_id: "ses-msg-001")
+    )
+
+    delivery = PostDigest::SesDelivery.new(@digest)
+
+    assert_difference [ "PostDigestDelivery.count", "Email::Event.count" ], 1 do
+      delivery.deliver_all
+    end
+
+    assert @digest.deliveries.exists?(email_subscriber: @subscriber)
+    assert @digest.reload.delivered_at?
+
+    event = Email::Event.last
+    assert_equal "ses-msg-001", event.message_id
+    assert_equal "ses", event.provider
+    assert_equal "sent", event.status
+  end
+
+  test "deliver_all skips suppressed emails" do
+    Email::Suppression.suppress!(@subscriber.email, reason: "bounce", bounce_type: "Permanent")
+
+    delivery = PostDigest::SesDelivery.new(@digest)
+
+    assert_no_difference [ "PostDigestDelivery.count", "Email::Event.count" ] do
+      delivery.deliver_all
+    end
+
+    assert @digest.reload.delivered_at?
+  end
+
+  test "deliver_all skips already-delivered subscribers" do
+    @digest.deliveries.create!(email_subscriber: @subscriber, delivered_at: Time.current)
+
+    delivery = PostDigest::SesDelivery.new(@digest)
+
+    assert_no_difference "PostDigestDelivery.count" do
+      delivery.deliver_all
+    end
+
+    assert @digest.reload.delivered_at?
+  end
+
+  test "deliver_all handles rejected messages gracefully" do
+    @mock_client.expects(:send_email).raises(
+      Aws::SESV2::Errors::MessageRejected.new(nil, "Email address is on the suppression list")
+    )
+
+    delivery = PostDigest::SesDelivery.new(@digest)
+
+    assert_no_difference [ "PostDigestDelivery.count", "Email::Event.count" ] do
+      delivery.deliver_all
+    end
+
+    assert @digest.reload.delivered_at?
+  end
+
+  test "deliver_all uses individual mailer action for individual digests" do
+    digest = PostDigest.create!(blog: @blog, kind: :individual)
+    digest.digest_posts.create!(post: @post)
+
+    @mock_client.expects(:send_email).returns(
+      OpenStruct.new(message_id: "ses-msg-002")
+    )
+
+    assert_difference "PostDigestDelivery.count", 1 do
+      PostDigest::SesDelivery.new(digest).deliver_all
+    end
+
+    assert digest.reload.delivered_at?
+  end
+
+  test "deliver_all uses send.pagecord.com as sender domain" do
+    captured_args = nil
+    @mock_client.expects(:send_email).with { |args|
+      captured_args = args
+      true
+    }.returns(OpenStruct.new(message_id: "ses-msg-003"))
+
+    PostDigest::SesDelivery.new(@digest).deliver_all
+
+    assert_match /send\.pagecord\.com/, captured_args[:from_email_address]
+  end
+
+  test "deliver_with_failover retries on service error" do
+    primary_client = mock("primary_ses_client")
+    failover_client = mock("failover_ses_client")
+
+    Aws::SESV2::Client.stubs(:new).with(has_entry(region: "eu-west-2")).returns(primary_client)
+    Aws::SESV2::Client.stubs(:new).with(has_entry(region: "eu-west-1")).returns(failover_client)
+
+    primary_client.expects(:send_email).raises(
+      Aws::SESV2::Errors::ServiceUnavailableException.new(nil, "Service unavailable")
+    )
+    failover_client.expects(:send_email).returns(
+      OpenStruct.new(message_id: "ses-failover-001")
+    )
+
+    assert_difference "PostDigestDelivery.count", 1 do
+      PostDigest::SesDelivery.deliver_with_failover(@digest)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ module ActiveSupport
     parallelize(workers: :number_of_processors)
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+    set_fixture_class email_suppressions: Email::Suppression, email_events: Email::Event
     fixtures :all
 
     # Ensure consistent locale for all tests


### PR DESCRIPTION
> **Experimental — do not merge until warm-up is complete.**

## Summary

- Migrates outbound newsletter delivery from Postmark to Amazon SES (~10x cost reduction)
- Feature-flagged per blog (`ses_newsletter_delivery`) — Postmark remains the default path
- SES sends from `send.pagecord.com` (separate domain from Postmark's `newsletters.pagecord.com`)
- Bounce/complaint handling via SQS polling creates `Email::Suppression` records that block future sends
- `EmailSubscriber` records stay intact — only the suppression list prevents delivery
- Admin UI at `/admin/suppressed_emails` for viewing and unsuppressing emails
- Region failover: `eu-west-2` → `eu-west-1`
- Provisioning rake task (`ses:provision`) automates full AWS setup

## What's new

| Area | Files |
|------|-------|
| Models | `Email::Suppression`, `Email::Event` |
| Delivery | `PostDigest::SesDelivery` (mirrors `PostmarkDelivery`) |
| Bounce processing | `Email::ProcessBouncesJob` (SQS polling, every 5 min) |
| Admin UI | `/admin/suppressed_emails` — list, filter, unsuppress |
| Rake tasks | `ses:provision`, `ses:status` |
| Feature flag | `ses_newsletter_delivery` in `config/features.rb` |
| Docs | `docs/ses-newsletter-delivery.md` |

## What's unchanged

- Postmark stays for Action Mailbox inbound (post-by-email, digest replies)
- MailPace stays for transactional email
- Mailer rendering pipeline (`PostDigestMailer` + Premailer) is reused as-is
- `PostDigest::PostmarkDelivery` is untouched and remains the default

## Rollout plan

Deploys inactive — no blogs have the feature flag. Gradual enablement:

1. Own blog only (days 1-3, verify delivery + bounce simulator)
2. ~10% of blogs (days 4-7, monitor SES dashboard)
3. ~50% of blogs (days 8-10)
4. All blogs (day 11+, then remove Postmark path)

## Test plan

- [x] All 1185 existing tests pass (0 failures, 0 errors)
- [x] 32 new tests across models, jobs, and controllers
- [ ] Run `ses:provision` and add DNS records
- [ ] Send to `success@simulator.amazonses.com` — verify delivery + event records
- [ ] Send to `bounce@simulator.amazonses.com` — verify suppression created
- [ ] Send to `complaint@simulator.amazonses.com` — verify complaint suppression
- [ ] Verify suppressed addresses are skipped on next digest
- [ ] Admin UI: filter tabs, unsuppress flow
- [ ] Check headers via mail-tester.com (DKIM, SPF, DMARC on `send.pagecord.com`)