### PR TITLE
Scope account routes to the default domain

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,161 +57,192 @@ Rails.application.routes.draw do
   # PWA routes
   get "manifest", to: "rails/pwa#manifest", as: :pwa_manifest, defaults: { format: :json }, constraints: { format: :json }
 
-  constraints AdminConstraint.new do
-    mount Sidekiq::Web, at: "/admin/sidekiq"
-    mount PgHero::Engine, at: "/admin/pghero"
-  end
-
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
   get "/404", to: "errors#not_found"
   get "/422", to: "errors#unacceptable"
   get "/500", to: "errors#internal_error"
 
-  resources :signups, only: [ :index, :new, :create ] do
-    get :thanks, on: :collection
-  end
-
   namespace :billing do
     resources :paddle_events, only: [ :create ]
     post "/paddle/create_update_payment_method_transaction", to: "paddle#create_update_payment_method_transaction"
   end
 
-  get "/login", to: "sessions#new"
-  delete "/logout", to: "sessions#destroy"
-  resources :sessions, only: [ :create ] do
-    get :thanks, on: :collection
-  end
-
-  resources :password_resets, only: [ :new, :create, :edit, :update ], param: :token do
-    get :thanks, on: :collection
-  end
-
-  get "/verify/:token", to: "access_requests#verify", as: :verify_access_request
-
-  namespace :app do
-    resource :upgrade_banner, only: [ :destroy ]
-    resources :analytics, only: [ :index ]
-    namespace :posts do
-      resource :trash, only: [ :show, :create, :destroy ], controller: "trash"
+  constraints(DomainConstraints.method(:default_domain?)) do
+    constraints AdminConstraint.new do
+      mount Sidekiq::Web, at: "/admin/sidekiq"
+      mount PgHero::Engine, at: "/admin/pghero"
     end
-    resources :posts, param: :token do
-      resource :broadcast, only: [ :create ], controller: "posts/broadcasts" do
-        post :test
+
+    resources :signups, only: [ :index, :new, :create ] do
+      get :thanks, on: :collection
+    end
+
+    get "/login", to: "sessions#new"
+    delete "/logout", to: "sessions#destroy"
+    resources :sessions, only: [ :create ] do
+      get :thanks, on: :collection
+    end
+
+    resources :password_resets, only: [ :new, :create, :edit, :update ], param: :token do
+      get :thanks, on: :collection
+    end
+
+    get "/verify/:token", to: "access_requests#verify", as: :verify_access_request
+
+    namespace :app do
+      resource :upgrade_banner, only: [ :destroy ]
+      resources :analytics, only: [ :index ]
+      namespace :posts do
+        resource :trash, only: [ :show, :create, :destroy ], controller: "trash"
       end
-      resource :open_graph_image, only: [ :destroy ], controller: "posts/open_graph_images"
-      resource :restoration, only: [ :create ], controller: "posts/restorations"
-    end
-
-    namespace :pages do
-      resource :trash, only: [ :show, :create, :destroy ], controller: "trash"
-    end
-    resources :pages, except: [ :show ], param: :token do
-      resource :restoration, only: [ :create ], controller: "pages/restorations"
-      member do
-        post :set_as_home_page
+      resources :posts, param: :token do
+        resource :broadcast, only: [ :create ], controller: "posts/broadcasts" do
+          post :test
+        end
+        resource :open_graph_image, only: [ :destroy ], controller: "posts/open_graph_images"
+        resource :restoration, only: [ :create ], controller: "posts/restorations"
       end
-    end
-    resource :home_page, only: [ :new, :create, :edit, :update, :destroy ]
-    resources :settings, only: [ :index ]
 
-    resource :onboarding, only: [ :show, :update ], path: "onboarding" do
-      member do
-        post :complete
+      namespace :pages do
+        resource :trash, only: [ :show, :create, :destroy ], controller: "trash"
       end
-    end
-
-    namespace :settings do
-      resources :about, only: [ :index, :update ]
-      resources :audience, only: [ :index ]
-      resources :users, only: [ :update, :destroy ]
-      resources :blogs, only: [ :index, :update ]
-      resources :appearance, only: [ :index, :update ]
-      resources :theme_garden, only: [ :index ] do
+      resources :pages, except: [ :show ], param: :token do
+        resource :restoration, only: [ :create ], controller: "pages/restorations"
         member do
-          get :preview
-          post :apply
+          post :set_as_home_page
         end
       end
-      resources :navigation_items, only: [ :index, :create, :update, :destroy ]
-      resources :email_change_requests, only: [ :create, :destroy ] do
+      resource :home_page, only: [ :new, :create, :edit, :update, :destroy ]
+      resources :settings, only: [ :index ]
+
+      resource :onboarding, only: [ :show, :update ], path: "onboarding" do
         member do
