### PR TITLE
Add Micropub API endpoint

### DIFF
--- a/app/controllers/api/attachments_controller.rb
+++ b/app/controllers/api/attachments_controller.rb
@@ -1,24 +1,21 @@
 class Api::AttachmentsController < Api::BaseController
   def create
     file = params[:file]
-
     return render json: { error: "No file provided" }, status: :unprocessable_entity unless file
 
     max_size = UploadLimits::CONTENT_TYPES[file.content_type]
-
-    unless max_size
-      return render json: { error: "Unsupported content type: #{file.content_type}" }, status: :unprocessable_entity
-    end
+    return render json: { error: "Unsupported content type: #{file.content_type}" }, status: :unprocessable_entity unless max_size
 
     if file.size > max_size
       return render json: { error: "File too large (max #{max_size / 1.megabyte}MB for #{file.content_type})" }, status: :unprocessable_entity
     end
 
-    blob = ActiveStorage::Blob.create_and_upload!(io: file, filename: file.original_filename, content_type: file.content_type)
-
-    render json: {
-      attachable_sgid: blob.attachable_sgid,
-      url: url_for(blob)
-    }, status: :created
+    render_blob ActiveStorage::Blob.create_and_upload!(io: file, filename: file.original_filename, content_type: file.content_type)
   end
+
+  private
+
+    def render_blob(blob)
+      render json: { attachable_sgid: blob.attachable_sgid, url: url_for(blob) }, status: :created
+    end
 end

--- a/app/controllers/api/micropub/media_controller.rb
+++ b/app/controllers/api/micropub/media_controller.rb
@@ -1,0 +1,8 @@
+class Api::Micropub::MediaController < Api::AttachmentsController
+  private
+
+    def render_blob(blob)
+      response.headers["Location"] = url_for(blob)
+      head :created
+    end
+end

--- a/app/controllers/api/micropub_controller.rb
+++ b/app/controllers/api/micropub_controller.rb
@@ -1,0 +1,131 @@
+class Api::MicropubController < Api::BaseController
+  include RoutingHelper
+
+  BLOB_URL_PATTERN = %r{/active_storage/blobs/(?:redirect|proxy)/([^/]+)/}.freeze
+
+  def create
+    case request_body[:action]
+    when "update" then update_post
+    when "delete" then delete_post
+    else               create_post
+    end
+  end
+
+  def query
+    case params[:q]
+    when "config" then render json: config_response
+    when "source" then render json: source_properties(find_post!)
+    else               head :bad_request
+    end
+  end
+
+  private
+
+    def request_body
+      request.request_parameters
+    end
+
+    def config_response
+      {
+        "media-endpoint" => "#{micropub_endpoint_url}/media",
+        "syndicate-to"   => [],
+        "post-status"    => %w[published draft]
+      }
+    end
+
+    def create_post
+      attrs = Micropub::PostParams.new(params).to_h
+      attrs[:content] = resolve_blob_images(attrs[:content]) if attrs[:content]
+      post = Current.blog.posts.create(attrs.merge(source: :api))
+
+      if post.persisted?
+        response.headers["Location"] = post_url(post)
+        head :created
+      else
+        render json: { error: post.errors.full_messages.first }, status: :unprocessable_entity
+      end
+    end
+
+    def update_post
+      post = find_post!
+
+      if post.update(unchanged_content_skipped(update_attributes(post), post))
+        head :ok
+      else
+        render json: { error: post.errors.full_messages.first }, status: :unprocessable_entity
+      end
+    end
+
+    def delete_post
+      find_post!.discard!
+      head :ok
+    end
+
+    def update_attributes(post)
+      attrs = (request_body[:replace] || {}).each_with_object({}) do |(prop, values), h|
+        if attr = Micropub::PostParams::ATTRIBUTE_MAP[prop.to_s]
+          h[attr] = Array(values).first
+        end
+      end
+      if tags = updated_tag_list(post)
+        attrs[:tag_list] = tags
+      end
+      attrs
+    end
+
+    def updated_tag_list(post)
+      replace = Array(request_body.dig(:replace, :category))
+      added   = Array(request_body.dig(:add,    :category))
+      removed = Array(request_body.dig(:remove, :category))
+      return if replace.empty? && added.empty? && removed.empty?
+
+      ((replace.presence || post.tag_list) + added - removed).uniq
+    end
+
+    def find_post!
+      Current.blog.posts.kept.find_by!(slug: slug_from_url)
+    end
+
+    def slug_from_url
+      URI.parse(params[:url].to_s).path.delete_prefix("/").chomp("/")
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def source_properties(post)
+      {
+        type: [ "h-entry" ],
+        properties: {
+          name:          [ post.title ].compact,
+          content:       [ { html: post.content.body.to_html } ],
+          category:      post.tag_list,
+          "post-status": [ post.status ],
+          published:     [ post.published_at&.iso8601 ].compact,
+          "mp-slug":     [ post.slug ]
+        }
+      }
+    end
+
+    # Micropub clients reference uploaded images by blob URL (returned from the
+    # media endpoint). Convert those <img> tags to <action-text-attachment> nodes
+    # so Action Text retains the blob association — otherwise the purge job will
+    # orphan the blob.
+    def resolve_blob_images(html)
+      return html unless html&.match?(BLOB_URL_PATTERN)
+
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      doc.css("img").each do |img|
+        next unless blob = blob_from_url(img["src"])
+        node = img.parent&.name == "figure" ? img.parent : img
+        node.replace attachment_preview_node(blob, img["src"], attributes: { alt: img["alt"] })
+      end
+      doc.to_html
+    end
+
+    def blob_from_url(url)
+      signed_id = url.to_s[BLOB_URL_PATTERN, 1]
+      ActiveStorage::Blob.find_signed(signed_id) if signed_id
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      nil
+    end
+end

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -43,6 +43,12 @@ module RoutingHelper
     email_subscriber_one_click_unsubscribe_url(email_subscriber.token, host: host(email_subscriber.blog))
   end
 
