### PR TITLE
Remove open_graph_image feature flag

### DIFF
--- a/app/controllers/app/home_pages_controller.rb
+++ b/app/controllers/app/home_pages_controller.rb
@@ -48,7 +48,7 @@ class App::HomePagesController < AppController
     def home_page_params
       status = params[:button] == "save_draft" ? :draft : :published
       permitted = [ :title, :content, :slug ]
-      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access?
+      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if Current.user.has_premium_access?
       params.require(:post).permit(*permitted).merge(is_page: true, status: status, is_home_page: true)
     end
 end

--- a/app/controllers/app/pages_controller.rb
+++ b/app/controllers/app/pages_controller.rb
@@ -74,7 +74,7 @@ class App::PagesController < AppController
     def page_params
       status = params[:button] == "save_draft" ? :draft : :published
       permitted = [ :title, :content, :slug ]
-      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access?
+      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if Current.user.has_premium_access?
       params.require(:post).permit(*permitted).merge(is_page: true, status: status)
     end
 end

--- a/app/controllers/app/posts/open_graph_images_controller.rb
+++ b/app/controllers/app/posts/open_graph_images_controller.rb
@@ -1,5 +1,4 @@
 class App::Posts::OpenGraphImagesController < AppController
-  before_action :require_feature
   before_action :require_premium
 
   def destroy
@@ -18,10 +17,6 @@ class App::Posts::OpenGraphImagesController < AppController
   end
 
   private
-
-    def require_feature
-      render_app_not_found unless current_features.enabled?(:open_graph_image)
-    end
 
     def require_premium
       render_app_not_found unless Current.user.has_premium_access?

--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -81,7 +81,7 @@ class App::PostsController < AppController
     def post_params
       status = params[:button] == "save_draft" ? :draft : :published
       permitted = [ :title, :content, :slug, :published_at, :canonical_url, :tags_string, :hidden, :locale ]
-      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access?
+      permitted += [ :open_graph_image, :open_graph_image_suppressed ] if Current.user.has_premium_access?
       params.require(:post).permit(*permitted).merge(status: status)
     end
 

--- a/app/views/app/home_pages/_form.html.erb
+++ b/app/views/app/home_pages/_form.html.erb
@@ -3,7 +3,7 @@
 
   <div class="mb-4"><%= trial_callout("Image uploads") %></div>
 
-  <% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+  <% if Current.user.has_premium_access? %>
   <div class="flex justify-end mb-4" data-controller="toggle">
     <%= link_to "#", class: "ms-3 font-medium text-slate-500 hover:text-black dark:text-slate-300 dark:hover:text-slate-50", data: { action: "click->toggle#toggle click@window->toggle#hide" } do %>
       <%= inline_svg_tag "icons/ellipsis-horizontal-circle.svg", class: "w-7 h-7" %>

--- a/app/views/app/pages/_form.html.erb
+++ b/app/views/app/pages/_form.html.erb
@@ -23,7 +23,7 @@
               <% end %>
             </div>
 
-            <% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+            <% if Current.user.has_premium_access? %>
               <div class="p-1">
                 <%= link_to "#", class: "flex justify-between items-center rounded-lg px-2 py-1 text-sm text-gray-500 dark:text-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-50",
                   data: { action: "click->post-attributes#toggle", toggle_target: "og-image" } do %>

--- a/app/views/app/posts/_drop_down_menu.html.erb
+++ b/app/views/app/posts/_drop_down_menu.html.erb
@@ -50,7 +50,7 @@
         <% end %>
       </div>
 
-      <% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+      <% if Current.user.has_premium_access? %>
         <div class="p-1">
           <%= link_to "#", class: "flex justify-between items-center rounded-lg px-2 py-1 text-sm text-gray-500 dark:text-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-50",
             data: { action: "click->post-attributes#toggle", toggle_target: "og-image" } do %>

