### PR TITLE
Add show_metrics blog setting to hide analytics and subscriber counts

### DIFF
--- a/app/controllers/app/analytics_controller.rb
+++ b/app/controllers/app/analytics_controller.rb
@@ -1,4 +1,6 @@
 class App::AnalyticsController < AppController
+  before_action :redirect_if_metrics_hidden
+
   def index
     @view_type = params[:view_type] || "month"
     @date = Current.user.has_premium_access? ? summary.parse_date(@view_type, params[:date]) : Date.current
@@ -20,6 +22,10 @@ class App::AnalyticsController < AppController
   end
 
   private
+
+    def redirect_if_metrics_hidden
+      redirect_to app_root_path unless Current.user.blog.show_metrics?
+    end
 
     def summary
       @summary ||= Analytics::Summary.new(@blog, user_timezone)

--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -31,7 +31,8 @@ class App::Settings::BlogsController < AppController
         :allow_search_indexing,
         :google_site_verification,
         :seo_title,
-        :locale
+        :locale,
+        :show_metrics
       ]
 
       if @blog.user.subscribed?

--- a/app/views/app/posts/_email_banner.html.erb
+++ b/app/views/app/posts/_email_banner.html.erb
@@ -10,7 +10,8 @@
         <div class="relative flex items-center gap-2">
           <%= inline_svg_tag "icons/envelope.svg", class: "w-4 h-4 text-[#4fbd9c] shrink-0" %>
           <% count = digest.delivered_at? ? digest.deliveries.count : subscriber_count %>
-          <span>Emailed to <%= pluralize(count, "subscriber") %> on <%= l(digest.created_at.in_time_zone(Current.user.timezone).to_date, format: :post_date) %>.</span>
+          <% recipients = @blog.show_metrics? ? pluralize(count, "subscriber") : "subscribers" %>
+          <span>Emailed to <%= recipients %> on <%= l(digest.created_at.in_time_zone(Current.user.timezone).to_date, format: :post_date) %>.</span>
         </div>
       </div>
     </div>
@@ -19,7 +20,7 @@
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div class="flex items-center gap-2">
           <%= inline_svg_tag "icons/envelope.svg", class: "w-4 h-4 text-slate-400 dark:text-slate-500 shrink-0" %>
-          <span>Send this post to your <%= pluralize(subscriber_count, "subscriber") %>.</span>
+          <span>Send this post to your <%= @blog.show_metrics? ? pluralize(subscriber_count, "subscriber") : "subscribers" %>.</span>
         </div>
         <div class="flex flex-row-reverse justify-between items-center gap-3 sm:flex-row sm:justify-start">
           <%= link_to "Send a test email", test_app_post_broadcast_path(@post), data: { turbo_method: :post, turbo_confirm: "Send a test email to #{Current.user.email}?" }, class: "text-xs underline" %>

--- a/app/views/app/posts/_post.html.erb
+++ b/app/views/app/posts/_post.html.erb
@@ -18,7 +18,7 @@
       <% if post.hidden? %>
         <%= inline_svg_tag "icons/eye-slash.svg", class: "w-4 h-4", title: "Private post", aria: { label: "Private post" }, role: "img" %>
       <% end %>
-      <% if @user.has_premium_access? && post.upvotes_count > 0 %>
+      <% if @user.has_premium_access? && @user.blog.show_metrics? && post.upvotes_count > 0 %>
         <span class="flex gap-x-0.5">
           <span class="text-xs"><%= post.upvotes_count %></span>
           <%= inline_svg_tag "icons/heart.svg", class: "w-4 h-4" %>

--- a/app/views/app/settings/audience/index.html.erb
+++ b/app/views/app/settings/audience/index.html.erb
@@ -18,7 +18,7 @@
 <% end %>
 
 <%= form_with url: app_settings_blog_path(@blog), model: @blog do |form| %>
-  <% if @blog.email_subscriptions_enabled && Current.user.subscribed? %>
+  <% if @blog.email_subscriptions_enabled && Current.user.subscribed? && @blog.show_metrics? %>
     <p>
       Your blog has <%= pluralize @blog.email_subscribers.confirmed.count, "email subscriber" %>.
     </p>
@@ -103,6 +103,20 @@
         <p class="text-slate-500 text-sm">
           When checked, a heart-shaped like button will appear next to each post for readers to show
           their appreciation.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-6">
+    <div class="flex gap-3">
+      <div class="flex h-6 shrink-0 items-center">
+        <%= form.check_box :show_metrics, { checked: @blog.show_metrics, class: "form-checkbox h-5 w-5 text-slate-600 border-slate-300 dark:border-slate-600 dark:bg-slate-700 rounded focus:ring focus:ring-slate-300 dark:focus:ring-slate-600 focus:ring-offset-0" } %>
+      </div>
+      <div>
+        <%= form.label :show_metrics, "Show metrics", class: "text-slate-800 dark:text-slate-100" %>
+        <p class="text-slate-500 text-sm">
+          When unchecked, the Analytics page is hidden and your subscriber count is no longer shown to you.
         </p>
       </div>
     </div>