+  def micropub_endpoint_url
+    options = Rails.application.config.action_controller.default_url_options
+    port    = options[:port] ? ":#{options[:port]}" : ""
+    "#{options[:protocol] || 'https'}://api.#{Rails.application.config.x.domain}#{port}/micropub"
+  end
+
   private
 
     def route_for_blog(blog, route_name, type, options = {})

--- a/app/models/micropub/post_params.rb
+++ b/app/models/micropub/post_params.rb
@@ -1,0 +1,76 @@
+class Micropub::PostParams
+  ATTRIBUTE_MAP = {
+    "name"        => :title,
+    "content"     => :content,
+    "mp-slug"     => :slug,
+    "published"   => :published_at,
+    "post-status" => :status
+  }.freeze
+
+  def initialize(params)
+    @params = params
+  end
+
+  def to_h
+    attrs = ATTRIBUTE_MAP.each_with_object({}) do |(key, attr), h|
+      next if key == "content"
+      value = first(key)
+      h[attr] = value if value.present?
+    end
+    attrs[:tag_list] = categories if categories.any?
+    attrs[:content]  = content_html if content_html.present?
+    attrs
+  end
+
+  private
+
+    # Micropub accepts both flat form posts ({content: "..."}) and mf2 JSON
+    # ({properties: {content: ["..."]}}). Treat them uniformly by reading
+    # from `properties` when present, otherwise from params directly.
+    def properties
+      @properties ||= @params[:properties].presence || @params
+    end
+
+    def first(key)
+      value = properties[key]
+      value.is_a?(Array) ? value.first : value
+    end
+
+    def all(key)
+      value = properties[key]
+      return [] if value.nil?
+      value.is_a?(Array) ? value : [ value ]
+    end
+
+    def categories
+      @categories ||= all("category")
+    end
+
+    def content_html
+      @content_html ||= [ body_html, *photo_html ].compact_blank.join("\n")
+    end
+
+    def body_html
+      case value = first("content")
+      when nil then nil
+      when ActionController::Parameters, Hash then (value[:html] || value["html"]).to_s.presence
+      else Post::Markdown.render(value.to_s).last
+      end
+    end
+
+    def photo_html
+      all("photo").filter_map do |photo|
+        url, alt = photo_url_and_alt(photo)
+        next if url.blank?
+        %(<img src="#{ERB::Util.html_escape(url)}" alt="#{ERB::Util.html_escape(alt)}">)
+      end
+    end
+
+    def photo_url_and_alt(photo)
+      if photo.is_a?(ActionController::Parameters) || photo.is_a?(Hash)
+        [ (photo[:value] || photo["value"]).to_s, (photo[:alt] || photo["alt"]).to_s ]
+      else
+        [ photo.to_s, "" ]
+      end
+    end
+end

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -39,6 +39,7 @@
     <link rel="canonical" href="<%= canonical_url %>" />
 
     <%= render "layouts/rss" %>