-          post :resend
+          post :complete
         end
+      end
+
+      namespace :settings do
+        resources :about, only: [ :index, :update ]
+        resources :audience, only: [ :index ]
+        resources :users, only: [ :update, :destroy ]
+        resources :blogs, only: [ :index, :update ]
+        resources :appearance, only: [ :index, :update ]
+        resources :theme_garden, only: [ :index ] do
+          member do
+            get :preview
+            post :apply
+          end
+        end
+        resources :navigation_items, only: [ :index, :create, :update, :destroy ]
+        resources :email_change_requests, only: [ :create, :destroy ] do
+          member do
+            post :resend
+          end
+          collection do
+            get "verify/:token", to: "email_change_requests#verify", as: :verify
+          end
+        end
+
+        resource :api, only: [ :show, :create, :destroy ], controller: "api"
+        resources :exports
+
+        resources :sender_email_addresses, only: [ :create, :destroy ] do
+          collection do
+            get "verify/:token", to: "sender_email_addresses#verify", as: :verify
+          end
+        end
+
+        get "/account/edit", to: "account#edit"
+
+        resources :subscriptions, only: [ :index, :destroy ] do
+          get :thanks, on: :collection
+          get :cancel_confirm, on: :collection
+          post :change_plan, on: :collection
+          post :resume, on: :collection
+        end
+      end
+
+      resources :blogs do
+        resource :avatar, only: [ :destroy ], controller: "blogs/avatars"
+      end
+
+      get "/account", to: "account#index"
+
+      root "posts#index"
+    end
+
+    get "/admin", to: "admin#index", as: :admin
+
+    namespace :admin do
+      resources :theme_templates do
+        get :fixtures, on: :collection
+      end
+      resources :blogs, only: [ :index ]
+      resources :analytics, only: [ :index ]
+      resources :posts, only: [ :index ]
+      resources :suppressions, only: [ :index ] do
         collection do
-          get "verify/:token", to: "email_change_requests#verify", as: :verify
+          delete :destroy
+          delete :destroy_all
         end
       end
-
-      resource :api, only: [ :show, :create, :destroy ], controller: "api"
-      resources :exports
-
-      resources :sender_email_addresses, only: [ :create, :destroy ] do
-        collection do
-          get "verify/:token", to: "sender_email_addresses#verify", as: :verify
-        end
-      end
-
-      get "/account/edit", to: "account#edit"
-
-      resources :subscriptions, only: [ :index, :destroy ] do
-        get :thanks, on: :collection
-        get :cancel_confirm, on: :collection
-        post :change_plan, on: :collection
-        post :resume, on: :collection
-      end
-    end
-
-    resources :blogs do
-      resource :avatar, only: [ :destroy ], controller: "blogs/avatars"
-    end
-
-    get "/account", to: "account#index"
-
-    root "posts#index"
-  end
-
-  get "/admin", to: "admin#index", as: :admin
-  namespace :admin do
-    resources :theme_templates do
-      get :fixtures, on: :collection
-    end
-    resources :blogs, only: [ :index ]
-    resources :analytics, only: [ :index ]
-    resources :posts, only: [ :index ]
-    resources :suppressions, only: [ :index ] do
-      collection do
-        delete :destroy
-        delete :destroy_all
-      end
-    end
-    resources :users, only: [ :show, :destroy, :new, :create, :update ] do
-      member do
-        post :restore
-      end
-      resource :subscription, only: [ :update ]
-      resource :verification_email, only: [ :create ]
-    end
-    namespace :moderation do
-      root to: redirect("/admin/moderation/spam")
-
-      resources :content, only: [ :index, :show ] do
+      resources :users, only: [ :show, :destroy, :new, :create, :update ] do
         member do
-          post :dismiss
-          post :discard
+          post :restore
         end
+        resource :subscription, only: [ :update ]
+        resource :verification_email, only: [ :create ]
       end
+      namespace :moderation do
+        root to: redirect("/admin/moderation/spam")
 
-      resources :spam, only: [ :index, :show ] do
-        collection do
-          post :run_detection
+        resources :content, only: [ :index, :show ] do
+          member do
+            post :dismiss
+            post :discard
+          end
         end
-        member do
-          post :dismiss
-          post :confirm
+
+        resources :spam, only: [ :index, :show ] do
+          collection do
+            post :run_detection
+          end
+          member do
+            post :dismiss
+            post :confirm
+          end
         end
       end
     end
