### PR TITLE
Add contextual help dialogs

### DIFF
--- a/.codex/skills/sentry/SKILL.md
+++ b/.codex/skills/sentry/SKILL.md
@@ -16,6 +16,6 @@ description: Investigate and fix a Sentry issue in this codebase. Use when the u
 
 ## Git and output
 
-- Create a branch named `fix/sentry-{issue-id}` when starting an implementation task.
+- Create a branch named `sentry-{issue-id}` when starting an implementation task.
 - Summarize the issue, cause, fix, and verification.
 - If the user wants a PR and GitHub tooling is available, prepare one with a short factual summary and a clear test plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Ruby on Rails blogging app (Pagecord). Ruby, CSS, YAML, JavaScript.
 
 ## Git Commits
 
+- Use plain branch names without category prefixes (for example `help-dialogs`, not `feature/help-dialogs` or `fix/help-dialogs`)
 - **NEVER** add "Co-Authored-By", "Generated with Claude Code", or any AI attribution to commit messages, PR descriptions, or code comments. This is a hard rule — no exceptions.
 - Ask for human review before committing generated code
 

--- a/app/assets/images/icons/information-circle.svg
+++ b/app/assets/images/icons/information-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"/>
+</svg>

--- a/app/javascript/controllers/dialog_controller.js
+++ b/app/javascript/controllers/dialog_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["dialog"]
+  static values = {
+    shortcut: String
+  }
+
+  open() {
+    this.dialogTarget.showModal()
+  }
+
+  close() {
+    this.dialogTarget.close()
+  }
+
+  closeOnBackdrop(event) {
+    if (event.target === this.dialogTarget) this.close()
+  }
+
+  openFromShortcut(event) {
+    if (event.defaultPrevented) return
+    if (!this.hasShortcutValue || this.typingTarget(event.target) || !this.matchesShortcut(event)) return
+    if (event.metaKey || event.ctrlKey || event.altKey) return
+
+    event.preventDefault()
+    if (!this.dialogTarget.open) this.open()
+  }
+
+  matchesShortcut(event) {
+    return this.shortcutValue === "?" ? (event.key === "?" || (event.key === "/" && event.shiftKey)) : event.key === this.shortcutValue
+  }
+
+  typingTarget(target) {
+    return target.closest("input, textarea, select, [contenteditable='true'], lexxy-editor, trix-editor")
+  }
+}

--- a/app/views/app/home_pages/_form.html.erb
+++ b/app/views/app/home_pages/_form.html.erb
@@ -5,26 +5,30 @@
 
   <div class="mb-4"><%= trial_callout("Image uploads") %></div>
 
-  <% if Current.user.has_premium_access? %>
-  <div class="flex justify-end mb-4" data-controller="toggle">
-    <%= link_to "#", class: "ms-3 font-medium text-slate-500 hover:text-black dark:text-slate-300 dark:hover:text-slate-50", data: { action: "click->toggle#toggle click@window->toggle#hide" } do %>
-      <%= inline_svg_tag "icons/ellipsis-horizontal-circle.svg", class: "w-7 h-7" %>
-    <% end %>
-    <div class="relative hidden" data-toggle-target="element">
-      <div class="absolute end-0 w-56 rounded-md border border-gray-100 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-lg z-100" role="menu">
-        <div class="py-2 px-1">
-          <div class="p-1">
-            <%= link_to "#", class: "flex justify-between items-center rounded-lg px-2 py-1 text-sm text-gray-500 dark:text-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-50",
-              data: { action: "click->post-attributes#toggle", toggle_target: "og-image" } do %>
-              <span class="ms-1">Open Graph Image</span>
-              <span class="hidden md:inline text-xs text-gray-400 dark:text-gray-500">G</span>
-            <% end %>
+  <div class="mb-4 flex items-center justify-end gap-x-2">
+    <%= render "app/shared/help/edit_page" %>
+
+    <% if Current.user.has_premium_access? %>
+      <div data-controller="toggle">
+        <%= link_to "#", class: "inline-flex h-7 w-7 items-center justify-center text-slate-500 hover:text-black dark:text-slate-300 dark:hover:text-slate-50", data: { action: "click->toggle#toggle click@window->toggle#hide" } do %>
+          <%= inline_svg_tag "icons/ellipsis-horizontal-circle.svg", class: "w-7 h-7" %>
+        <% end %>
+        <div class="relative hidden" data-toggle-target="element">
+          <div class="absolute end-0 w-56 rounded-md border border-gray-100 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-lg z-100" role="menu">
+            <div class="py-2 px-1">
+              <div class="p-1">
+                <%= link_to "#", class: "flex justify-between items-center rounded-lg px-2 py-1 text-sm text-gray-500 dark:text-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:hover:bg-gray-600 dark:hover:text-gray-50",
+                  data: { action: "click->post-attributes#toggle", toggle_target: "og-image" } do %>
+                  <span class="ms-1">Open Graph Image</span>
+                  <span class="hidden md:inline text-xs text-gray-400 dark:text-gray-500">G</span>
+                <% end %>
+              </div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    <% end %>
   </div>
