### PR TITLE
Remove blog feature flags column

### DIFF
--- a/db/migrate/20260602130000_remove_features_from_blogs.rb
+++ b/db/migrate/20260602130000_remove_features_from_blogs.rb
@@ -1,0 +1,9 @@
+class RemoveFeaturesFromBlogs < ActiveRecord::Migration[8.2]
+  def up
+    remove_column :blogs, :features if column_exists?(:blogs, :features)
+  end
+
+  def down
+    add_column :blogs, :features, :string, array: true, default: [] unless column_exists?(:blogs, :features)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_02_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_02_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -110,7 +110,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_02_120000) do
     t.datetime "discarded_at"
     t.integer "email_delivery_mode", default: 0, null: false
     t.boolean "email_subscriptions_enabled", default: true, null: false
-    t.string "features", default: [], array: true
     t.string "fediverse_author_attribution"
     t.string "font", default: "sans", null: false
     t.string "google_site_verification"


### PR DESCRIPTION
## Summary

- remove the obsolete `features` column from `blogs`
- leave feature toggles on `users.features`, including the existing admin Features panel
- make the migration tolerant of databases where the column has already been removed

## Tests

- `bin/rails test test/controllers/admin/users_controller_test.rb test/controllers/app/posts_controller_test.rb`