+
+    get "/sitemap.xml", to: "public#sitemap", as: :public_sitemap, format: :xml
+    get "/robots.txt", to: "public#robots", as: :robots, format: :text
+    get "/llms.txt", to: "public/llms#show", as: :llms_txt, format: :text
+    get "/terms", to: "public#terms", as: :terms
+    get "/privacy", to: "public#privacy", as: :privacy
+    get "/faq", to: "public#faq", as: :faq
+    get "/pagecord-vs-about-me", to: "public#pagecord_vs_about_me"
+    get "/pagecord-vs-medium", to: "public#pagecord_vs_medium"
+    get "/pagecord-vs-hey-world", to: "public#pagecord_vs_hey_world"
+    get "/pagecord-vs-wordpress", to: "public#pagecord_vs_wordpress"
+    get "/pagecord-vs-substack", to: "public#pagecord_vs_substack"
+    get "/minimalist-blogging", to: "public#minimalist_blogging"
+    get "/blogging-by-email", to: "public#blogging_by_email"
+    get "/blog-with-newsletter", to: "public#blog_with_newsletter"
+
+    get "/spotlight", to: "home/spotlight#show"
+    get "/shuffle", to: "posts/shuffle#show"
+
+    get "/@:name", to: redirect("/%{name}")
+
+    get "/:name.rss", to: redirect(subdomain_redirect("/feed.xml")),
+        constraints: { name: /(?!rails|admin|app|api)[a-z0-9]+/i }, defaults: { format: :rss }
+
+    get "/:name(/*path)", to: redirect { |params, _req|
+      path = params[:path] ? "/#{params[:path]}" : "/"
+      subdomain_redirect(path).call(params, _req)
+    }, constraints: { name: /(?!rails|admin|app|api)[a-z0-9]+/i }
   end
 
   constraints(DomainConstraints.method(:api_domain?)) do
@@ -260,36 +291,6 @@ Rails.application.routes.draw do
 
     # Catch-all for unmatched routes on blog domains
     match "*path", to: "blogs/posts#not_found", via: :all
-  end
-
-  constraints(DomainConstraints.method(:default_domain?)) do
-    get "/sitemap.xml", to: "public#sitemap", as: :public_sitemap, format: :xml
-    get "/robots.txt", to: "public#robots", as: :robots, format: :text
-    get "/llms.txt", to: "public/llms#show", as: :llms_txt, format: :text
-    get "/terms", to: "public#terms", as: :terms
-    get "/privacy", to: "public#privacy", as: :privacy
-    get "/faq", to: "public#faq", as: :faq
-    get "/pagecord-vs-about-me", to: "public#pagecord_vs_about_me"
-    get "/pagecord-vs-medium", to: "public#pagecord_vs_medium"
-    get "/pagecord-vs-hey-world", to: "public#pagecord_vs_hey_world"
-    get "/pagecord-vs-wordpress", to: "public#pagecord_vs_wordpress"
-    get "/pagecord-vs-substack", to: "public#pagecord_vs_substack"
-    get "/minimalist-blogging", to: "public#minimalist_blogging"
-    get "/blogging-by-email", to: "public#blogging_by_email"
-    get "/blog-with-newsletter", to: "public#blog_with_newsletter"
-
-    get "/spotlight", to: "home/spotlight#show"
-    get "/shuffle", to: "posts/shuffle#show"
-
-    get "/@:name", to: redirect("/%{name}")
-
-    get "/:name.rss", to: redirect(subdomain_redirect("/feed.xml")),
-        constraints: { name: /(?!rails|admin|app|api)[a-z0-9]+/i }, defaults: { format: :rss }
-
-    get "/:name(/*path)", to: redirect { |params, _req|
-      path = params[:path] ? "/#{params[:path]}" : "/"
-      subdomain_redirect(path).call(params, _req)
-    }, constraints: { name: /(?!rails|admin|app|api)[a-z0-9]+/i }
   end
 
   direct :rails_public_blob do |blob|

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,6 +5,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   setup do
     Capybara.always_include_port = true
+    Capybara.app_host = "http://lvh.me:#{Capybara.current_session.server.port}"
   end
 
   def use_subdomain(subdomain, path = "/")

--- a/test/controllers/app/posts_controller_test.rb
+++ b/test/controllers/app/posts_controller_test.rb
@@ -404,13 +404,13 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "svg title", text: "Private post"
   end
 
-  test "app area should be inaccessible on custom domain" do
+  test "app area should not route on custom domain" do
     post = posts(:four)
     login_as post.blog.user
 
     get app_posts_url, headers: { "HOST" => post.blog.custom_domain }
 
-    assert_redirected_to root_url(host: post.blog.custom_domain)
+    assert_response :not_found
   end
 
   test "should preview draft post with blog layout" do

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -102,6 +102,76 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_equal post, assigns(:post)
   end
 
