### PR TITLE
Redirect lapsed custom domains to Pagecord URLs

### DIFF
--- a/app/controllers/blogs/base_controller.rb
+++ b/app/controllers/blogs/base_controller.rb
@@ -43,13 +43,14 @@ class Blogs::BaseController < ApplicationController
     end
 
     def enforce_custom_domain
-      redirect_from_default_domain || redirect_to_canonical_custom_domain
+      redirect_from_lapsed_custom_domain || redirect_from_default_domain || redirect_to_canonical_custom_domain
     end
 
     # Redirects requests from the default pagecord.com subdomain to the blog's custom domain
     # Example: joel.pagecord.com/about -> example.com/about
     def redirect_from_default_domain
       return false unless default_domain_request? && @blog.custom_domain.present?
+      return false unless @blog.user.custom_domain_access?
 
       escaped_subdomain = Regexp.escape(@blog.subdomain)
       request_path = request.path.gsub(/^\/@?#{escaped_subdomain}\/?/, "")
@@ -58,6 +59,15 @@ class Blogs::BaseController < ApplicationController
       request_path = request_path.sub(/^\//, "") if full_url.end_with?("/")
       new_url = "#{full_url}#{request_path}"
 
+      redirect_to new_url, status: :moved_permanently, allow_other_host: true
+      true
+    end
+
+    def redirect_from_lapsed_custom_domain
+      return false unless custom_domain_request? && @blog.custom_domain.present?
+      return false if @blog.user.custom_domain_access?
+
+      new_url = "#{request.protocol}#{@blog.subdomain}.#{Rails.application.config.x.domain}#{request.fullpath}"
       redirect_to new_url, status: :moved_permanently, allow_other_host: true
       true
     end

--- a/app/models/concerns/subscribable.rb
+++ b/app/models/concerns/subscribable.rb
@@ -2,6 +2,7 @@ module Subscribable
   extend ActiveSupport::Concern
 
   TRIAL_PERIOD_DAYS = 14
+  CUSTOM_DOMAIN_GRACE_PERIOD = 60.days
 
   included do
     has_one :subscription, dependent: :destroy
@@ -33,6 +34,10 @@ module Subscribable
 
   def lapsed?
     subscription&.lapsed?
+  end
+
+  def custom_domain_access?
+    subscribed? || subscription&.next_billed_at&.after?(CUSTOM_DOMAIN_GRACE_PERIOD.ago)
   end
 
   private

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -577,6 +577,28 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to "http://#{post.blog.custom_domain}/#{post.slug}"
   end
 
+  test "should not redirect from default domain to custom domain after grace period" do
+    @blog = blogs(:annie)
+    @blog.user.subscription.update!(next_billed_at: 61.days.ago)
+    host! "#{@blog.subdomain}.example.com"
+    post = @blog.posts.visible.first
+
+    get "/#{post.slug}"
+
+    assert_response :success
+  end
+
+  test "should redirect from lapsed custom domain to default domain after grace period" do
+    @blog = blogs(:annie)
+    @blog.user.subscription.update!(next_billed_at: 61.days.ago)
+    host! @blog.custom_domain
+    post = @blog.posts.visible.first
+
+    get "/#{post.slug}"
+
+    assert_redirected_to "http://#{@blog.subdomain}.example.com/#{post.slug}"
+  end
+
   test "should redirect from www variant to canonical custom domain" do
     @blog = blogs(:annie)
     @blog.update!(custom_domain: "example.blog")

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -82,4 +82,20 @@ class UserTest < ActiveSupport::TestCase
     user = User.create!(email: "trial@example.com", created_at: 5.days.ago)
     assert_not user.on_free_plan?
   end
+
+  test "custom_domain_access? allows active subscribers" do
+    assert users(:joel).custom_domain_access?
+  end
+
+  test "custom_domain_access? allows lapsed subscribers during grace period" do
+    users(:joel).subscription.update!(next_billed_at: 30.days.ago)
+
+    assert users(:joel).custom_domain_access?
+  end
+
+  test "custom_domain_access? rejects subscribers after grace period" do
+    users(:joel).subscription.update!(next_billed_at: 61.days.ago)
+
+    assert_not users(:joel).custom_domain_access?
+  end
 end


### PR DESCRIPTION
## Summary
- add a 60-day grace period for custom domain access after a subscription lapses
- stop redirecting Pagecord subdomain traffic to custom domains after grace expires
- redirect lapsed custom-domain traffic back to the blog's Pagecord subdomain

## Tests
- bin/rails test test/models/user_test.rb test/controllers/blogs/posts_controller_test.rb
- RUBOCOP_CACHE_ROOT=tmp/rubocop_cache bundle exec rubocop app/models/concerns/subscribable.rb app/controllers/blogs/base_controller.rb test/models/user_test.rb test/controllers/blogs/posts_controller_test.rb