+    <link rel="micropub" href="<%= micropub_endpoint_url %>">
     <%= render "layouts/favicons" %>
 
     <%= font_preload_links %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -29,6 +29,7 @@
     <meta property="twitter:card" content="summary_large_image">
 
     <link rel="canonical" href="<%= canonical_url %>">
+    <link rel="micropub" href="<%= micropub_endpoint_url %>">
 
     <%= stylesheet_link_tag "tailwind", "inter", "source-serif-4", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,11 +4,8 @@ session_options = {
   domain: :all
 }
 
-# When using a custom domain tool like ngrok in development, the domain
-# (e.g., .ngrok-free.app) is often on the public suffix list, which blocks
-# wildcard cookies. We disable the explicit domain setting in this case.
 if Rails.env.development? && ENV["APP_DOMAIN"].present?
-  session_options.delete(:domain)
+  session_options[:domain] = ".#{ENV['APP_DOMAIN']}"
 end
 
 Rails.application.config.session_store :cookie_store, **session_options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -217,6 +217,9 @@ Rails.application.routes.draw do
       resources :pages, only: [ :index, :show, :create, :update, :destroy ], param: :token
       resource :home_page, only: [ :show, :create, :update, :destroy ]
       resources :attachments, only: [ :create ]
+      post "/micropub",       to: "micropub#create"
+      get  "/micropub",       to: "micropub#query"
+      post "/micropub/media", to: "micropub/media#create"
     end
   end
 

