### PR TITLE
Add per-post Open Graph image control

### DIFF
--- a/app/assets/tailwind/components.css
+++ b/app/assets/tailwind/components.css
@@ -71,4 +71,5 @@
     @apply !text-current !underline !decoration-pagecord-accent !decoration-2 !font-medium hover:!bg-pagecord-accent/10 !transition-all !duration-200 !rounded;
   }
 
+
 }

--- a/app/controllers/app/home_pages_controller.rb
+++ b/app/controllers/app/home_pages_controller.rb
@@ -47,9 +47,8 @@ class App::HomePagesController < AppController
 
     def home_page_params
       status = params[:button] == "save_draft" ? :draft : :published
-
-      params.require(:post).permit(:title, :content, :slug).merge(
-          is_page: true, status: status, is_home_page: true
-        )
+      permitted = [ :title, :content, :slug ]
+      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access?
+      params.require(:post).permit(*permitted).merge(is_page: true, status: status, is_home_page: true)
     end
 end

--- a/app/controllers/app/pages_controller.rb
+++ b/app/controllers/app/pages_controller.rb
@@ -73,7 +73,8 @@ class App::PagesController < AppController
 
     def page_params
       status = params[:button] == "save_draft" ? :draft : :published
-
-      params.require(:post).permit(:title, :content, :slug).merge(is_page: true, status: status)
+      permitted = [ :title, :content, :slug ]
+      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access?
+      params.require(:post).permit(*permitted).merge(is_page: true, status: status)
     end
 end

--- a/app/controllers/app/posts/open_graph_images_controller.rb
+++ b/app/controllers/app/posts/open_graph_images_controller.rb
@@ -3,9 +3,19 @@ class App::Posts::OpenGraphImagesController < AppController
   before_action :require_premium
 
   def destroy
-    post = Current.user.blog.posts.kept.find_by!(token: params[:post_token])
+    token = params[:post_token] || params[:page_token]
+    post = token ? Current.user.blog.all_posts.kept.find_by!(token: token) : Current.user.blog.home_page
     post.open_graph_image.purge
-    redirect_to edit_app_post_path(post), notice: "Open Graph image removed"
+
+    path = if post.home_page?
+      edit_app_home_page_path
+    elsif post.page?
+      edit_app_page_path(post)
+    else
+      edit_app_post_path(post)
+    end
+
+    redirect_to path, notice: "Open Graph image removed"
   end
 
   private

--- a/app/controllers/app/posts/open_graph_images_controller.rb
+++ b/app/controllers/app/posts/open_graph_images_controller.rb
@@ -3,11 +3,10 @@ class App::Posts::OpenGraphImagesController < AppController
   before_action :require_premium
 
   def destroy
-    token = params[:post_token] || params[:page_token]
-    post = token ? Current.user.blog.all_posts.kept.find_by!(token: token) : Current.user.blog.home_page
+    post = Current.user.blog.all_posts.kept.find_by!(token: params[:post_token])
     post.open_graph_image.purge
 
-    path = if post.home_page?
+    redirect_path = if post.home_page?
       edit_app_home_page_path
     elsif post.page?
       edit_app_page_path(post)
@@ -15,7 +14,7 @@ class App::Posts::OpenGraphImagesController < AppController
       edit_app_post_path(post)
     end
 
-    redirect_to path, notice: "Open Graph image removed"
+    redirect_to redirect_path, notice: "Open Graph image removed"
   end
 
   private

--- a/app/controllers/app/posts/open_graph_images_controller.rb
+++ b/app/controllers/app/posts/open_graph_images_controller.rb
@@ -1,0 +1,20 @@
+class App::Posts::OpenGraphImagesController < AppController
+  before_action :require_feature
+  before_action :require_premium
+
+  def destroy
+    post = Current.user.blog.posts.kept.find_by!(token: params[:post_token])
+    post.open_graph_image.purge
+    redirect_to edit_app_post_path(post), notice: "Open Graph image removed"
+  end
+
+  private
+
+    def require_feature
+      render_app_not_found unless current_features.enabled?(:open_graph_image)
+    end
+
+    def require_premium
+      render_app_not_found unless Current.user.has_premium_access?
+    end
+end

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -81,7 +81,7 @@ class App::PostsController < AppController
     def post_params
       status = params[:button] == "save_draft" ? :draft : :published
 
-      params.require(:post).permit(:title, :content, :slug, :published_at, :canonical_url, :tags_string, :hidden, :locale).merge(status: status)
+      params.require(:post).permit(:title, :content, :slug, :published_at, :canonical_url, :tags_string, :hidden, :locale, :open_graph_image, :open_graph_image_suppressed).merge(status: status)
     end
 
     def redirect_to_first_page

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -80,8 +80,9 @@ class App::PostsController < AppController
 
     def post_params
       status = params[:button] == "save_draft" ? :draft : :published
-
-      params.require(:post).permit(:title, :content, :slug, :published_at, :canonical_url, :tags_string, :hidden, :locale, :open_graph_image, :open_graph_image_suppressed).merge(status: status)
+      permitted = [ :title, :content, :slug, :published_at, :canonical_url, :tags_string, :hidden, :locale ]
+      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access?
+      params.require(:post).permit(*permitted).merge(status: status)
     end
 
     def redirect_to_first_page

--- a/app/helpers/open_graph_helper.rb
+++ b/app/helpers/open_graph_helper.rb
@@ -4,7 +4,10 @@ module OpenGraphHelper
   end
 
   def open_graph_image
-    if @post && @post.first_image.present?
+    return dynamic_og_image_for_post(@post) if @post&.open_graph_image_suppressed?
+    if @post&.open_graph_image&.attached?
+      resized_image_url @post.open_graph_image, width: 1200, height: 630, crop: true
+    elsif @post&.first_image.present?
       resized_image_url @post.first_image, width: 1200, height: 630, crop: true
     elsif @post
       dynamic_og_image_for_post(@post)