-  <% end %>
 
   <%= form_with(model: home_page, url: home_page.persisted? ? app_home_page_path : app_home_page_path, method: home_page.persisted? ? :patch : :post, html: { id: "homepage-form" }) do |form| %>
     <%= hidden_field_tag :context_blog_id, Current.user.blog.id unless home_page.persisted? %>

--- a/app/views/app/pages/_form.html.erb
+++ b/app/views/app/pages/_form.html.erb
@@ -7,12 +7,13 @@
 
   <div class="mb-4"><%= trial_callout("Image uploads") %></div>
 
-  <div class="flex justify-end mb-4" data-controller="toggle">
-    <%= link_to "#", class: "ms-3 font-medium text-slate-500 hover:text-black dark:text-slate-300 dark:hover:text-slate-50", data: { action: "click->toggle#toggle click@window->toggle#hide" } do %>
-        <div class="">
+  <div class="mb-4 flex items-center justify-end gap-x-2">
+    <%= render "app/shared/help/edit_page" %>
+
+    <div data-controller="toggle">
+      <%= link_to "#", class: "inline-flex h-7 w-7 items-center justify-center text-slate-500 hover:text-black dark:text-slate-300 dark:hover:text-slate-50", data: { action: "click->toggle#toggle click@window->toggle#hide" } do %>
           <%= inline_svg_tag "icons/ellipsis-horizontal-circle.svg", class: "w-7 h-7" %>
-        </div>
-      <% end %>
+        <% end %>
 
       <div class="relative hidden" data-toggle-target="element">
         <div class="absolute end-0 w-56 rounded-md border border-gray-100 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-lg z-100" role="menu">
@@ -63,6 +64,7 @@
           </div>
         </div>
       </div>
+    </div>
   </div>
 
   <%= form_with(model: @page, url: @page.persisted? ? app_page_path(@page) : app_pages_path, html: { id: "page-form" }) do |form| %>

--- a/app/views/app/settings/navigation_items/index.html.erb
+++ b/app/views/app/settings/navigation_items/index.html.erb
@@ -1,9 +1,20 @@
 <div class="mx-auto max-w-2xl w-full text-slate-950 dark:text-slate-50">
   <div class="my-8">
-    <h2 class="text-2xl font-bold mb-2">Navigation</h2>
-    <p class="mb-8">
-      Manage the links in your blog's header. Drag to reorder.
-    </p>
+    <div class="mb-2 flex items-start justify-between gap-4">
+      <div>
+        <h2 class="text-2xl font-bold">Navigation</h2>
+        <p class="mt-2">
+          Manage the links in your blog's header. Drag to reorder.
+        </p>
+      </div>
+
+      <%= render "app/shared/dialog",
+        id: "navigation-help",
+        title: "Navigation Quick Start",
+        button_label: "Navigation help",
+        shortcut: "?",
+        content_partial: "app/shared/help/navigation_content" %>
+    </div>
 
     <% if @navigation_items.any? %>
       <div class="border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden"