--- a/test/controllers/micropub_controller_test.rb
+++ b/test/controllers/micropub_controller_test.rb
@@ -1,0 +1,213 @@
+require "test_helper"
+
+class Api::MicropubControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "api.example.com"
+
+    @blog = blogs(:joel)
+    @user = users(:joel)
+    @user.update!(trial_ends_at: 30.days.from_now)
+
+    @post = posts(:one)
+  end
+
+  # -- Authentication --
+
+  test "returns unauthorized without token" do
+    post "/micropub", params: { h: "entry", name: "Test", content: "Hello" }
+    assert_response :unauthorized
+  end
+
+  test "returns unauthorized with invalid token" do
+    post "/micropub", params: { h: "entry", name: "Test", content: "Hello" }, headers: auth_header("bad-token")
+    assert_response :unauthorized
+  end
+
+  test "returns forbidden without premium access" do
+    @user.subscription.destroy!
+    @user.update!(trial_ends_at: nil)
+    post "/micropub", params: { h: "entry", name: "Test", content: "Hello" }, headers: auth_header
+    assert_response :forbidden
+  end
+
+  # -- Create (form-encoded) --
+
+  test "creates a post from form-encoded params" do
+    post "/micropub",
+      params: { h: "entry", name: "Hello World", content: "Some content" },
+      headers: auth_header
+
+    assert_response :created
+    assert response.headers["Location"].present?
+    assert_includes response.headers["Location"], "hello-world"
+  end
+
+  test "creates a draft post" do
+    post "/micropub",
+      params: { h: "entry", name: "Draft Post", content: "Hello", "post-status": "draft" },
+      headers: auth_header
+
+    assert_response :created
+    slug = response.headers["Location"].split("/").last
+    assert @blog.posts.find_by(slug: slug).draft?
+  end
+
+  test "creates a post with tags" do
+    post "/micropub",
+      params: { h: "entry", name: "Tagged Post", content: "Hello", "category[]": [ "ruby", "rails" ] },
+      headers: auth_header
+
+    assert_response :created
+    slug = response.headers["Location"].split("/").last
+    created_post = @blog.posts.find_by(slug: slug)
+    assert_includes created_post.tag_list, "ruby"
+    assert_includes created_post.tag_list, "rails"
+  end
+
+  test "creates a post with custom slug" do
+    post "/micropub",
+      params: { h: "entry", name: "Some Post", content: "Hello", "mp-slug": "custom-slug" },
+      headers: auth_header
+
+    assert_response :created
+    assert_includes response.headers["Location"], "custom-slug"
+  end
+
+  # -- Create (JSON) --
+
+  test "creates a post from JSON" do
+    post "/micropub",
+      params: { h: "entry", name: "JSON Post", content: "Hello from JSON" }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    assert response.headers["Location"].present?
+  end
+
+  test "creates a post with HTML content via content[html]" do
+    post "/micropub",
+      params: { h: "entry", name: "HTML Post", content: { html: "<p>Hello <strong>world</strong></p>" } }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    slug = response.headers["Location"].split("/").last
+    assert_includes @blog.posts.find_by(slug: slug).content.body.to_html, "<strong>world</strong>"
+  end
+
+  # -- Create (mf2 JSON - iA Writer format) --
+
+  test "creates a post from mf2 JSON" do
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "mf2 Post" ],
+          content: [ { html: "<p>Hello from iA Writer</p>" } ],
+          "post-status": [ "draft" ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    slug = response.headers["Location"].split("/").last
+    created_post = @blog.posts.find_by(slug: slug)
+    assert_equal "mf2 Post", created_post.title
+    assert created_post.draft?
+    assert_includes created_post.content.body.to_html, "Hello from iA Writer"
+  end
+
+  # -- Update --
+
+  test "updates a post title via replace" do
+    post "/micropub",
+      params: { action: "update", url: "http://joel.example.com/#{@post.slug}", replace: { name: [ "New Title" ] } }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :ok
+    assert_equal "New Title", @post.reload.title
+  end
+
+  test "adds tags via add" do
+    post "/micropub",
+      params: { action: "update", url: "http://joel.example.com/#{@post.slug}", add: { category: [ "newtag" ] } }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :ok
+    assert_includes @post.reload.tag_list, "newtag"
+  end
+
+  test "removes tags via remove" do
+    @post.update!(tag_list: [ "photography", "travel" ])
+
+    post "/micropub",
+      params: { action: "update", url: "http://joel.example.com/#{@post.slug}", remove: { category: [ "travel" ] } }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :ok
+    assert_not_includes @post.reload.tag_list, "travel"
+    assert_includes @post.reload.tag_list, "photography"
+  end
+
+  test "returns 404 when updating nonexistent post" do
+    post "/micropub",
+      params: { action: "update", url: "http://joel.example.com/no-such-post", replace: { name: [ "X" ] } }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :not_found
+  end
+
+  # -- Delete --
+
+  test "deletes a post" do
+    post "/micropub",
+      params: { action: "delete", url: "http://joel.example.com/#{@post.slug}" }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :ok
+    assert @post.reload.discarded?
+  end
+
+  test "returns 404 when deleting nonexistent post" do
+    post "/micropub",
+      params: { action: "delete", url: "http://joel.example.com/no-such-post" }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :not_found
+  end
+
+  # -- Query --
+
+  test "q=config returns media endpoint" do
+    get "/micropub", params: { q: "config" }, headers: auth_header
+
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal "http://api.example.com/micropub/media", json["media-endpoint"]
+    assert_equal [], json["syndicate-to"]
+  end
+
+  test "q=source returns post properties" do
+    get "/micropub", params: { q: "source", url: "http://joel.example.com/#{@post.slug}" }, headers: auth_header
+
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal [ @post.title ], json["properties"]["name"]
+    assert_equal [ @post.slug ], json["properties"]["mp-slug"]
+  end
+
+  test "q=source returns 404 for unknown post" do
+    get "/micropub", params: { q: "source", url: "http://joel.example.com/no-such-post" }, headers: auth_header
+    assert_response :not_found
+  end
+
+  test "unknown q param returns 400" do
+    get "/micropub", params: { q: "unknown" }, headers: auth_header
+    assert_response :bad_request
+  end
+
+  private
+
+    def auth_header(token = "test_api_key_for_fixtures")
+      { "Authorization" => "Bearer #{token}" }
+    end
+end


### PR DESCRIPTION
## Summary
- Implements the W3C Micropub spec at `api.<domain>/micropub` — create/update/delete posts plus `q=config` and `q=source` queries
- Adds a media endpoint (`/micropub/media`) that reuses the existing attachments pipeline and rewrites returned blob URLs into `<action-text-attachment>` nodes so sgids are preserved
- Dev-only session cookie tweak so login survives subdomain redirects when running behind a Cloudflare tunnel (`APP_DOMAIN=dev.pagecord.net`)

## Test plan
- [ ] `bin/rails test test/controllers/micropub_controller_test.rb`
- [ ] Hit `POST /micropub` with a real client (e.g. Quill, IndiePass) and confirm a post is created
- [ ] Upload via `POST /micropub/media` and verify the returned `Location` resolves to a blob
- [ ] Reference an uploaded blob in a subsequent `create` and confirm the image survives Action Text purge
- [ ] Update/delete via Micropub client, verify slug/tag handling
- [ ] `q=config` returns `media-endpoint` / `post-status` / `syndicate-to`
- [ ] `q=source` returns h-entry properties for an existing post
- [ ] Log in via magic link with `APP_DOMAIN` set and confirm redirect to `/app/posts` authenticates correctly