--- a/app/javascript/controllers/open_graph_controller.js
+++ b/app/javascript/controllers/open_graph_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "preview", "uploadArea"]
+
+  open(event) {
+    event.preventDefault()
+    this.inputTarget.click()
+  }
+
+  handleFileSelect(event) {
+    const file = event.target.files[0]
+    if (!file) return
+
+    const allowedTypes = ["image/jpeg", "image/png", "image/webp"]
+    if (!allowedTypes.includes(file.type)) {
+      alert("Please select a JPEG, PNG, or WebP image.")
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      this.previewTarget.src = e.target.result
+      this.previewTarget.classList.remove("hidden")
+      if (this.hasUploadAreaTarget) this.uploadAreaTarget.classList.add("hidden")
+    }
+    reader.readAsDataURL(file)
+  }
+}

--- a/app/javascript/controllers/open_graph_controller.js
+++ b/app/javascript/controllers/open_graph_controller.js
@@ -8,15 +8,37 @@ export default class extends Controller {
     this.inputTarget.click()
   }
 
+  dragover(event) {
+    event.preventDefault()
+    if (this.hasUploadAreaTarget) this.uploadAreaTarget.dataset.dragover = true
+  }
+
+  dragleave() {
+    if (this.hasUploadAreaTarget) delete this.uploadAreaTarget.dataset.dragover
+  }
+
+  drop(event) {
+    event.preventDefault()
+    this.dragleave()
+    const file = event.dataTransfer.files[0]
+    if (file) this.#handleFile(file)
+  }
+
   handleFileSelect(event) {
     const file = event.target.files[0]
-    if (!file) return
+    if (file) this.#handleFile(file)
+  }
 
+  #handleFile(file) {
     const allowedTypes = ["image/jpeg", "image/png", "image/webp"]
     if (!allowedTypes.includes(file.type)) {
       alert("Please select a JPEG, PNG, or WebP image.")
       return
     }