--- a/app/views/app/shared/_dialog.html.erb
+++ b/app/views/app/shared/_dialog.html.erb
@@ -1,0 +1,41 @@
+<%
+  dialog_id = local_assigns.fetch(:id)
+  title_id = "#{dialog_id}-title"
+  shortcut = local_assigns[:shortcut]
+  button_label = local_assigns.fetch(:button_label, title)
+  button_title = shortcut.present? ? "#{button_label} (#{shortcut})" : button_label
+  dialog_data = { controller: "dialog" }
+  dialog_data[:dialog_shortcut_value] = shortcut if shortcut.present?
+  wrapper_options = { data: dialog_data }
+  wrapper_options[:data][:action] = "keydown@document->dialog#openFromShortcut" if shortcut.present?
+%>
+
+<%= tag.div(**wrapper_options) do %>
+  <button type="button"
+          class="inline-flex h-7 w-7 cursor-pointer items-center justify-center text-slate-500 hover:text-black dark:text-slate-300 dark:hover:text-slate-50"
+          title="<%= button_title %>"
+          aria-label="<%= button_label %>"
+          data-action="dialog#open">
+    <%= inline_svg_tag "icons/information-circle.svg", class: "w-7 h-7" %>
+  </button>
+
+  <dialog class="fixed inset-0 m-auto max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg overflow-y-auto rounded-lg border border-slate-200 bg-white p-0 text-slate-900 shadow-xl backdrop:bg-slate-950/50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+          aria-labelledby="<%= title_id %>"
+          data-dialog-target="dialog"
+          data-action="click->dialog#closeOnBackdrop">
+    <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-700">
+      <h2 id="<%= title_id %>" class="text-base font-semibold"><%= title %></h2>
+      <button type="button"
+              class="cursor-pointer rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+              title="Close"
+              aria-label="Close"
+              data-action="dialog#close">
+        <%= inline_svg_tag "icons/close.svg", class: "h-5 w-5" %>
+      </button>
+    </div>
+
+    <div class="space-y-5 px-5 py-5">
+      <%= render content_partial %>
+    </div>
+  </dialog>
+<% end %>

--- a/app/views/app/shared/help/_edit_page.html.erb
+++ b/app/views/app/shared/help/_edit_page.html.erb
@@ -1,0 +1,6 @@
+<%= render "app/shared/dialog",
+  id: "page-composer-help",
+  title: "Quick Start Guide for Pages",
+  button_label: "Page ideas and help",
+  shortcut: "?",
+  content_partial: "app/shared/help/page_content" %>

--- a/app/views/app/shared/help/_navigation_content.html.erb
+++ b/app/views/app/shared/help/_navigation_content.html.erb
@@ -1,0 +1,30 @@
+<div>
+  <p class="text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Add links to your blog's header so readers can find their way around.
+  </p>
+</div>
+
+<div>
+  <h3 class="font-medium text-slate-900 dark:text-slate-100">Link to an existing page</h3>
+  <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Use this to link to About, Contact, Archive, and other published pages.
+  </p>
+</div>
+
+<div>
+  <h3 class="font-medium text-slate-900 dark:text-slate-100">Custom link</h3>
+  <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Use this for a link to <code class="rounded bg-slate-100 px-1 py-0.5 text-slate-800 dark:bg-slate-800 dark:text-slate-200">/posts</code> to show all your posts in your header, or for any external URL you want in your header.
+  </p>
+</div>
+
+<div>
+  <h3 class="font-medium text-slate-900 dark:text-slate-100">Social link</h3>
+  <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Use this for linking to your Mastodon, Bluesky, X, GitHub, RSS, or other social platforms.
+  </p>
+</div>
+
+<div>
+  <%= link_to "Full navigation help", "https://help.pagecord.com/setting-up-navigation", class: "text-sm font-medium underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:decoration-slate-600 dark:hover:decoration-slate-300", target: "_blank", rel: "noopener" %>
+</div>

