### PR TITLE
Cache Bandcamp embed lookups

### DIFF
--- a/app/controllers/api/embeds_controller.rb
+++ b/app/controllers/api/embeds_controller.rb
@@ -6,6 +6,8 @@ class Api::EmbedsController < ApplicationController
 
   def bandcamp
     url = params[:url]
+    return render json: { error: "Invalid Bandcamp URL" }, status: :unprocessable_entity unless bandcamp_url?(url)
+
     embed_url = og_video_attribute(url)
 
     if embed_url
@@ -19,9 +21,18 @@ class Api::EmbedsController < ApplicationController
 
   private
 
+    def bandcamp_url?(url)
+      uri = URI.parse(url)
+      uri.is_a?(URI::HTTPS) && (uri.host == "bandcamp.com" || uri.host&.end_with?(".bandcamp.com"))
+    rescue URI::InvalidURIError
+      false
+    end
+
     def og_video_attribute(url)
-      doc = Nokogiri::HTML(URI.open(url))
-      meta_tag = doc.at("meta[property=\"og:video\"]")
-      meta_tag&.attr("content")
+      Rails.cache.fetch([ "bandcamp_embed", url ], expires_in: 7.days, race_condition_ttl: 10.seconds) do
+        doc = Nokogiri::HTML(URI.open(url, open_timeout: 2, read_timeout: 3))
+        meta_tag = doc.at("meta[property=\"og:video\"]")
+        meta_tag&.attr("content")
+      end
     end
 end

--- a/test/controllers/api/embeds_controller_test.rb
+++ b/test/controllers/api/embeds_controller_test.rb
@@ -5,6 +5,7 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @blog = blogs(:joel)
     host_subdomain! @blog.subdomain
+    Rails.cache.clear
   end
 
   test "should return embed URL when og:video found" do
@@ -17,9 +18,9 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
       </html>
     HTML
 
-    URI.stubs(:open).with("https://example.com/album").returns(StringIO.new(mock_html))
+    URI.stubs(:open).with(bandcamp_url, uri_open_options).returns(StringIO.new(mock_html))
 
-    post "/api/embeds/bandcamp", params: { url: "https://example.com/album" }
+    post "/api/embeds/bandcamp", params: { url: bandcamp_url }
 
     assert_response :success
     json_response = JSON.parse(response.body)
@@ -36,9 +37,9 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
       </html>
     HTML
 
-    URI.stubs(:open).with("https://example.com/album").returns(StringIO.new(mock_html))
+    URI.stubs(:open).with(bandcamp_url, uri_open_options).returns(StringIO.new(mock_html))
 
-    post "/api/embeds/bandcamp", params: { url: "https://example.com/album" }
+    post "/api/embeds/bandcamp", params: { url: bandcamp_url }
 
     assert_response :unprocessable_entity
     json_response = JSON.parse(response.body)
@@ -46,9 +47,9 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should handle network errors gracefully" do
-    URI.stubs(:open).with("https://example.com/album").raises(StandardError.new("Network error"))
+    URI.stubs(:open).with(bandcamp_url, uri_open_options).raises(StandardError.new("Network error"))
 
-    post "/api/embeds/bandcamp", params: { url: "https://example.com/album" }
+    post "/api/embeds/bandcamp", params: { url: bandcamp_url }
 
     assert_response :unprocessable_entity
     json_response = JSON.parse(response.body)
@@ -68,9 +69,9 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
       </html>
     HTML
 
-    URI.stubs(:open).with("https://example.com/album").returns(StringIO.new(mock_html))
+    URI.stubs(:open).with(bandcamp_url, uri_open_options).returns(StringIO.new(mock_html))
 
-    post "/api/embeds/bandcamp", params: { url: "https://example.com/album" }
+    post "/api/embeds/bandcamp", params: { url: bandcamp_url }
 
     assert_response :success
     json_response = JSON.parse(response.body)
@@ -79,17 +80,60 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
 
   test "should skip CSRF token verification" do
     # This test ensures the endpoint works without CSRF tokens (important for API endpoints)
-    URI.stubs(:open).with("https://example.com/album").returns(StringIO.new("<html></html>"))
+    URI.stubs(:open).with(bandcamp_url, uri_open_options).returns(StringIO.new("<html></html>"))
 
-    post "/api/embeds/bandcamp", params: { url: "https://example.com/album" }
+    post "/api/embeds/bandcamp", params: { url: bandcamp_url }
 
     # Should not get InvalidAuthenticityToken error
     assert_not_equal "ActionController::InvalidAuthenticityToken", response.body
   end
 
+  test "should cache resolved embed URLs" do
+    Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+
+    mock_html = <<~HTML
+      <html>
+        <head>
+          <meta property="og:video" content="https://bandcamp.com/EmbeddedPlayer/v=2/album=789/"/>
+        </head>
+      </html>
+    HTML
+
+    URI.expects(:open).once.with(bandcamp_url, uri_open_options).returns(StringIO.new(mock_html))
+
+    2.times do
+      post "/api/embeds/bandcamp", params: { url: bandcamp_url }
+
+      assert_response :success
+      json_response = JSON.parse(response.body)
+      assert_equal "https://bandcamp.com/EmbeddedPlayer/v=2/album=789/", json_response["embed_url"]
+    end
+  end
+
+  test "should reject non-Bandcamp URLs" do
+    URI.expects(:open).never
+
+    post "/api/embeds/bandcamp", params: { url: "https://example.com/album" }
+
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    assert_equal "Invalid Bandcamp URL", json_response["error"]
+  end
+
   private
 
-  def host_subdomain!(name)
-    host! "#{name}.#{Rails.application.config.x.domain}"
-  end
+    def host_subdomain!(name)
+      host! "#{name}.#{Rails.application.config.x.domain}"
+    end
+
+    def bandcamp_url
+      "https://artist.bandcamp.com/album/example"
+    end
+
+    def uri_open_options
+      {
+        open_timeout: 2,
+        read_timeout: 3
+      }
+    end
 end


### PR DESCRIPTION
## Summary
- Cache resolved Bandcamp embed URLs for 7 days
- Add short open/read timeouts when fetching Bandcamp pages
- Reject non-Bandcamp URLs before attempting a server-side fetch

## Tests
- `bin/rails test test/controllers/api/embeds_controller_test.rb`
- `bundle exec rubocop app/controllers/api/embeds_controller.rb test/controllers/api/embeds_controller_test.rb`