### PR TITLE
Align gallery edges to article column with CSS Grid

### DIFF
--- a/app/assets/stylesheets/blogs.css
+++ b/app/assets/stylesheets/blogs.css
@@ -163,11 +163,23 @@ footer.blog-footer #brand svg {
 
     .attachment-gallery {
       margin-block: 1.5rem;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 0.5rem;
     }
 
-    .attachment-gallery .attachment {
+    .attachment-gallery--2,
+    .attachment-gallery--4 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    .attachment-gallery .attachment,
+    .attachment-gallery.attachment-gallery--2 .attachment,
+    .attachment-gallery.attachment-gallery--4 .attachment {
       margin-block: 0;
       gap: calc(var(--lexxy-attachment-gap) / 2);
+      inline-size: 100%;
+      padding: 0;
     }
 
     .attachment--preview {

--- a/docs/help-guide/custom-css.md
+++ b/docs/help-guide/custom-css.md
@@ -334,6 +334,32 @@ article img {
 }
 ```
 
+### Galleries: fewer columns on mobile
+
+By default, image galleries render in 2 or 3 columns depending on how many images you've added. On narrow screens this can feel cramped. Change the layout below a chosen breakpoint.
+
+**One image per row on mobile:**
+
+```css
+@media (max-width: 600px) {
+  .attachment-gallery {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+**Two images per row on mobile:**
+
+```css
+@media (max-width: 600px) {
+  .attachment-gallery {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+```
+
+Adjust `600px` to your preferred breakpoint.
+
 ### Adding a background image to your blog
 
 You can set a background image so that it fits the viewport and scales nicely. It can be unreliable to rely on a 3rd party URL for the image, so I would recommend creating page on your Pagecord blog and upload your background image of choice to it. View the page, then copy the link to the image and then reference that image in your CSS.


### PR DESCRIPTION
## Summary

- Replaces lexxy's inline-flex gallery with CSS Grid so the leftmost and rightmost images sit flush to the article column edges (matching how single images look), instead of floating centered with a visible inset.
- 3-up by default; 2- and 4-image galleries get a 2-column grid. 0.5rem gap between cells.
- Adds a "Galleries: fewer columns on mobile" recipe to the custom CSS guide so customers can collapse to 1 or 2 columns via a media query.

## Notes

- Selector duplicated for `.attachment-gallery--2/--4` to match lexxy's (0,3,0) specificity on its own calc-based widths.
- With grid, partial last rows (e.g. 5 images = 3+2) are left-aligned rather than centered. Felt like a fair trade for consistent edge alignment.
- Editor view (`.lexxy-editor__content`) is unchanged — different CSS bundle. Can be mirrored later if WYSIWYG parity matters.

## Test plan

- [ ] 1-image post: unchanged
- [ ] 2-image gallery: two columns, flush to edges, gap between
- [ ] 3-image gallery: three columns, flush to edges
- [ ] 4-image gallery: 2x2, flush to edges
- [ ] 5-image gallery: 3 + 2 (left-aligned second row)
- [ ] On mobile (<600px) with the doc recipe applied, gallery collapses correctly