--- a/app/views/app/shared/_nav.html.erb
+++ b/app/views/app/shared/_nav.html.erb
@@ -6,9 +6,11 @@
     <li>
       <%= link_to "Pages", app_pages_path, class: nav_class_for("pages") %>
     </li>
-    <li>
-      <%= link_to "Analytics", app_analytics_path, class: nav_class_for("analytics") %>
-    </li> 
+    <% if Current.user.blog.show_metrics? %>
+      <li>
+        <%= link_to "Analytics", app_analytics_path, class: nav_class_for("analytics") %>
+      </li>
+    <% end %>
     <li>
       <%= link_to "Settings", app_settings_path, class: nav_class_for("settings") %>
     </li>

--- a/db/migrate/20260427104710_add_show_metrics_to_blogs.rb
+++ b/db/migrate/20260427104710_add_show_metrics_to_blogs.rb
@@ -1,0 +1,5 @@
+class AddShowMetricsToBlogs < ActiveRecord::Migration[8.2]
+  def change
+    add_column :blogs, :show_metrics, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_04_16_114406) do
+ActiveRecord::Schema[8.2].define(version: 2026_04_27_104710) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -113,6 +113,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_04_16_114406) do
     t.boolean "reply_by_email", default: false, null: false
     t.string "seo_title"
     t.boolean "show_branding", default: true, null: false
+    t.boolean "show_metrics", default: true, null: false
     t.boolean "show_subscription_in_footer", default: true, null: false
     t.boolean "show_subscription_in_header", default: true, null: false
     t.boolean "show_upvotes", default: true, null: false

--- a/test/controllers/app/analytics_controller_test.rb
+++ b/test/controllers/app/analytics_controller_test.rb
@@ -146,4 +146,11 @@ class App::AnalyticsControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "h2", text: /Unlock your blog's analytics with Premium/i, count: 1
   end
+
+  test "redirects to dashboard when blog has metrics hidden" do
+    @user.blog.update!(show_metrics: false)
+
+    get app_analytics_path
+    assert_redirected_to app_root_path
+  end
 end

--- a/test/controllers/app/settings/audience_controller_test.rb
+++ b/test/controllers/app/settings/audience_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class App::Settings::AudienceControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  setup do
+    @user = users(:joel)
+    @blog = @user.blog
+    login_as @user
+  end
+
+  test "shows subscriber count when show_metrics is enabled" do
+    get app_settings_audience_index_url
+
+    assert_response :success
+    assert_select "p", text: /Your blog has 1 email subscriber/
+  end
+
+  test "hides subscriber count when show_metrics is disabled" do
+    @blog.update!(show_metrics: false)
+
+    get app_settings_audience_index_url
+
+    assert_response :success
+    assert_select "p", text: /Your blog has/, count: 0
+  end
+end

--- a/test/controllers/app/settings/blogs_controller_test.rb
+++ b/test/controllers/app/settings/blogs_controller_test.rb
@@ -183,6 +183,13 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
     assert_equal false, @blog.reload.show_subscription_in_footer
   end
 
+  test "should update show_metrics" do
+    patch app_settings_blog_url(@blog), params: { blog: { show_metrics: false } }, as: :turbo_stream
+
+    assert_redirected_to app_settings_url
+    assert_equal false, @blog.reload.show_metrics
+  end
+
   test "should not allow non-subscribed user to update subscription location settings" do
     login_as users(:vivian)
 


### PR DESCRIPTION
## Summary
- New `show_metrics` boolean on `Blog` (default `true`), exposed as a checkbox in **Settings → Audience**
- When unchecked: Analytics nav link is hidden, direct visits to `/app/analytics` redirect to the dashboard, and subscriber counts are suppressed in the audience page and post email banner
- Existing behaviour is unchanged for current users (default-on)

Closes [Fizzy 232](https://app.fizzy.do/6102591/cards/232).

## Test plan
- [x] `bin/rails test test/controllers/app/analytics_controller_test.rb test/controllers/app/settings/blogs_controller_test.rb test/controllers/app/settings/audience_controller_test.rb`
- [ ] Manual: toggle the setting in Audience settings, confirm Analytics link disappears from the nav and `/app/analytics` redirects
- [ ] Manual: confirm "Your blog has N email subscribers" line on Audience page disappears
- [ ] Manual: confirm post email banner shows "subscribers" instead of the count when hidden