--- a/app/views/app/shared/help/_page_content.html.erb
+++ b/app/views/app/shared/help/_page_content.html.erb
@@ -1,0 +1,38 @@
+<div>
+  <p class="text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Use <a href="https://help.pagecord.com/dynamic-variables-for-pages" class="font-medium text-slate-900 dark:text-slate-100 underline" target="_blank" rel="noopener noreferrer">dynamic variables</a> to add functionality to your pages. Here are some examples.
+  </p>
+</div>
+
+<div>
+  <h3 class="font-medium text-slate-900 dark:text-slate-100">Add a Contact form</h3>
+  <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Let your visitors send you messages without revealing your email address.
+  </p>
+  <div class="mt-2 inline-flex rounded-md bg-slate-100 px-2 py-1 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">{{ contact_form }}</div>
+  <div class="mt-2">
+    <%= link_to "Contact form help", "https://help.pagecord.com/contact-form", class: "text-sm font-medium underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:decoration-slate-600 dark:hover:decoration-slate-300", target: "_blank", rel: "noopener" %>
+  </div>
+</div>
+
+<div>
+  <h3 class="font-medium text-slate-900 dark:text-slate-100">Show recent posts</h3>
+  <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Useful on a custom home page.
+  </p>
+  <div class="mt-2 inline-flex rounded-md bg-slate-100 px-2 py-1 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">{{ posts | limit: 5 }}</div>
+  <div class="mt-2">
+    <%= link_to "See the recent posts example", "https://help.pagecord.com/dynamic-variables-for-pages#recent-posts-on-your-home-page", class: "text-sm font-medium underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:decoration-slate-600 dark:hover:decoration-slate-300", target: "_blank", rel: "noopener" %>
+  </div>
+</div>
+
+<div>
+  <h3 class="font-medium text-slate-900 dark:text-slate-100">Make an Archive page</h3>
+  <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Render a list of all your posts grouped by year.
+  </p>
+  <div class="mt-2 inline-flex rounded-md bg-slate-100 px-2 py-1 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">{{ posts_by_year }}</div>
+  <div class="mt-2">
+    <%= link_to "Archive help", "https://help.pagecord.com/dynamic-variables-for-pages#posts-by-year", class: "text-sm font-medium underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:decoration-slate-600 dark:hover:decoration-slate-300", target: "_blank", rel: "noopener" %>
+  </div>
+</div>

