### PR TITLE
Allow admins to exclude blogs from the public spotlight

### DIFF
--- a/app/controllers/admin/spotlight_exclusions_controller.rb
+++ b/app/controllers/admin/spotlight_exclusions_controller.rb
@@ -1,0 +1,13 @@
+class Admin::SpotlightExclusionsController < AdminController
+  def create
+    user = User.find(params[:user_id])
+    user.blog.exclude_from_spotlight
+    redirect_to admin_user_path(user), notice: "Blog excluded from spotlight"
+  end
+
+  def destroy
+    user = User.find(params[:user_id])
+    user.blog.include_in_spotlight
+    redirect_to admin_user_path(user), notice: "Blog included in spotlight"
+  end
+end

--- a/app/controllers/home/spotlight_controller.rb
+++ b/app/controllers/home/spotlight_controller.rb
@@ -36,9 +36,6 @@ class Home::SpotlightController < ApplicationController
     end
 
     def spotlight_posts_scope
-      Post.visible.posts
-        .joins(blog: :user)
-        .where(blogs: { allow_search_indexing: true })
-        .where(users: { discarded_at: nil })
+      Post.visible.posts.joins(:blog).merge(Blog.spotlit)
     end
 end

--- a/app/controllers/posts/shuffle_controller.rb
+++ b/app/controllers/posts/shuffle_controller.rb
@@ -13,9 +13,7 @@ class Posts::ShuffleController < ApplicationController
 
     def random_post
       Post.visible.posts
-        .joins(blog: :user)
-        .where(blogs: { allow_search_indexing: true })
-        .where(users: { discarded_at: nil })
+        .joins(:blog).merge(Blog.spotlit)
         .where(posts: { published_at: 1.month.ago..2.hours.ago })
         .order("RANDOM()")
         .first

--- a/app/models/analytics/trending.rb
+++ b/app/models/analytics/trending.rb
@@ -15,9 +15,7 @@ class Analytics::Trending
     eligible_post_ids = view_counts.select { |_, count| count >= MIN_VIEWS }.keys
 
     Post.visible.posts
-      .joins(blog: :user)
-      .where(blogs: { allow_search_indexing: true })
-      .where(users: { discarded_at: nil })
+      .joins(:blog).merge(Blog.spotlit)
       .where(published_at: 14.days.ago..)
       .where("posts.locale = 'en' OR (posts.locale IS NULL AND blogs.locale = 'en')")
       .where(id: eligible_post_ids)

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -1,5 +1,5 @@
 class Blog < ApplicationRecord
-  include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, StorageTrackable, Blog::Contactable, Blog::ApiKey
+  include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, StorageTrackable, Blog::Contactable, Blog::ApiKey, Blog::Spotlit
 
   enum :layout, [ :stream_layout, :title_layout, :cards_layout ]
 

--- a/app/models/blog/spotlight_exclusion.rb
+++ b/app/models/blog/spotlight_exclusion.rb
@@ -1,0 +1,3 @@
+class Blog::SpotlightExclusion < ApplicationRecord
+  belongs_to :blog, touch: true
+end

--- a/app/models/concerns/blog/spotlit.rb
+++ b/app/models/concerns/blog/spotlit.rb
@@ -1,0 +1,26 @@
+module Blog::Spotlit
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :spotlight_exclusion, dependent: :destroy, class_name: "Blog::SpotlightExclusion"
+
+    scope :spotlit, -> {
+      joins(:user)
+        .where(allow_search_indexing: true)
+        .where(users: { discarded_at: nil })
+        .where.missing(:spotlight_exclusion)
+    }
+  end
+
+  def spotlit?
+    allow_search_indexing? && user.discarded_at.nil? && spotlight_exclusion.nil?
+  end
+
+  def exclude_from_spotlight
+    create_spotlight_exclusion! unless spotlight_exclusion
+  end
+
+  def include_in_spotlight
+    spotlight_exclusion&.destroy
+  end
+end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -179,6 +179,16 @@
         <dt class="font-medium text-slate-900 dark:text-slate-50">Theme</dt>
         <dd class="text-slate-500 dark:text-slate-400"><%= @user.blog.theme %> · <%= @user.blog.width %> · <%= @user.blog.font %></dd>
       </div>