+  test "should treat app as a post slug on blog subdomains" do
+    post = @blog.posts.create!(
+      title: "App slug",
+      content: "This is a post at /app",
+      slug: "app",
+      status: :published,
+      published_at: Time.current
+    )
+
+    get "/app"
+
+    assert_response :success
+    assert_equal post, assigns(:post)
+  end
+
+  test "should treat login as a post slug on blog subdomains" do
+    post = @blog.posts.create!(
+      title: "Login slug",
+      content: "This is a post at /login",
+      slug: "login",
+      status: :published,
+      published_at: Time.current
+    )
+
+    get "/login"
+
+    assert_response :success
+    assert_equal post, assigns(:post)
+  end
+
+  test "should treat admin as a post slug on blog subdomains" do
+    post = @blog.posts.create!(
+      title: "Admin slug",
+      content: "This is a post at /admin",
+      slug: "admin",
+      status: :published,
+      published_at: Time.current
+    )
+
+    get "/admin"
+
+    assert_response :success
+    assert_equal post, assigns(:post)
+  end
+
+  test "should treat app as a post slug on custom domains" do
+    blog = blogs(:annie)
+    post = blog.posts.create!(
+      title: "Custom domain app slug",
+      content: "This is a custom domain post at /app",
+      slug: "app",
+      status: :published,
+      published_at: Time.current
+    )
+    host! blog.custom_domain
+
+    get "/app"
+
+    assert_response :success
+    assert_equal post, assigns(:post)
+  end
+
+  test "should return not found for app path on custom domains without matching slug" do
+    host! blogs(:annie).custom_domain
+
+    get "/app"
+
+    assert_response :not_found
+  end
+
   test "should render image attachments without action text wrappers on post show" do
     post = create_content_with_attachment(
       blog: @blog,

--- a/test/support/concerns/authenticated_test.rb
+++ b/test/support/concerns/authenticated_test.rb
@@ -3,9 +3,13 @@ module AuthenticatedTest
 
   def login_as(user)
     access_request = user.access_requests.create!
+    original_host = host
+
+    host! Rails.application.config.action_controller.default_url_options[:host]
 
     get verify_access_request_url(access_request.token_digest)
 
+    host! original_host
     Current.user = user
   end
 

--- a/test/system/autosave_test.rb
+++ b/test/system/autosave_test.rb
@@ -7,7 +7,7 @@ class AutosaveTest < ApplicationSystemTestCase
     @other_blog = users(:joel).blog
 
     access_request = @user.access_requests.create!
-    visit verify_access_request_url(token: access_request.token_digest)
+    visit verify_access_request_path(token: access_request.token_digest)
 
     assert_current_path app_posts_path
   end

--- a/test/system/navigation_items_test.rb
+++ b/test/system/navigation_items_test.rb
@@ -6,7 +6,7 @@ class NavigationItemsTest < ApplicationSystemTestCase
     @blog = @user.blog
 
     access_request = @user.access_requests.create!
-    visit verify_access_request_url(token: access_request.token_digest)
+    visit verify_access_request_path(token: access_request.token_digest)
 
     assert_current_path app_posts_path
   end

--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -5,7 +5,7 @@ class SearchTest < ApplicationSystemTestCase
     @user = users(:vivian)
     access_request = @user.access_requests.create!
 
-    visit verify_access_request_url(token: access_request.token_digest)
+    visit verify_access_request_path(access_request.token_digest)
 
     assert_current_path app_posts_path
 

--- a/test/system/user_sign_up_test.rb
+++ b/test/system/user_sign_up_test.rb
@@ -20,7 +20,7 @@ class SignUpTest < ApplicationSystemTestCase
     user = User.create!(email: "test@example.com", blog: blog = Blog.new(subdomain: "testuser"))
     user.access_requests.create!
 
-    visit verify_access_request_url(token: user.access_requests.last.token_digest)
+    visit verify_access_request_path(token: user.access_requests.last.token_digest)
 
     assert_current_path app_onboarding_path
   end


### PR DESCRIPTION
Summary:
- constrain app, admin, auth, and public routes to the default Pagecord domain
- allow blog/custom domains to treat /app, /login, and /admin as normal blog slugs
- update authentication test helper to verify access requests on the default host while preserving caller host

Tests:
- bin/rails test test/controllers/blogs/posts_controller_test.rb test/controllers/blogs/page_views_controller_test.rb test/controllers/app/posts_controller_test.rb test/controllers/sessions_controller_test.rb test/controllers/signups_controller_test.rb test/controllers/password_resets_controller_test.rb test/controllers/access_requests_controller_test.rb test/controllers/admin
- bundle exec rubocop config/routes.rb test/controllers/blogs/posts_controller_test.rb test/controllers/app/posts_controller_test.rb test/controllers/blogs/page_views_controller_test.rb test/support/concerns/authenticated_test.rb