--- a/docs/help-guide/contact-form.md
+++ b/docs/help-guide/contact-form.md
@@ -16,6 +16,8 @@ Contact forms are embedded using a dynamic variable on a [page](creating-pages.m
 {{ contact_form }}
 ```
 
+Paste it directly into the page content. Don't wrap it in a code block inside the editor – that will display it as literal text instead of rendering the form.
+
 The form asks the reader for their name, email address, and a message.
 
 ## How it works

--- a/docs/help-guide/dynamic-variables-for-pages.md
+++ b/docs/help-guide/dynamic-variables-for-pages.md
@@ -264,6 +264,8 @@ Embed a contact form so readers can send you a message directly from your blog.
 
 _Note: This is a premium feature and only appears for subscribers and users on a free trial._
 
+_Paste it directly into the page content, not inside a code block in the editor._
+
 ## Examples
 
 ### Simple Archive Page

--- a/docs/help-guide/setting-up-navigation.md
+++ b/docs/help-guide/setting-up-navigation.md
@@ -23,7 +23,7 @@ Links to one of your published pages. The label is automatically set to the page
 
 A manual link with your own label and URL. Use this for:
 
-- A link to `/posts` (your full post list)
+- A link to `/posts` (all your posts)
 - External links (e.g., your portfolio or shop)
 - Any URL you want
 
@@ -57,4 +57,3 @@ Drag items to change their order. The order you see in settings is the order the
 ## Removing navigation items
 
 Click the trash icon next to any navigation item to remove it.
-

--- a/test/controllers/app/home_pages_controller_test.rb
+++ b/test/controllers/app/home_pages_controller_test.rb
@@ -15,6 +15,10 @@ class App::HomePagesControllerTest < ActionDispatch::IntegrationTest
   test "should get new" do
     get new_app_home_page_url
     assert_response :success
+    assert_select "button[aria-label='Page ideas and help']"
+    assert_includes response.body, "{{ posts | limit: 5 }}"
+    assert_includes response.body, "https://help.pagecord.com/dynamic-variables-for-pages#recent-posts-on-your-home-page"
+    assert_includes response.body, "https://help.pagecord.com/dynamic-variables-for-pages#posts-by-year"
   end
 
   # Create action
@@ -82,6 +86,7 @@ class App::HomePagesControllerTest < ActionDispatch::IntegrationTest
 
     get edit_app_home_page_url
     assert_response :success
+    assert_select "button[aria-label='Page ideas and help']"
   end
 
   test "should redirect to new when home page does not exist" do

--- a/test/controllers/app/pages_controller_test.rb
+++ b/test/controllers/app/pages_controller_test.rb
@@ -41,6 +41,12 @@ class App::PagesControllerTest < ActionDispatch::IntegrationTest
   test "should get new" do
     get new_app_page_path
     assert_response :success
+    assert_select "button[aria-label='Page ideas and help']"
+    assert_select "[data-dialog-shortcut-value='?']"
+    assert_includes response.body, "{{ contact_form }}"
+    assert_includes response.body, "{{ posts_by_year }}"
+    assert_includes response.body, "https://help.pagecord.com/dynamic-variables-for-pages#recent-posts-on-your-home-page"
+    assert_includes response.body, "https://help.pagecord.com/dynamic-variables-for-pages#posts-by-year"
   end
 
   test "should create page" do
@@ -79,6 +85,7 @@ class App::PagesControllerTest < ActionDispatch::IntegrationTest
   test "should get edit" do
     get edit_app_page_path(@page)
     assert_response :success
+    assert_select "button[aria-label='Page ideas and help']"
   end
 
   test "should not create page when form blog context does not match session blog" do

--- a/test/controllers/app/posts_controller_test.rb
+++ b/test/controllers/app/posts_controller_test.rb
@@ -18,6 +18,7 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
         assert_equal "Save Draft", elements.first.text.strip
       end
     end
+    assert_select "button[aria-label='Page ideas and help']", false
   end
 
   test "should get root" do

--- a/test/controllers/app/settings/navigation_items_controller_test.rb
+++ b/test/controllers/app/settings/navigation_items_controller_test.rb
@@ -13,6 +13,9 @@ class App::Settings::NavigationItemsControllerTest < ActionDispatch::Integration
     get app_settings_navigation_items_path
     assert_response :success
     assert_select "h2", "Navigation"
+    assert_select "button[aria-label='Navigation help']"
+    assert_select "[data-dialog-shortcut-value='?']"
+    assert_includes response.body, "/posts"
   end
 
   test "index shows pages dropdown without home page" do


### PR DESCRIPTION
## Summary
- add a reusable app dialog shell with optional keyboard shortcut support
- surface page dynamic-variable examples on Page/Home Page editors
- add navigation help to Navigation settings and clarify related help docs

## Tests
- bin/rails test test/controllers/app/pages_controller_test.rb test/controllers/app/home_pages_controller_test.rb test/controllers/app/settings/navigation_items_controller_test.rb test/controllers/app/posts_controller_test.rb
- bundle exec rubocop test/controllers/app/pages_controller_test.rb test/controllers/app/home_pages_controller_test.rb test/controllers/app/settings/navigation_items_controller_test.rb test/controllers/app/posts_controller_test.rb