+      <div class="flex justify-between gap-4 items-center">
+        <dt class="font-medium text-slate-900 dark:text-slate-50">Spotlight</dt>
+        <dd>
+          <% if @user.blog.spotlight_exclusion %>
+            <%= button_to "Include in spotlight", admin_user_spotlight_exclusion_path(@user), method: :delete, class: "btn-optional text-xs" %>
+          <% else %>
+            <%= button_to "Exclude from spotlight", admin_user_spotlight_exclusion_path(@user), method: :post, class: "btn-optional text-xs" %>
+          <% end %>
+        </dd>
+      </div>
     </dl>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,7 @@ Rails.application.routes.draw do
         end
         resource :subscription, only: [ :update ]
         resource :verification_email, only: [ :create ]
+        resource :spotlight_exclusion, only: [ :create, :destroy ]
       end
       namespace :moderation do
         root to: redirect("/admin/moderation/spam")

--- a/db/migrate/20260522120000_create_blog_spotlight_exclusions.rb
+++ b/db/migrate/20260522120000_create_blog_spotlight_exclusions.rb
@@ -1,0 +1,8 @@
+class CreateBlogSpotlightExclusions < ActiveRecord::Migration[8.2]
+  def change
+    create_table :blog_spotlight_exclusions do |t|
+      t.references :blog, null: false, foreign_key: true, index: { unique: true }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_18_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -82,6 +82,13 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_18_120000) do
     t.integer "format", default: 0, null: false
     t.integer "status", default: 0
     t.datetime "updated_at", null: false
+  end
+
+  create_table "blog_spotlight_exclusions", force: :cascade do |t|
+    t.bigint "blog_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["blog_id"], name: "index_blog_spotlight_exclusions_on_blog_id", unique: true
   end
 
   create_table "blogs", force: :cascade do |t|
@@ -446,6 +453,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_18_120000) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blog_exports", "blogs"
+  add_foreign_key "blog_spotlight_exclusions", "blogs"
   add_foreign_key "blogs", "posts", column: "home_page_id", on_delete: :nullify
   add_foreign_key "blogs", "users"
   add_foreign_key "contact_messages", "blogs"

--- a/test/controllers/admin/spotlight_exclusions_controller_test.rb
+++ b/test/controllers/admin/spotlight_exclusions_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Admin::SpotlightExclusionsControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  setup do
+    login_as users(:joel)
+    @user = users(:elliot)
+  end
+
+  test "create excludes the blog from spotlight" do
+    assert @user.blog.spotlit?
+
+    post admin_user_spotlight_exclusion_url(@user)
+
+    assert_redirected_to admin_user_path(@user)
+    assert_not @user.blog.reload.spotlit?
+  end
+
+  test "destroy includes the blog back in spotlight" do
+    @user.blog.exclude_from_spotlight
+
+    delete admin_user_spotlight_exclusion_url(@user)
+
+    assert_redirected_to admin_user_path(@user)
+    assert @user.blog.reload.spotlit?
+  end
+end

--- a/test/controllers/home/spotlight_controller_test.rb
+++ b/test/controllers/home/spotlight_controller_test.rb
@@ -32,24 +32,14 @@ class Home::SpotlightControllerTest < ActionDispatch::IntegrationTest
     assert_select "nav a.bg-slate-900", "Trending"
   end
 
-  test "excludes blogs with search indexing disabled from recent" do
+  test "excludes blogs that aren't spotlit from recent" do
     blog = blogs(:joel)
-    blog.update!(allow_search_indexing: false)
+    blog.exclude_from_spotlight
 
     get spotlight_path(tab: "recent")
 
     assert_response :success
     assert_no_match blog.subdomain, response.body