+
+    const dt = new DataTransfer()
+    dt.items.add(file)
+    this.inputTarget.files = dt.files
 
     const reader = new FileReader()
     reader.onload = (e) => {

--- a/app/javascript/controllers/post_attributes_controller.js
+++ b/app/javascript/controllers/post_attributes_controller.js
@@ -79,7 +79,8 @@ export default class extends Controller {
         "t": "tags",
         "p": "published-at",
         "c": "canonical-url",
-        "l": "locale"
+        "l": "locale",
+        "g": "og-image"
       }
 
       const sectionId = shortcuts[event.key.toLowerCase()]

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,6 +10,7 @@ class Post < ApplicationRecord
 
   has_rich_text :content
   has_many_attached :attachments, dependent: :destroy
+  has_one_attached :open_graph_image
 
   has_many :digest_posts, dependent: :destroy
   has_many :post_digests, through: :digest_posts

--- a/app/views/app/home_pages/_form.html.erb
+++ b/app/views/app/home_pages/_form.html.erb
@@ -27,7 +27,7 @@
   <%= form_with(model: home_page, url: home_page.persisted? ? app_home_page_path : app_home_page_path, method: home_page.persisted? ? :patch : :post, html: { id: "homepage-form" }) do |form| %>
     <%= hidden_field_tag :context_blog_id, Current.user.blog.id unless home_page.persisted? %>
 
-    <%= render "app/posts/open_graph_image_section", record: home_page, form: form, delete_path: app_home_page_open_graph_image_path if home_page.persisted? %>
+    <%= render "app/posts/open_graph_image_section", record: home_page, form: form %>
 
     <%= form.text_field :title,
           placeholder: "Home page title (optional)",

--- a/app/views/app/home_pages/_form.html.erb
+++ b/app/views/app/home_pages/_form.html.erb
@@ -3,8 +3,31 @@
 
   <div class="mb-4"><%= trial_callout("Image uploads") %></div>
 
+  <% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+  <div class="flex justify-end mb-4" data-controller="toggle">
+    <%= link_to "#", class: "ms-3 font-medium text-slate-500 hover:text-black dark:text-slate-300 dark:hover:text-slate-50", data: { action: "click->toggle#toggle click@window->toggle#hide" } do %>
+      <%= inline_svg_tag "icons/ellipsis-horizontal-circle.svg", class: "w-7 h-7" %>
+    <% end %>
+    <div class="relative hidden" data-toggle-target="element">
+      <div class="absolute end-0 w-56 rounded-md border border-gray-100 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-lg z-100" role="menu">
+        <div class="py-2 px-1">
+          <div class="p-1">
+            <%= link_to "#", class: "flex justify-between items-center rounded-lg px-2 py-1 text-sm text-gray-500 dark:text-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-50",
+              data: { action: "click->post-attributes#toggle", toggle_target: "og-image" } do %>
+              <span class="ms-1">Open Graph Image</span>
+              <span class="hidden md:inline text-xs text-gray-400 dark:text-gray-500">G</span>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <% end %>
+
   <%= form_with(model: home_page, url: home_page.persisted? ? app_home_page_path : app_home_page_path, method: home_page.persisted? ? :patch : :post, html: { id: "homepage-form" }) do |form| %>
     <%= hidden_field_tag :context_blog_id, Current.user.blog.id unless home_page.persisted? %>
+
+    <%= render "app/posts/open_graph_image_section", record: home_page, form: form, delete_path: app_home_page_open_graph_image_path if home_page.persisted? %>
 
     <%= form.text_field :title,
           placeholder: "Home page title (optional)",

--- a/app/views/app/pages/_form.html.erb
+++ b/app/views/app/pages/_form.html.erb
@@ -58,7 +58,7 @@
   <%= form_with(model: @page, url: @page.persisted? ? app_page_path(@page) : app_pages_path, html: { id: "page-form" }) do |form| %>
     <%= hidden_field_tag :context_blog_id, Current.user.blog.id if is_new %>
 
-    <%= render "app/posts/open_graph_image_section", record: @page, form: form, delete_path: app_page_open_graph_image_path(@page) if @page.persisted? %>
+    <%= render "app/posts/open_graph_image_section", record: @page, form: form %>
 
     <div class="<%= 'hidden' unless @page.errors[:slug].any? %> mb-8" data-post-attributes-target="section" data-section="slug">
       <div class="mt-4 font-bold">

--- a/app/views/app/pages/_form.html.erb
+++ b/app/views/app/pages/_form.html.erb
@@ -23,6 +23,16 @@
               <% end %>
             </div>
 
+            <% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+              <div class="p-1">
+                <%= link_to "#", class: "flex justify-between items-center rounded-lg px-2 py-1 text-sm text-gray-500 dark:text-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-50",
+                  data: { action: "click->post-attributes#toggle", toggle_target: "og-image" } do %>
+                  <span class="ms-1">Open Graph Image</span>
+                  <span class="hidden md:inline text-xs text-gray-400 dark:text-gray-500">G</span>
+                <% end %>
+              </div>
+            <% end %>
+
             <% if @page.persisted? %>
               <hr class="mx-2 mt-2 dark:border-gray-600">
 
@@ -47,6 +57,8 @@
 
   <%= form_with(model: @page, url: @page.persisted? ? app_page_path(@page) : app_pages_path, html: { id: "page-form" }) do |form| %>
     <%= hidden_field_tag :context_blog_id, Current.user.blog.id if is_new %>
+
+    <%= render "app/posts/open_graph_image_section", record: @page, form: form, delete_path: app_page_open_graph_image_path(@page) if @page.persisted? %>
 
     <div class="<%= 'hidden' unless @page.errors[:slug].any? %> mb-8" data-post-attributes-target="section" data-section="slug">
       <div class="mt-4 font-bold">

--- a/app/views/app/posts/_drop_down_menu.html.erb
+++ b/app/views/app/posts/_drop_down_menu.html.erb
@@ -50,6 +50,16 @@
         <% end %>
       </div>
 
+      <% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+        <div class="p-1">
+          <%= link_to "#", class: "flex justify-between items-center rounded-lg px-2 py-1 text-sm text-gray-500 dark:text-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-50",
+            data: { action: "click->post-attributes#toggle", toggle_target: "og-image" } do %>
+            <span class="ms-1">Open Graph Image</span>
+            <span class="hidden md:inline text-xs text-gray-400 dark:text-gray-500">G</span>
+          <% end %>
+        </div>
+      <% end %>
+
       <% if @post.persisted? %>
         <hr class="mx-2 mt-2 dark:border-gray-600">
 

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -67,7 +67,7 @@
           <%= form.check_box :hidden, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" %>
         </div>
         <div>
-          <%= form.label :hidden, "Hide this post on my blog", class: "text-slate-800 dark:text-slate-100" %>
+          <%= form.label :hidden, "Hide this post on my blog", class: "text-sm text-slate-800 dark:text-slate-100" %>
           <p class="text-slate-500 text-sm">
             When checked, this post will not be visible on your blog, but it can accessed via it's link.
           </p>
@@ -92,6 +92,61 @@
         </div>
       </div>
     </div>
+
+    <% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+    <div class="<%= 'hidden' unless @post.open_graph_image.attached? || @post.open_graph_image_suppressed? %> mb-8" data-post-attributes-target="section" data-section="og-image">
+      <div class="mt-4 font-bold">Open Graph Image</div>
+
+      <% if @post.open_graph_image.attached? %>
+        <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Click the image to select a new one, or click 'Remove' to delete it.
+        </p>
+        <div class="mt-4" data-controller="open-graph">
+          <a href="#" data-action="click->open-graph#open" class="inline-block">
+            <img src="<%= url_for(@post.open_graph_image) %>"
+                 class="max-w-xs rounded border border-slate-200 dark:border-slate-700 hover:opacity-80 transition-opacity"
+                 data-open-graph-target="preview" alt="Open Graph image">
+          </a>
+          <%= form.file_field :open_graph_image, accept: "image/jpeg, image/png, image/webp",
+                class: "hidden",
+                data: { open_graph_target: "input", action: "input->open-graph#handleFileSelect" } %>
+        </div>
+        <%= link_to app_post_open_graph_image_path(@post), title: "Remove custom Open Graph image", data: { turbo_method: :delete }, class: "flex items-center text-sm text-slate-500 hover:text-slate-800 dark:text-slate-400 hover:dark:text-slate-200 mt-1" do %>
+          <%= inline_svg_tag "icons/trash.svg", class: "w-4 h-4 me-1" %>
+          Remove
+        <% end %>
+      <% else %>
+        <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          By default, the first image in your post is used. Click to upload a custom image.
+        </p>
+        <div class="mt-3" data-controller="open-graph">
+          <img src="" class="hidden max-w-xs rounded border border-slate-200 dark:border-slate-700" data-open-graph-target="preview" alt="Open Graph image preview">
+          <a href="#" data-action="click->open-graph#open" data-open-graph-target="uploadArea"
+             class="flex items-center justify-center w-full max-w-xs aspect-video py-6 rounded border-2 border-dashed border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500 transition-colors bg-slate-50 dark:bg-slate-800">
+            <div class="flex flex-col items-center gap-1 text-slate-400 dark:text-slate-500">
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              <span class="text-xs">Click to upload</span>
+            </div>
+          </a>
+          <%= form.file_field :open_graph_image, accept: "image/jpeg, image/png, image/webp",
+                class: "hidden",
+                data: { open_graph_target: "input", action: "input->open-graph#handleFileSelect" } %>
+        </div>
+      <% end %>
+
+      <div class="mt-4 flex gap-3 items-start">
+        <div class="flex h-6 shrink-0 items-center">
+          <%= form.check_box :open_graph_image_suppressed, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" %>
+        </div>
+        <div>
+          <%= form.label :open_graph_image_suppressed, "Use text-based card only", class: "text-sm text-slate-800 dark:text-slate-100" %>
+          <p class="text-slate-500 text-sm">Skip images — use the branded text card for social sharing.</p>
+        </div>
+      </div>
+    </div>
+    <% end %>
 
     <div class="<%= 'hidden' unless @post.locale.present? %> mb-8" data-post-attributes-target="section" data-section="locale">
       <div class="mt-4 font-bold">

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -64,7 +64,7 @@
 
       <div class="mt-4 flex gap-3">
         <div class="flex h-6 shrink-0 items-center">
-          <%= form.check_box :hidden, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" %>
+          <%= form.check_box :hidden, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0" %>
         </div>
         <div>
           <%= form.label :hidden, "Hide this post on my blog", class: "text-sm text-slate-800 dark:text-slate-100" %>

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -93,7 +93,7 @@
       </div>
     </div>
 
-    <%= render "app/posts/open_graph_image_section", record: @post, form: form, delete_path: app_post_open_graph_image_path(@post) if @post.persisted? %>
+    <%= render "app/posts/open_graph_image_section", record: @post, form: form %>
 
     <div class="<%= 'hidden' unless @post.locale.present? %> mb-8" data-post-attributes-target="section" data-section="locale">
       <div class="mt-4 font-bold">

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -93,60 +93,7 @@
       </div>
     </div>
 
-    <% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
-    <div class="<%= 'hidden' unless @post.open_graph_image.attached? || @post.open_graph_image_suppressed? %> mb-8" data-post-attributes-target="section" data-section="og-image">
-      <div class="mt-4 font-bold">Open Graph Image</div>
-
-      <% if @post.open_graph_image.attached? %>
-        <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
-          Click the image to select a new one, or click 'Remove' to delete it.
-        </p>
-        <div class="mt-4" data-controller="open-graph">
-          <a href="#" data-action="click->open-graph#open" class="inline-block">
-            <img src="<%= url_for(@post.open_graph_image) %>"
-                 class="max-w-xs rounded border border-slate-200 dark:border-slate-700 hover:opacity-80 transition-opacity"
-                 data-open-graph-target="preview" alt="Open Graph image">
-          </a>
-          <%= form.file_field :open_graph_image, accept: "image/jpeg, image/png, image/webp",
-                class: "hidden",
-                data: { open_graph_target: "input", action: "input->open-graph#handleFileSelect" } %>
-        </div>
-        <%= link_to app_post_open_graph_image_path(@post), title: "Remove custom Open Graph image", data: { turbo_method: :delete }, class: "flex items-center text-sm text-slate-500 hover:text-slate-800 dark:text-slate-400 hover:dark:text-slate-200 mt-1" do %>
-          <%= inline_svg_tag "icons/trash.svg", class: "w-4 h-4 me-1" %>
-          Remove
-        <% end %>
-      <% else %>
-        <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
-          By default, the first image in your post is used. Click to upload a custom image.
-        </p>
-        <div class="mt-3" data-controller="open-graph">
-          <img src="" class="hidden max-w-xs rounded border border-slate-200 dark:border-slate-700" data-open-graph-target="preview" alt="Open Graph image preview">
-          <a href="#" data-action="click->open-graph#open" data-open-graph-target="uploadArea"
-             class="flex items-center justify-center w-full max-w-xs aspect-video py-6 rounded border-2 border-dashed border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500 transition-colors bg-slate-50 dark:bg-slate-800">
-            <div class="flex flex-col items-center gap-1 text-slate-400 dark:text-slate-500">
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-              <span class="text-xs">Click to upload</span>
-            </div>
-          </a>
-          <%= form.file_field :open_graph_image, accept: "image/jpeg, image/png, image/webp",
-                class: "hidden",
-                data: { open_graph_target: "input", action: "input->open-graph#handleFileSelect" } %>
-        </div>
-      <% end %>
-
-      <div class="mt-4 flex gap-3 items-start">
-        <div class="flex h-6 shrink-0 items-center">
-          <%= form.check_box :open_graph_image_suppressed, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" %>
-        </div>
-        <div>
-          <%= form.label :open_graph_image_suppressed, "Use text-based card only", class: "text-sm text-slate-800 dark:text-slate-100" %>
-          <p class="text-slate-500 text-sm">Skip images — use the branded text card for social sharing.</p>
-        </div>
-      </div>
-    </div>
-    <% end %>
+    <%= render "app/posts/open_graph_image_section", record: @post, form: form, delete_path: app_post_open_graph_image_path(@post) if @post.persisted? %>
 
     <div class="<%= 'hidden' unless @post.locale.present? %> mb-8" data-post-attributes-target="section" data-section="locale">
       <div class="mt-4 font-bold">

--- a/app/views/app/posts/_open_graph_image_section.html.erb
+++ b/app/views/app/posts/_open_graph_image_section.html.erb
@@ -16,7 +16,7 @@
             class: "hidden",
             data: { open_graph_target: "input", action: "input->open-graph#handleFileSelect" } %>
     </div>
-    <%= link_to delete_path, title: "Remove custom Open Graph image", data: { turbo_method: :delete }, class: "flex items-center text-sm text-slate-500 hover:text-slate-800 dark:text-slate-400 hover:dark:text-slate-200 mt-1" do %>
+    <%= link_to app_post_open_graph_image_path(record), title: "Remove custom Open Graph image", data: { turbo_method: :delete }, class: "flex items-center text-sm text-slate-500 hover:text-slate-800 dark:text-slate-400 hover:dark:text-slate-200 mt-1" do %>
       <%= inline_svg_tag "icons/trash.svg", class: "w-4 h-4 me-1" %>
       Remove
     <% end %>

--- a/app/views/app/posts/_open_graph_image_section.html.erb
+++ b/app/views/app/posts/_open_graph_image_section.html.erb
@@ -26,8 +26,8 @@
     </p>
     <div class="mt-3" data-controller="open-graph">
       <img src="" class="hidden max-w-xs rounded border border-slate-200 dark:border-slate-700" data-open-graph-target="preview" alt="Open Graph image preview">
-      <a href="#" data-action="click->open-graph#open" data-open-graph-target="uploadArea"
-         class="flex items-center justify-center w-full max-w-xs aspect-video py-6 rounded border-2 border-dashed border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500 transition-colors bg-slate-50 dark:bg-slate-800">
+      <a href="#" data-action="click->open-graph#open dragover->open-graph#dragover dragleave->open-graph#dragleave drop->open-graph#drop" data-open-graph-target="uploadArea"
+         class="flex items-center justify-center w-full max-w-xs aspect-video py-6 rounded border-2 border-dashed border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500 transition-colors bg-slate-50 dark:bg-slate-800 data-[dragover]:border-slate-500 data-[dragover]:bg-slate-100 dark:data-[dragover]:border-slate-400 dark:data-[dragover]:bg-slate-700">
         <div class="flex flex-col items-center gap-1 text-slate-400 dark:text-slate-500">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -43,7 +43,7 @@
 
   <div class="mt-4 flex gap-3 items-start">
     <div class="flex h-6 shrink-0 items-center">
-      <%= form.check_box :open_graph_image_suppressed, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" %>
+      <%= form.check_box :open_graph_image_suppressed, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0" %>
     </div>
     <div>
       <%= form.label :open_graph_image_suppressed, "Use text-based card only", class: "text-sm text-slate-800 dark:text-slate-100" %>

--- a/app/views/app/posts/_open_graph_image_section.html.erb
+++ b/app/views/app/posts/_open_graph_image_section.html.erb
@@ -1,0 +1,54 @@
+<% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+<div class="<%= 'hidden' unless record.open_graph_image.attached? || record.open_graph_image_suppressed? %> mb-8" data-post-attributes-target="section" data-section="og-image">
+  <div class="mt-4 font-bold">Open Graph Image</div>
+
+  <% if record.open_graph_image.attached? %>
+    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+      Click the image to select a new one, or click 'Remove' to delete it.
+    </p>
+    <div class="mt-4" data-controller="open-graph">
+      <a href="#" data-action="click->open-graph#open" class="inline-block">
+        <img src="<%= url_for(record.open_graph_image) %>"
+             class="max-w-xs rounded border border-slate-200 dark:border-slate-700 hover:opacity-80 transition-opacity"
+             data-open-graph-target="preview" alt="Open Graph image">
+      </a>
+      <%= form.file_field :open_graph_image, accept: "image/jpeg, image/png, image/webp",
+            class: "hidden",
+            data: { open_graph_target: "input", action: "input->open-graph#handleFileSelect" } %>
+    </div>
+    <%= link_to delete_path, title: "Remove custom Open Graph image", data: { turbo_method: :delete }, class: "flex items-center text-sm text-slate-500 hover:text-slate-800 dark:text-slate-400 hover:dark:text-slate-200 mt-1" do %>
+      <%= inline_svg_tag "icons/trash.svg", class: "w-4 h-4 me-1" %>
+      Remove
+    <% end %>
+  <% else %>
+    <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+      Upload a custom image to use instead, then click <%= publish_button_text(record) %>.
+    </p>
+    <div class="mt-3" data-controller="open-graph">
+      <img src="" class="hidden max-w-xs rounded border border-slate-200 dark:border-slate-700" data-open-graph-target="preview" alt="Open Graph image preview">
+      <a href="#" data-action="click->open-graph#open" data-open-graph-target="uploadArea"
+         class="flex items-center justify-center w-full max-w-xs aspect-video py-6 rounded border-2 border-dashed border-slate-300 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500 transition-colors bg-slate-50 dark:bg-slate-800">
+        <div class="flex flex-col items-center gap-1 text-slate-400 dark:text-slate-500">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          <span class="text-xs">Click to upload</span>
+        </div>
+      </a>
+      <%= form.file_field :open_graph_image, accept: "image/jpeg, image/png, image/webp",
+            class: "hidden",
+            data: { open_graph_target: "input", action: "input->open-graph#handleFileSelect" } %>
+    </div>
+  <% end %>
+
+  <div class="mt-4 flex gap-3 items-start">
+    <div class="flex h-6 shrink-0 items-center">
+      <%= form.check_box :open_graph_image_suppressed, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" %>
+    </div>
+    <div>
+      <%= form.label :open_graph_image_suppressed, "Use text-based card only", class: "text-sm text-slate-800 dark:text-slate-100" %>
+      <p class="text-slate-500 text-sm">Skip images — use the branded text card for social sharing.</p>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/app/views/app/settings/appearance/_form.html.erb
+++ b/app/views/app/settings/appearance/_form.html.erb
@@ -80,7 +80,7 @@
         data: { controller: "checkbox-auto-submit" } do |form| %>
     <div class="flex gap-3 <%= 'opacity-50' if branding_disabled %>">
       <div class="flex h-6 shrink-0 items-center">
-        <%= form.check_box :show_branding, { checked: @blog.show_branding, disabled: branding_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded #{branding_disabled ? 'cursor-not-allowed' : 'focus:ring focus:ring-slate-300'}" } %>
+        <%= form.check_box :show_branding, { checked: @blog.show_branding, disabled: branding_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded #{branding_disabled ? 'cursor-not-allowed' : 'focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0'}" } %>
       </div>
       <div>
         <%= form.label :show_branding, "Show Pagecord branding", class: "text-slate-800 dark:text-slate-100" %>

--- a/app/views/app/settings/audience/index.html.erb
+++ b/app/views/app/settings/audience/index.html.erb
@@ -27,7 +27,7 @@
   <div data-controller="subscription-settings" class="mt-8">
     <div class="flex gap-3 <%= 'opacity-50' if email_disabled %>">
       <div class="flex h-6 shrink-0 items-center">
-        <%= form.check_box :email_subscriptions_enabled, { checked: @blog.email_subscriptions_enabled, disabled: email_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300 disabled:cursor-not-allowed", data: { subscription_settings_target: "primary", action: "change->subscription-settings#toggleDependents" } } %>
+        <%= form.check_box :email_subscriptions_enabled, { checked: @blog.email_subscriptions_enabled, disabled: email_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0 disabled:cursor-not-allowed", data: { subscription_settings_target: "primary", action: "change->subscription-settings#toggleDependents" } } %>
       </div>
       <div>
         <%= form.label :email_subscriptions_enabled, "Email subscriptions enabled", class: "text-slate-800 dark:text-slate-100" %>
@@ -55,7 +55,7 @@
 
       <div class="flex gap-3" data-subscription-settings-target="dependent">
         <div class="flex h-6 shrink-0 items-center">
-          <%= form.check_box :show_subscription_in_header, { checked: @blog.show_subscription_in_header, disabled: email_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300 disabled:opacity-50 disabled:cursor-not-allowed", data: { subscription_settings_target: "dependent" } } %>
+          <%= form.check_box :show_subscription_in_header, { checked: @blog.show_subscription_in_header, disabled: email_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0 disabled:opacity-50 disabled:cursor-not-allowed", data: { subscription_settings_target: "dependent" } } %>
         </div>
         <div>
           <%= form.label :show_subscription_in_header, "Show subscription form in blog header", class: "text-slate-800 dark:text-slate-100" %>
@@ -67,7 +67,7 @@
 
       <div class="mt-4 flex gap-3" data-subscription-settings-target="dependent">
         <div class="flex h-6 shrink-0 items-center">
-          <%= form.check_box :show_subscription_in_footer, { checked: @blog.show_subscription_in_footer, disabled: email_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300 disabled:opacity-50 disabled:cursor-not-allowed", data: { subscription_settings_target: "dependent" } } %>
+          <%= form.check_box :show_subscription_in_footer, { checked: @blog.show_subscription_in_footer, disabled: email_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0 disabled:opacity-50 disabled:cursor-not-allowed", data: { subscription_settings_target: "dependent" } } %>
         </div>
         <div>
           <%= form.label :show_subscription_in_footer, "Show subscription form in post footer", class: "text-slate-800 dark:text-slate-100" %>
@@ -82,7 +82,7 @@
   <div class="mt-6">
     <div class="flex gap-3 <%= 'opacity-50' if features_disabled %>">
       <div class="flex h-6 shrink-0 items-center">
-        <%= form.check_box :reply_by_email, { checked: @blog.reply_by_email, disabled: features_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300 disabled:cursor-not-allowed" } %>
+        <%= form.check_box :reply_by_email, { checked: @blog.reply_by_email, disabled: features_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0 disabled:cursor-not-allowed" } %>
       </div>
       <div>
         <%= form.label :reply_by_email, "Allow replies by email", class: "text-slate-800 dark:text-slate-100" %>
@@ -96,7 +96,7 @@
   <div class="mt-6">
     <div class="flex gap-3 <%= 'opacity-50' if features_disabled %>">
       <div class="flex h-6 shrink-0 items-center">
-        <%= form.check_box :show_upvotes, { checked: @blog.show_upvotes, disabled: features_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300 disabled:cursor-not-allowed" } %>
+        <%= form.check_box :show_upvotes, { checked: @blog.show_upvotes, disabled: features_disabled, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0 disabled:cursor-not-allowed" } %>
       </div>
       <div>
         <%= form.label :show_upvotes, "Show Post Likes ❤️", class: "text-slate-800 dark:text-slate-100" %>

--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -61,7 +61,7 @@
     <div class="mt-6">
       <div class="flex gap-3">
         <div class="flex h-6 shrink-0 items-center">
-          <%= form.check_box :allow_search_indexing, { checked: @blog.allow_search_indexing, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 rounded focus:ring focus:ring-slate-300" } %>
+          <%= form.check_box :allow_search_indexing, { checked: @blog.allow_search_indexing, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0" } %>
         </div>
         <div>
           <%= form.label :allow_search_indexing, "Allow search engines to index my blog", class: "text-slate-800 dark:text-slate-100" %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,9 +1,5 @@
 env "FEATURE"
 
-feature :analytics_countries do |blog: nil|
-  blog&.features.include?("analytics_countries")
-end
-
 feature :open_graph_image do |blog: nil|
   blog&.features.include?("open_graph_image")
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -3,3 +3,7 @@ env "FEATURE"
 feature :analytics_countries do |blog: nil|
   blog&.features.include?("analytics_countries")
 end
+
+feature :open_graph_image do |blog: nil|
+  blog&.features.include?("open_graph_image")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       resource :broadcast, only: [ :create ], controller: "posts/broadcasts" do
         post :test
       end
+      resource :open_graph_image, only: [ :destroy ], controller: "posts/open_graph_images"
     end
 
     namespace :pages do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,11 +109,8 @@ Rails.application.routes.draw do
       member do
         post :set_as_home_page
       end
-      resource :open_graph_image, only: [ :destroy ], controller: "posts/open_graph_images"
     end
-    resource :home_page, only: [ :new, :create, :edit, :update, :destroy ] do
-      resource :open_graph_image, only: [ :destroy ], controller: "posts/open_graph_images"
-    end
+    resource :home_page, only: [ :new, :create, :edit, :update, :destroy ]
     resources :settings, only: [ :index ]
 
     resource :onboarding, only: [ :show, :update ], path: "onboarding" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,8 +109,11 @@ Rails.application.routes.draw do
       member do
         post :set_as_home_page
       end
+      resource :open_graph_image, only: [ :destroy ], controller: "posts/open_graph_images"
     end
-    resource :home_page, only: [ :new, :create, :edit, :update, :destroy ]
+    resource :home_page, only: [ :new, :create, :edit, :update, :destroy ] do
+      resource :open_graph_image, only: [ :destroy ], controller: "posts/open_graph_images"
+    end
     resources :settings, only: [ :index ]
 
     resource :onboarding, only: [ :show, :update ], path: "onboarding" do

--- a/db/migrate/20260416114406_add_open_graph_image_suppressed_to_posts.rb
+++ b/db/migrate/20260416114406_add_open_graph_image_suppressed_to_posts.rb
@@ -1,0 +1,5 @@
+class AddOpenGraphImageSuppressedToPosts < ActiveRecord::Migration[8.2]
+  def change
+    add_column :posts, :open_graph_image_suppressed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_03_18_172003) do
+ActiveRecord::Schema[8.2].define(version: 2026_04_16_114406) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -293,9 +293,11 @@ ActiveRecord::Schema[8.2].define(version: 2026_03_18_172003) do
     t.string "canonical_url"
     t.datetime "created_at", null: false
     t.datetime "discarded_at"
+    t.text "excerpt"
     t.boolean "hidden", default: false, null: false
     t.boolean "is_page", default: false, null: false
     t.string "locale"
+    t.boolean "open_graph_image_suppressed", default: false, null: false
     t.datetime "published_at"
     t.string "slug"
     t.integer "source", default: 0, null: false

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -114,16 +114,6 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_empty user.blog.reload.features
   end
 
-  test "should render features section on show page" do
-    user = users(:vivian)
-
-    get admin_user_url(user)
-
-    assert_response :success
-    assert_select "h3", text: "Features"
-    assert_select "input[type=checkbox][value=analytics_countries]"
-  end
-
   test "should update user trial_ends_at" do
     user = users(:vivian)
     new_trial_date = 30.days.from_now.to_date

--- a/test/controllers/app/home_pages_controller_test.rb
+++ b/test/controllers/app/home_pages_controller_test.rb
@@ -147,4 +147,29 @@ class App::HomePagesControllerTest < ActionDispatch::IntegrationTest
     assert_nil @blog.reload.home_page_id
     assert_equal "Contact", page.reload.title
   end
+
+  test "should update home page with open graph image" do
+    user = users(:annie)
+    user.blog.update!(features: [ "open_graph_image" ])
+    login_as user
+    home_page = user.blog.home_page
+    image = fixture_file_upload("avatar.png", "image/png")
+
+    patch app_home_page_url, params: { post: { open_graph_image: image } }
+
+    assert_redirected_to app_pages_path
+    assert home_page.reload.open_graph_image.attached?
+  end
+
+  test "should update home page with open_graph_image_suppressed" do
+    user = users(:annie)
+    user.blog.update!(features: [ "open_graph_image" ])
+    login_as user
+    home_page = user.blog.home_page
+
+    patch app_home_page_url, params: { post: { open_graph_image_suppressed: true } }
+
+    assert_redirected_to app_pages_path
+    assert home_page.reload.open_graph_image_suppressed?
+  end
 end

--- a/test/controllers/app/pages_controller_test.rb
+++ b/test/controllers/app/pages_controller_test.rb
@@ -209,6 +209,25 @@ class App::PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Home page set!", flash[:notice]
   end
 
+  test "should update page with open graph image" do
+    @blog.update!(features: [ "open_graph_image" ])
+    image = fixture_file_upload("avatar.png", "image/png")
+
+    patch app_page_path(@page), params: { post: { open_graph_image: image } }
+
+    assert_redirected_to app_pages_path
+    assert @page.reload.open_graph_image.attached?
+  end
+
+  test "should update page with open_graph_image_suppressed" do
+    @blog.update!(features: [ "open_graph_image" ])
+
+    patch app_page_path(@page), params: { post: { open_graph_image_suppressed: true } }
+
+    assert_redirected_to app_pages_path
+    assert @page.reload.open_graph_image_suppressed?
+  end
+
   test "should preview draft page with blog layout" do
     get app_post_path(@draft_page)
 

--- a/test/controllers/app/posts/open_graph_images_controller_test.rb
+++ b/test/controllers/app/posts/open_graph_images_controller_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class App::Posts::OpenGraphImagesControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  setup do
+    @user = users(:joel)
+    @post = posts(:one)
+    @user.blog.update!(features: [ "open_graph_image" ])
+    login_as @user
+  end
+
+  test "should destroy open graph image and redirect with notice" do
+    @post.open_graph_image.attach(
+      io: File.open(Rails.root.join("test", "fixtures", "files", "avatar.png")),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+
+    assert @post.open_graph_image.attached?
+
+    delete app_post_open_graph_image_path(@post)
+
+    assert_redirected_to edit_app_post_path(@post)
+    assert_equal "Open Graph image removed", flash[:notice]
+    assert_not @post.reload.open_graph_image.attached?
+  end
+
+  test "should not destroy open graph image belonging to another user" do
+    other_post = posts(:three)
+    other_post.open_graph_image.attach(
+      io: File.open(Rails.root.join("test", "fixtures", "files", "avatar.png")),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+
+    delete app_post_open_graph_image_path(other_post)
+
+    assert_response :not_found
+    assert other_post.reload.open_graph_image.attached?
+  end
+end

--- a/test/controllers/app/posts/open_graph_images_controller_test.rb
+++ b/test/controllers/app/posts/open_graph_images_controller_test.rb
@@ -39,4 +39,37 @@ class App::Posts::OpenGraphImagesControllerTest < ActionDispatch::IntegrationTes
     assert_response :not_found
     assert other_post.reload.open_graph_image.attached?
   end
+
+  test "should destroy open graph image on a page and redirect to page edit" do
+    page = posts(:about)
+    page.open_graph_image.attach(
+      io: File.open(Rails.root.join("test", "fixtures", "files", "avatar.png")),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+
+    delete app_post_open_graph_image_path(page)
+
+    assert_redirected_to edit_app_page_path(page)
+    assert_equal "Open Graph image removed", flash[:notice]
+    assert_not page.reload.open_graph_image.attached?
+  end
+
+  test "should destroy open graph image on home page and redirect to home page edit" do
+    annie = users(:annie)
+    annie.blog.update!(features: [ "open_graph_image" ])
+    login_as annie
+    home_page = posts(:annie_home_page)
+    home_page.open_graph_image.attach(
+      io: File.open(Rails.root.join("test", "fixtures", "files", "avatar.png")),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+
+    delete app_post_open_graph_image_path(home_page)
+
+    assert_redirected_to edit_app_home_page_path
+    assert_equal "Open Graph image removed", flash[:notice]
+    assert_not home_page.reload.open_graph_image.attached?
+  end
 end

--- a/test/controllers/app/posts_controller_test.rb
+++ b/test/controllers/app/posts_controller_test.rb
@@ -165,7 +165,10 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update post with open graph image" do
-    post = @user.blog.posts.first
+    user = users(:joel)
+    user.blog.update!(features: [ "open_graph_image" ])
+    login_as user
+    post = user.blog.posts.first
     image = fixture_file_upload("avatar.png", "image/png")
 
     patch app_post_url(post), params: { post: { title: post.title, content: post.content.to_s, open_graph_image: image } }
@@ -175,7 +178,10 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update post with open_graph_image_suppressed" do
-    post = @user.blog.posts.first
+    user = users(:joel)
+    user.blog.update!(features: [ "open_graph_image" ])
+    login_as user
+    post = user.blog.posts.first
 
     patch app_post_url(post), params: { post: { title: post.title, content: post.content.to_s, open_graph_image_suppressed: true } }
 

--- a/test/controllers/app/posts_controller_test.rb
+++ b/test/controllers/app/posts_controller_test.rb
@@ -171,7 +171,7 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
     post = user.blog.posts.first
     image = fixture_file_upload("avatar.png", "image/png")
 
-    patch app_post_url(post), params: { post: { title: post.title, content: post.content.to_s, open_graph_image: image } }
+    patch app_post_url(post), params: { post: { open_graph_image: image } }
 
     assert_redirected_to app_posts_url
     assert post.reload.open_graph_image.attached?
@@ -183,7 +183,7 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
     login_as user
     post = user.blog.posts.first
 
-    patch app_post_url(post), params: { post: { title: post.title, content: post.content.to_s, open_graph_image_suppressed: true } }
+    patch app_post_url(post), params: { post: { open_graph_image_suppressed: true } }
 
     assert_redirected_to app_posts_url
     assert post.reload.open_graph_image_suppressed?

--- a/test/controllers/app/posts_controller_test.rb
+++ b/test/controllers/app/posts_controller_test.rb
@@ -164,6 +164,25 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "https://example.com", @user.blog.posts.first.canonical_url
   end
 
+  test "should update post with open graph image" do
+    post = @user.blog.posts.first
+    image = fixture_file_upload("avatar.png", "image/png")
+
+    patch app_post_url(post), params: { post: { title: post.title, content: post.content.to_s, open_graph_image: image } }
+
+    assert_redirected_to app_posts_url
+    assert post.reload.open_graph_image.attached?
+  end
+
+  test "should update post with open_graph_image_suppressed" do
+    post = @user.blog.posts.first
+
+    patch app_post_url(post), params: { post: { title: post.title, content: post.content.to_s, open_graph_image_suppressed: true } }
+
+    assert_redirected_to app_posts_url
+    assert post.reload.open_graph_image_suppressed?
+  end
+
   test "should update post and preserve page via session" do
     get edit_app_post_url(@user.blog.posts.first, page: 3)
 

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -194,3 +194,8 @@ embeds:
     <h3>Strava</h3>
     <p><a href="https://www.strava.com/activities/2307958367">https://www.strava.com/activities/2307958367</a></p>
 
+
+annie_home_page:
+  record: annie_home_page (Post)
+  name: content
+  body: <p>Welcome to my blog.</p>

--- a/test/fixtures/blogs.yml
+++ b/test/fixtures/blogs.yml
@@ -31,6 +31,7 @@ annie:
   delivery_email: annie_asj232j@post.pagecord.com
   custom_domain: annie.blog
   reply_by_email: true
+  home_page: annie_home_page
   <<: *default
 
 saul:

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -150,3 +150,12 @@ joel_spanish:
   <<: *default
 
 
+
+annie_home_page:
+  title: Welcome
+  blog: annie
+  published_at: <%= 1.day.ago %>
+  token: <%= SecureRandom.hex(4) %>
+  slug: home
+  is_page: true
+  <<: *default

--- a/test/helpers/open_graph_helper_test.rb
+++ b/test/helpers/open_graph_helper_test.rb
@@ -7,14 +7,69 @@ class OpenGraphHelperTest < ActionView::TestCase
   test "open_graph_image with first image" do
     @post = posts(:one)
 
-    # Mock an attachment as first image
     attachment = mock("attachment")
     @post.stubs(:first_image).returns(attachment)
 
-    # Mock the resized_image_url helper
     stubs(:resized_image_url).with(attachment, width: 1200, height: 630, crop: true).returns("https://example.com/resized-image.jpg")
 
     assert_equal "https://example.com/resized-image.jpg", open_graph_image
+  end
+
+  test "open_graph_image uses custom open_graph_image attachment when present" do
+    @post = posts(:one)
+
+    og_image = mock("og_image")
+    og_image.stubs(:attached?).returns(true)
+    @post.stubs(:open_graph_image).returns(og_image)
+
+    stubs(:resized_image_url).with(og_image, width: 1200, height: 630, crop: true).returns("https://example.com/custom-og.jpg")
+
+    assert_equal "https://example.com/custom-og.jpg", open_graph_image
+  end
+
+  test "open_graph_image falls back to first_image when no custom image attached" do
+    @post = posts(:one)
+
+    not_attached = mock("not_attached")
+    not_attached.stubs(:attached?).returns(false)
+    @post.stubs(:open_graph_image).returns(not_attached)
+
+    content_image = mock("content_image")
+    @post.stubs(:first_image).returns(content_image)
+
+    stubs(:resized_image_url).with(content_image, width: 1200, height: 630, crop: true).returns("https://example.com/first-image.jpg")
+
+    assert_equal "https://example.com/first-image.jpg", open_graph_image
+  end
+
+  test "open_graph_image returns dynamic image when suppressed, even with first image present" do
+    with_og_env_vars do
+      @post = posts(:one)
+      @post.open_graph_image_suppressed = true
+
+      attachment = mock("attachment")
+      @post.stubs(:first_image).returns(attachment)
+
+      result = open_graph_image
+
+      assert_includes result, "https://og.example.com/og"
+      assert_includes result, "The+Art+of+Street+Photography"
+    end
+  end
+
+  test "open_graph_image returns dynamic image when suppressed, even with custom image attached" do
+    with_og_env_vars do
+      @post = posts(:one)
+      @post.open_graph_image_suppressed = true
+
+      attached = mock("attached")
+      attached.stubs(:attached?).returns(true)
+      @post.stubs(:open_graph_image).returns(attached)
+
+      result = open_graph_image
+
+      assert_includes result, "https://og.example.com/og"
+    end
   end
 
   test "text-only post for subscribed account should have custom open graph image" do
@@ -31,7 +86,7 @@ class OpenGraphHelperTest < ActionView::TestCase
 
       assert_nil open_graph_image
     end
-end
+  end
 
   private
 


### PR DESCRIPTION
## Summary

- Writers can upload a custom OG image per post; it takes priority over the first content image in the fallback chain (custom → first content image → dynamic branded card)
- New `open_graph_image_suppressed` boolean skips images entirely and forces the dynamic text-based card
- Feature-flagged (`open_graph_image`) and premium-only; both gates are independent so the premium check persists after the flag is removed
- Dedicated `App::Posts::OpenGraphImagesController` for deletion, following the existing sub-resource pattern
- Minimal Stimulus controller (`open_graph_controller`) handles client-side upload preview
- `G` keyboard shortcut opens the OG image section in the editor dropdown

## Test plan

- [ ] Upload a custom OG image on a post — verify `og:image` meta tag uses it (resized to 1200×630)
- [ ] Remove the custom image — verify fallback to first content image (or dynamic card)
- [ ] Check `open_graph_image_suppressed` — verify dynamic text card is used regardless of images
- [ ] Confirm the section and dropdown item are hidden for non-premium users
- [ ] Confirm the section and dropdown item are hidden when feature flag is off
- [ ] Run `bin/rails test test/controllers/app/posts/open_graph_images_controller_test.rb test/helpers/open_graph_helper_test.rb test/controllers/app/posts_controller_test.rb`