### PR TITLE
Speed up analytics chart aggregation

### DIFF
--- a/app/models/analytics/chart.rb
+++ b/app/models/analytics/chart.rb
@@ -74,14 +74,7 @@ class Analytics::Chart < Analytics::Base
       start_time_utc = start_date.in_time_zone(user_timezone).beginning_of_day.utc
       end_time_utc = end_date.in_time_zone(user_timezone).end_of_day.utc
 
-      page_views = blog.page_views.where(viewed_at: start_time_utc..end_time_utc, is_unique: true)
-
-      unique_views_by_day = Hash.new(0)
-
-      page_views.find_each do |page_view|
-        day_key = page_view.viewed_at.in_time_zone(user_timezone).to_date
-        unique_views_by_day[day_key] += 1
-      end
+      unique_views_by_day = page_view_counts_by_day(start_time_utc, end_time_utc)
 
       (start_date..end_date).map do |day|
         {
@@ -105,15 +98,7 @@ class Analytics::Chart < Analytics::Base
         dimensions: { blog_id: blog.id }
       ).group(:time).sum(:value)
 
-      # Get raw page views for the entire year to handle months without rollups
-      all_page_views = blog.page_views.where(viewed_at: start_time_utc..end_time_utc, is_unique: true)
-
-      unique_views_by_month = Hash.new(0)
-
-      all_page_views.find_each do |page_view|
-        month_key = page_view.viewed_at.in_time_zone(user_timezone).beginning_of_month.to_date
-        unique_views_by_month[month_key] += 1
-      end
+      unique_views_by_month = page_view_counts_by_month([ start_time_utc, cutoff_time ].max, end_time_utc)
 
       (0..11).map do |month_offset|
         month_start = start_date.beginning_of_month + month_offset.months
@@ -134,6 +119,36 @@ class Analytics::Chart < Analytics::Base
           unique_page_views: unique_views
         }
       end
+    end
+
+    def page_view_counts_by_day(start_time, end_time)
+      page_view_counts_grouped_by(
+        "DATE(page_views.viewed_at AT TIME ZONE 'UTC' AT TIME ZONE ?)",
+        start_time,
+        end_time
+      )
+    end
+
+    def page_view_counts_by_month(start_time, end_time)
+      page_view_counts_grouped_by(
+        "DATE_TRUNC('month', page_views.viewed_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::date",
+        start_time,
+        end_time
+      )
+    end
+
+    def page_view_counts_grouped_by(group_sql, start_time, end_time)
+      group_expression = Arel.sql(PageView.sanitize_sql_array([ group_sql, database_timezone ]))
+
+      blog.page_views
+          .where(viewed_at: start_time..end_time, is_unique: true)
+          .group(group_expression)
+          .count
+          .transform_keys(&:to_date)
+    end
+
+    def database_timezone
+      ActiveSupport::TimeZone[user_timezone]&.tzinfo&.name || user_timezone
     end
 
     def year_chart_data_from_rollups(start_date, end_date)

--- a/test/models/analytics/chart_test.rb
+++ b/test/models/analytics/chart_test.rb
@@ -67,4 +67,44 @@ class Analytics::ChartTest < ActiveSupport::TestCase
     current_month_data = chart_data.find { |month| month[:date].month == recent_time.month }
     assert_equal 1, current_month_data[:unique_page_views]
   end
+
+  test "month chart groups raw page views in the user's timezone" do
+    chart = Analytics::Chart.new(@blog, "America/New_York")
+
+    PageView.create!(
+      blog: @blog,
+      visitor_hash: "new_york_late_visitor",
+      user_agent: "Test Browser",
+      is_unique: true,
+      viewed_at: Time.utc(2026, 5, 2, 3, 30)
+    )
+
+    chart_data = chart.chart_data("month", Date.new(2026, 5, 1), nil)
+
+    may_first = chart_data.find { |day| day[:date] == Date.new(2026, 5, 1) }
+    may_second = chart_data.find { |day| day[:date] == Date.new(2026, 5, 2) }
+
+    assert_equal 1, may_first[:unique_page_views]
+    assert_equal 0, may_second[:unique_page_views]
+  end
+
+  test "year chart groups raw page views by local month" do
+    chart = Analytics::Chart.new(@blog, "America/Los_Angeles")
+
+    PageView.create!(
+      blog: @blog,
+      visitor_hash: "los_angeles_month_visitor",
+      user_agent: "Test Browser",
+      is_unique: true,
+      viewed_at: Time.utc(2026, 6, 1, 6, 30)
+    )
+
+    chart_data = chart.chart_data("year", Date.new(2026, 1, 1), nil)
+
+    may = chart_data.find { |month| month[:date] == Date.new(2026, 5, 1) }
+    june = chart_data.find { |month| month[:date] == Date.new(2026, 6, 1) }
+
+    assert_equal 1, may[:unique_page_views]
+    assert_equal 0, june[:unique_page_views]
+  end
 end


### PR DESCRIPTION
## Summary

- Groups raw analytics chart page views in PostgreSQL instead of iterating through every `PageView` in Ruby.
- Keeps chart buckets in the user timezone for day and month boundaries.
- Adds regression coverage for local day/month grouping around UTC boundaries.

## Context

Yesterday's performance report showed `App::AnalyticsController#index` requests for the app taking 8-11s with 108-116 SQL queries. The likely affected account is `bytehaven.pagecord.com` / `blog.ppb1701.com`, which has about 92k raw unique page views since 2026-05-01. The old chart path used `find_each`, so it batched through those rows just to count chart buckets.

## Risk

Moderate: this changes analytics chart aggregation logic. The query window and output shape are unchanged, but the grouping now happens in SQL using PostgreSQL timezone conversion. Added tests cover local timezone day/month boundaries.

## Verification

```bash
bin/rails test test/models/analytics test/controllers/app/analytics_controller_test.rb
bundle exec rubocop app/models/analytics/chart.rb test/models/analytics/chart_test.rb
```

After deploy, verify the affected account with:

```bash
RAILS_ENV=production bin/rails runner 'require "benchmark"; blog = Blog.find_by!(subdomain: "bytehaven"); chart = Analytics::Chart.new(blog, blog.user.timezone); queries = 0; callback = ->(*, payload) { queries += 1 unless payload[:name].in?(%w[SCHEMA CACHE]) }; elapsed = Benchmark.realtime { ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { chart.chart_data("year", Date.new(2026, 1, 1), nil) } }; puts "bytehaven analytics year chart: #{(elapsed * 1000).round}ms, #{queries} SQL queries"'
```