--- a/app/views/app/posts/_open_graph_image_section.html.erb
+++ b/app/views/app/posts/_open_graph_image_section.html.erb
@@ -1,4 +1,4 @@
-<% if current_features.enabled?(:open_graph_image) && Current.user.has_premium_access? %>
+<% if Current.user.has_premium_access? %>
 <div class="<%= 'hidden' unless record.open_graph_image.attached? || record.open_graph_image_suppressed? %> mb-8" data-post-attributes-target="section" data-section="og-image">
   <div class="mt-4 font-bold">Open Graph Image</div>
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,5 +1,1 @@
 env "FEATURE"
-
-feature :open_graph_image do |blog: nil|
-  blog&.features.include?("open_graph_image")
-end

--- a/test/controllers/app/home_pages_controller_test.rb
+++ b/test/controllers/app/home_pages_controller_test.rb
@@ -150,7 +150,6 @@ class App::HomePagesControllerTest < ActionDispatch::IntegrationTest
 
   test "should update home page with open graph image" do
     user = users(:annie)
-    user.blog.update!(features: [ "open_graph_image" ])
     login_as user
     home_page = user.blog.home_page
     image = fixture_file_upload("avatar.png", "image/png")
@@ -163,7 +162,6 @@ class App::HomePagesControllerTest < ActionDispatch::IntegrationTest
 
   test "should update home page with open_graph_image_suppressed" do
     user = users(:annie)
-    user.blog.update!(features: [ "open_graph_image" ])
     login_as user
     home_page = user.blog.home_page
 

--- a/test/controllers/app/pages_controller_test.rb
+++ b/test/controllers/app/pages_controller_test.rb
@@ -210,7 +210,6 @@ class App::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update page with open graph image" do
-    @blog.update!(features: [ "open_graph_image" ])
     image = fixture_file_upload("avatar.png", "image/png")
 
     patch app_page_path(@page), params: { post: { open_graph_image: image } }
@@ -220,8 +219,6 @@ class App::PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update page with open_graph_image_suppressed" do
-    @blog.update!(features: [ "open_graph_image" ])
-
     patch app_page_path(@page), params: { post: { open_graph_image_suppressed: true } }
 
     assert_redirected_to app_pages_path

--- a/test/controllers/app/posts/open_graph_images_controller_test.rb
+++ b/test/controllers/app/posts/open_graph_images_controller_test.rb
@@ -6,7 +6,6 @@ class App::Posts::OpenGraphImagesControllerTest < ActionDispatch::IntegrationTes
   setup do
     @user = users(:joel)
     @post = posts(:one)
-    @user.blog.update!(features: [ "open_graph_image" ])
     login_as @user
   end
 
@@ -57,7 +56,6 @@ class App::Posts::OpenGraphImagesControllerTest < ActionDispatch::IntegrationTes
 
   test "should destroy open graph image on home page and redirect to home page edit" do
     annie = users(:annie)
-    annie.blog.update!(features: [ "open_graph_image" ])
     login_as annie
     home_page = posts(:annie_home_page)
     home_page.open_graph_image.attach(

--- a/test/controllers/app/posts_controller_test.rb
+++ b/test/controllers/app/posts_controller_test.rb
@@ -166,7 +166,6 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
 
   test "should update post with open graph image" do
     user = users(:joel)
-    user.blog.update!(features: [ "open_graph_image" ])
     login_as user
     post = user.blog.posts.first
     image = fixture_file_upload("avatar.png", "image/png")
@@ -179,7 +178,6 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
 
   test "should update post with open_graph_image_suppressed" do
     user = users(:joel)
-    user.blog.update!(features: [ "open_graph_image" ])
     login_as user
     post = user.blog.posts.first
 


### PR DESCRIPTION
## Summary
- Drops the `:open_graph_image` feature flag from `config/features.rb`
- Per-post/page/home-page OG image controls are now gated by premium access only
- Removes the now-unneeded `blog.update!(features: ["open_graph_image"])` setup from affected tests

## Test plan
- [x] `bin/rails test` on the four affected controller tests + OG helper tests (79 runs, 0 failures)
- [ ] Spot-check as a premium user that the OG image section still renders on post/page/home-page forms
- [ ] Spot-check as a non-premium user that the section is hidden