### PR TITLE
Upgrade Lexxy to 0.9.12.beta

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 985e510db4331798e5bf43b892cef9ede7dca43f
+  revision: 9cc62ec2a5c4ac56f7571f05489da9d27c6df69d
   branch: main
   specs:
     actioncable (8.2.0.alpha)
@@ -261,7 +261,7 @@ GEM
       letter_opener (~> 1.9)
       railties (>= 6.1)
       rexml
-    lexxy (0.9.11.beta)
+    lexxy (0.9.12.beta)
       rails (>= 8.0.2)
     lint_roller (1.1.0)
     local_time (3.0.3)

--- a/app/assets/stylesheets/lexxy-editor-overrides.css
+++ b/app/assets/stylesheets/lexxy-editor-overrides.css
@@ -54,6 +54,8 @@ lexxy-editor {
 /* ================================== */
 
 lexxy-toolbar {
+  --lexxy-toolbar-button-size: 1.75lh;
+
   position: sticky;
   top: 0;
   z-index: 10;
@@ -69,7 +71,6 @@ lexxy-toolbar {
     background: var(--color-slate-100);
     color: var(--color-slate-800);
     border: none;
-    block-size: 1.75lh;
 
     svg path {
       fill: currentColor;
@@ -91,8 +92,23 @@ lexxy-toolbar {
     }
   }
 
-  .lexxy-editor__toolbar-dropdown[open] .lexxy-editor__toolbar-button:not([value="link"]):not([value="unlink"]) {
+  .lexxy-editor__toolbar-dropdown > .lexxy-editor__toolbar-button[aria-expanded="true"]:not([value="link"]):not([value="unlink"]) {
     background-color: var(--color-slate-300);
+  }
+
+  /* Lexxy 0.9.12 moved dropdown triggers from summary elements to buttons. */
+  .lexxy-editor__toolbar-dropdown .lexxy-editor__toolbar-button--chevron {
+    gap: 0.5ch;
+    grid-template-columns: auto auto;
+    min-inline-size: 0;
+
+    &::after {
+      box-sizing: content-box;
+    }
+  }
+
+  .lexxy-editor__toolbar-dropdown-list {
+    padding: var(--lexxy-toolbar-spacing);
   }
 }
 
@@ -150,7 +166,7 @@ lexxy-toolbar {
       }
     }
 
-    .lexxy-editor__toolbar-dropdown[open] .lexxy-editor__toolbar-button:not([value="link"]):not([value="unlink"]) {
+    .lexxy-editor__toolbar-dropdown > .lexxy-editor__toolbar-button[aria-expanded="true"]:not([value="link"]):not([value="unlink"]) {
       background-color: var(--color-slate-600);
     }
 
@@ -168,17 +184,12 @@ lexxy-toolbar {
 
 }
 
-/* Tailwind's border-box on ::after makes the 0.3ch chevron collapse into a dot */
-lexxy-toolbar .lexxy-editor__toolbar-dropdown--chevron summary::after {
-  box-sizing: content-box;
-}
-
 /* ================================== */
 /* Minimal Toolbar Buttons Hidden      */
 /* ================================== */
 .lexxy-minimal lexxy-toolbar {
-  button:is([name="quote"], [name="code"], [name="table"], [name="divider"], [name="image"], [name="file"]),
-  details:has(summary:is([name="format"], [name="lists"], [name="highlight"])) {
+  button:is([name="quote"], [name="code"], [name="table"], [name="divider"], [name="image"], [name="file"], [name="unordered-list"], [name="ordered-list"]),
+  :is(lexxy-toolbar-dropdown, lexxy-highlight-dropdown):has(> .lexxy-editor__toolbar-button:is([name="format"], [name="highlight"])) {
     display: none;
   }
 }
@@ -198,8 +209,10 @@ lexxy-highlight-dropdown button {
 }
 
 lexxy-link-dropdown {
-  max-inline-size: 48ch;
-  margin-inline: auto;
+  [data-dropdown-panel] {
+    max-inline-size: 48ch;
+    margin-inline: auto;
+  }
 
   form {
     display: flex;
@@ -226,7 +239,6 @@ lexxy-link-dropdown {
   /* Shared styles for link/unlink buttons */
   button.lexxy-editor__toolbar-button:is([value="link"], [value="unlink"]) {
     aspect-ratio: auto;
-    block-size: 1.75lh;
     padding-inline: 1ch;
   }
 


### PR DESCRIPTION
## Summary
- Bump `lexxy` to `0.9.12.beta`
- Update CSS overrides to track the new toolbar markup:
  - dropdown triggers moved from `<details>/<summary>` to `<button aria-expanded>`
  - sets the new `--lexxy-toolbar-button-size` variable instead of hardcoding `block-size` on individual buttons
  - moves the chevron `box-sizing` fix onto `.lexxy-editor__toolbar-button--chevron`
- Fix minimal toolbar: hide the now top-level `unordered-list` / `ordered-list` buttons, and stop `lexxy-link-dropdown` from auto-centering itself in the toolbar (the wrapper now contains the trigger button, so `margin-inline: auto` was pushing the link button into the middle of the row)

## Test plan
- [ ] Full toolbar renders correctly in light + dark mode
- [ ] Format and highlight dropdowns open/close and highlight the trigger when open
- [ ] Link dropdown sits next to italic; panel still caps at 48ch and centers when open
- [ ] Minimal toolbar shows only **B I link | undo redo**