-  end
-
-  test "excludes posts from discarded users from recent" do
-    user = users(:elliot)
-    user.discard!
-
-    get spotlight_path(tab: "recent")
-
-    assert_response :success
-    assert_no_match user.blog.subdomain, response.body
   end
 
   test "excludes posts published within the last 15 minutes from recent" do

--- a/test/controllers/posts/shuffle_controller_test.rb
+++ b/test/controllers/posts/shuffle_controller_test.rb
@@ -20,20 +20,12 @@ class Posts::ShuffleControllerTest < ActionDispatch::IntegrationTest
     refute_match %r{/#{page.slug}$}, response.location
   end
 
-  test "should exclude blogs with search indexing disabled" do
+  test "should exclude blogs that aren't spotlit" do
     blog = blogs(:joel)
-    blog.update!(allow_search_indexing: false)
+    blog.exclude_from_spotlight
 
     get shuffle_path
     refute_match /#{blog.subdomain}\./, response.location
-  end
-
-  test "should exclude posts from discarded users" do
-    user = users(:joel)
-    user.discard!
-
-    get shuffle_path
-    refute_match /#{user.blog.subdomain}\./, response.location
   end
 
   test "should exclude posts published within the last 2 hours" do

--- a/test/models/blog/spotlit_test.rb
+++ b/test/models/blog/spotlit_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class Blog::SpotlitTest < ActiveSupport::TestCase
+  setup do
+    @blog = blogs(:joel)
+  end
+
+  test "blogs are spotlit by default" do
+    assert @blog.spotlit?
+    assert_includes Blog.spotlit, @blog
+  end
+
+  test "excludes blogs with search indexing disabled" do
+    @blog.update!(allow_search_indexing: false)
+
+    assert_not @blog.spotlit?
+    assert_not_includes Blog.spotlit, @blog
+  end
+
+  test "excludes blogs whose user is discarded" do
+    @blog.user.discard!
+
+    assert_not @blog.reload.spotlit?
+    assert_not_includes Blog.spotlit, @blog
+  end
+
+  test "excludes blogs with a spotlight_exclusion" do
+    @blog.exclude_from_spotlight
+
+    assert_not @blog.spotlit?
+    assert_not_includes Blog.spotlit, @blog
+  end
+
+  test "exclude_from_spotlight is idempotent" do
+    @blog.exclude_from_spotlight
+    @blog.exclude_from_spotlight
+
+    assert_equal 1, Blog::SpotlightExclusion.where(blog: @blog).count
+  end
+
+  test "include_in_spotlight removes the exclusion" do
+    @blog.exclude_from_spotlight
+    assert_not @blog.spotlit?
+
+    @blog.include_in_spotlight
+
+    assert @blog.reload.spotlit?
+    assert_nil @blog.spotlight_exclusion
+  end
+
+  test "include_in_spotlight is a no-op when not excluded" do
+    assert_nothing_raised { @blog.include_in_spotlight }
+  end
+end


### PR DESCRIPTION
## Summary
- Introduces `Blog::SpotlightExclusion` — presence on a blog means it's excluded from the public spotlight, trending feed, and shuffle. Inspired by Basecamp's `Card::Goldness` / `Card::Golden` pattern.
- New `Blog::Spotlit` concern centralises the eligibility rule (`allow_search_indexing`, user not discarded, no `spotlight_exclusion`) behind a single `Blog.spotlit` scope and a `spotlit?` predicate. Spotlight, trending, and shuffle queries now share it via `.joins(:blog).merge(Blog.spotlit)`.
- Admin can toggle exclusion for a blog from the admin user show page.

## Test plan
- [x] `bin/rails test test/models/blog/spotlit_test.rb` — covers scope, predicate, idempotent exclude, include no-op
- [x] `bin/rails test test/controllers/admin/spotlight_exclusions_controller_test.rb` — create/destroy round-trip
- [x] Smoke tests in spotlight + shuffle controller specs confirm the scope is wired in
- [ ] Manual: visit `/admin/users/:id`, toggle "Exclude from spotlight", verify blog disappears from /spotlight and /shuffle