### PR TITLE
Add experimental Standard.site support

### DIFF
--- a/app/controllers/app/settings/standard_site_controller.rb
+++ b/app/controllers/app/settings/standard_site_controller.rb
@@ -1,0 +1,50 @@
+class App::Settings::StandardSiteController < AppController
+  def show
+  end
+
+  def create
+    unless @blog.user.has_premium_access?
+      redirect_to app_settings_standard_site_path, alert: "Standard.site requires a premium subscription"
+      return
+    end
+
+    session = StandardSite::Client.connect(
+      handle: standard_site_params[:handle],
+      app_password: standard_site_params[:app_password],
+      pds_url: standard_site_params[:pds_url].presence || "https://bsky.social"
+    )
+
+    account = @blog.standard_site_account || @blog.build_standard_site_account
+    account.assign_attributes(
+      handle: session.fetch("handle", standard_site_params[:handle]),
+      did: session.fetch("did"),
+      pds_url: standard_site_params[:pds_url].presence || "https://bsky.social",
+      access_jwt: session.fetch("accessJwt"),
+      refresh_jwt: session.fetch("refreshJwt"),
+      connected_at: Time.current,
+      disconnected_at: nil
+    )
+    account.save!
+
+    @blog.standard_site_publication || @blog.create_standard_site_publication!
+    StandardSite::SyncPublicationJob.perform_later(@blog.id)
+
+    redirect_to app_settings_standard_site_path, notice: "Bluesky connected"
+  rescue StandardSite::Client::Error => e
+    redirect_to app_settings_standard_site_path, alert: "Could not connect Bluesky: #{e.message}"
+  end
+
+  def destroy
+    @blog.standard_site_account&.destroy
+    @blog.standard_site_publication&.destroy
+    StandardSite::Document.where(post: @blog.all_posts).destroy_all
+
+    redirect_to app_settings_standard_site_path, notice: "Bluesky disconnected"
+  end
+
+  private
+
+    def standard_site_params
+      params.require(:standard_site).permit(:handle, :app_password, :pds_url)
+    end
+end

--- a/app/controllers/blogs/standard_site_publications_controller.rb
+++ b/app/controllers/blogs/standard_site_publications_controller.rb
@@ -1,0 +1,11 @@
+class Blogs::StandardSitePublicationsController < Blogs::BaseController
+  def show
+    publication = @blog.standard_site_publication
+
+    if publication&.synced? && publication.at_uri.present?
+      render plain: publication.at_uri, content_type: "text/plain"
+    else
+      head :not_found
+    end
+  end
+end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -59,6 +59,16 @@ module BlogsHelper
     end
   end
 
+  def standard_site_publication_at_uri
+    publication = @blog&.standard_site_publication
+    publication.at_uri if publication&.synced?
+  end
+
+  def standard_site_document_at_uri
+    document = @post&.standard_site_document
+    document.at_uri if document&.synced?
+  end
+
   private
 
     def blog_description(blog)

--- a/app/jobs/standard_site/sync_document_job.rb
+++ b/app/jobs/standard_site/sync_document_job.rb
@@ -1,0 +1,11 @@
+class StandardSite::SyncDocumentJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(post_id)
+    post = Post.find(post_id)
+    return unless post.blog.standard_site_account&.connected?
+
+    document = post.standard_site_document || post.create_standard_site_document!
+    document.sync!
+  end
+end

--- a/app/jobs/standard_site/sync_publication_job.rb
+++ b/app/jobs/standard_site/sync_publication_job.rb
@@ -1,0 +1,17 @@
+class StandardSite::SyncPublicationJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(blog_id)
+    blog = Blog.find(blog_id)
+    return unless blog.standard_site_account&.connected?
+
+    publication = blog.standard_site_publication || blog.create_standard_site_publication!
+    publication.sync!
+
+    if publication.synced?
+      blog.all_posts.visible.find_each do |post|
+        StandardSite::SyncDocumentJob.perform_later(post.id)
+      end
+    end
+  end
+end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -23,6 +23,8 @@ class Blog < ApplicationRecord
   has_many :exports, class_name: "Blog::Export", dependent: :destroy
   has_many :page_views, dependent: :destroy
   has_one :spam_detection, dependent: :destroy
+  has_one :standard_site_account, class_name: "StandardSite::Account", dependent: :destroy
+  has_one :standard_site_publication, class_name: "StandardSite::Publication", dependent: :destroy
 
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [ 96, 96 ], format: :png
@@ -33,7 +35,7 @@ class Blog < ApplicationRecord
   validate :within_blog_limit, on: :create
 
   before_validation :downcase_subdomain
-  after_commit :purge_cloudflare_cache, on: :update
+  after_commit :purge_cloudflare_cache, :sync_standard_site_publication, on: :update
 
   validates :subdomain, presence: true, uniqueness: true, length: { minimum: Subdomain::MIN_LENGTH, maximum: Subdomain::MAX_LENGTH }
   validate  :subdomain_valid
@@ -91,5 +93,13 @@ class Blog < ApplicationRecord
       return unless Rails.env.production?
       return unless Rails.cache.write("cf_purge:#{id}", true, expires_in: 5.seconds, unless_exist: true)
       PurgeCloudflareCacheJob.perform_later(id)
+    end
+
+    def sync_standard_site_publication
+      return unless standard_site_account&.connected?
+      return unless standard_site_publication
+      return unless (previous_changes.keys & %w[allow_search_indexing custom_domain discarded_at subdomain title]).any?
+
+      StandardSite::SyncPublicationJob.perform_later(id)
     end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,6 +17,7 @@ class Post < ApplicationRecord
   has_many :replies, class_name: "Post::Reply", dependent: :destroy
   has_many :page_views, dependent: :destroy
   has_many :navigation_items, dependent: :destroy
+  has_one :standard_site_document, class_name: "StandardSite::Document", dependent: :destroy
 
   before_create :limit_content_size
   before_save :set_text_summary, :set_published_at
@@ -43,7 +44,7 @@ class Post < ApplicationRecord
       )
     }
   scope :for_blog_render, -> { with_full_rich_text.with_attached_attachments.includes(:upvotes) }
-  after_commit :touch_blog, on: [ :create, :update, :destroy ]
+  after_commit :touch_blog, :sync_standard_site_document, on: [ :create, :update, :destroy ]
 
   def content_present
     has_content = content.body.present? && content.body.to_plain_text.strip.present?
@@ -214,5 +215,11 @@ class Post < ApplicationRecord
     def touch_blog
       return unless published? || status_previously_changed?
       blog.touch unless blog.destroyed?
+    end
+
+    def sync_standard_site_document
+      return unless blog.standard_site_account&.connected?
+
+      StandardSite::SyncDocumentJob.perform_later(id)
     end
 end

--- a/app/models/standard_site.rb
+++ b/app/models/standard_site.rb
@@ -1,0 +1,4 @@
+module StandardSite
+  COLLECTION_PUBLICATION = "site.standard.publication"
+  COLLECTION_DOCUMENT = "site.standard.document"
+end

--- a/app/models/standard_site/account.rb
+++ b/app/models/standard_site/account.rb
@@ -1,0 +1,51 @@
+class StandardSite::Account < ApplicationRecord
+  self.table_name = "standard_site_accounts"
+
+  belongs_to :blog
+
+  validates :handle, :did, :pds_url, presence: true
+  validates :blog_id, uniqueness: true
+  validates :did, format: { with: /\Adid:[a-z0-9]+:[A-Za-z0-9._:%-]+\z/ }
+
+  normalizes :handle, with: ->(handle) { handle.to_s.delete_prefix("@").strip.downcase }
+  normalizes :pds_url, with: ->(url) { url.to_s.strip.delete_suffix("/") }
+
+  def connected?
+    disconnected_at.nil?
+  end
+
+  def access_jwt
+    decrypt(access_jwt_ciphertext)
+  end
+
+  def access_jwt=(value)
+    self.access_jwt_ciphertext = encrypt(value)
+  end
+
+  def refresh_jwt
+    decrypt(refresh_jwt_ciphertext)
+  end
+
+  def refresh_jwt=(value)
+    self.refresh_jwt_ciphertext = encrypt(value)
+  end
+
+  private
+
+    def encrypt(value)
+      return if value.blank?
+      crypt.encrypt_and_sign(value)
+    end
+
+    def decrypt(value)
+      return if value.blank?
+      crypt.decrypt_and_verify(value)
+    rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage
+      nil
+    end
+
+    def crypt
+      key = ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base).generate_key("standard-site-account", 32)
+      ActiveSupport::MessageEncryptor.new(key)
+    end
+end

--- a/app/models/standard_site/client.rb
+++ b/app/models/standard_site/client.rb
@@ -1,0 +1,79 @@
+require "httparty"
+
+class StandardSite::Client
+  class Error < StandardError; end
+
+  def self.connect(handle:, app_password:, pds_url: "https://bsky.social")
+    response = HTTParty.post(
+      "#{pds_url.delete_suffix("/")}/xrpc/com.atproto.server.createSession",
+      headers: { "Content-Type" => "application/json" },
+      body: {
+        identifier: handle.to_s.delete_prefix("@"),
+        password: app_password
+      }.to_json
+    )
+
+    raise Error, error_message(response) unless response.success?
+
+    response.parsed_response
+  end
+
+  def self.error_message(response)
+    body = response.parsed_response
+    body.is_a?(Hash) ? body["message"].presence || body["error"].presence || response.message : response.message
+  end
+
+  def initialize(account)
+    @account = account
+  end
+
+  def put_record(collection:, rkey:, record:)
+    response = put_record_request(collection: collection, rkey: rkey, record: record)
+    response = refresh_and_retry(collection: collection, rkey: rkey, record: record) if response.code == 401
+
+    raise Error, self.class.error_message(response) unless response.success?
+
+    response.parsed_response
+  end
+
+  private
+
+    def put_record_request(collection:, rkey:, record:)
+      HTTParty.post(
+        "#{@account.pds_url}/xrpc/com.atproto.repo.putRecord",
+        headers: {
+          "Authorization" => "Bearer #{@account.access_jwt}",
+          "Content-Type" => "application/json"
+        },
+        body: {
+          repo: @account.did,
+          collection: collection,
+          rkey: rkey,
+          record: record,
+          validate: true
+        }.to_json
+      )
+    end
+
+    def refresh_and_retry(collection:, rkey:, record:)
+      refresh_session
+      put_record_request(collection: collection, rkey: rkey, record: record)
+    end
+
+    def refresh_session
+      response = HTTParty.post(
+        "#{@account.pds_url}/xrpc/com.atproto.server.refreshSession",
+        headers: { "Authorization" => "Bearer #{@account.refresh_jwt}" }
+      )
+
+      raise Error, self.class.error_message(response) unless response.success?
+
+      session = response.parsed_response
+      @account.update!(
+        access_jwt: session.fetch("accessJwt"),
+        refresh_jwt: session.fetch("refreshJwt"),
+        handle: session.fetch("handle", @account.handle),
+        did: session.fetch("did", @account.did)
+      )
+    end
+end

--- a/app/models/standard_site/document.rb
+++ b/app/models/standard_site/document.rb
@@ -1,0 +1,73 @@
+class StandardSite::Document < ApplicationRecord
+  include Rails.application.routes.url_helpers
+  include RoutingHelper
+
+  self.table_name = "standard_site_documents"
+
+  belongs_to :post
+
+  enum :sync_status, { pending: 0, synced: 1, failed: 2, disabled: 3 }
+
+  validates :post_id, uniqueness: true
+  validates :rkey, presence: true
+  validates :at_uri, format: { with: %r{\Aat://did:[^/]+/site\.standard\.document/[^/]+\z} }, allow_blank: true
+
+  before_validation :set_rkey, on: :create
+
+  def record
+    publication = post.blog.standard_site_publication
+
+    {
+      "$type" => StandardSite::COLLECTION_DOCUMENT,
+      "site" => publication.at_uri,
+      "path" => post_path(post),
+      "title" => post.display_title,
+      "description" => post.summary(limit: 160),
+      "textContent" => post.plain_text_content.truncate(30_000, omission: ""),
+      "tags" => post.tag_list,
+      "publishedAt" => post.published_at&.utc&.iso8601(3),
+      "updatedAt" => post.updated_at.utc.iso8601(3)
+    }.compact
+  end
+
+  def sync!
+    return disable! unless syncable?
+
+    update!(sync_status: :pending, sync_error: nil)
+
+    result = StandardSite::Client.new(post.blog.standard_site_account).put_record(
+      collection: StandardSite::COLLECTION_DOCUMENT,
+      rkey: rkey,
+      record: record
+    )
+
+    update!(
+      at_uri: result.fetch("uri"),
+      cid: result.fetch("cid"),
+      sync_status: :synced,
+      last_synced_at: Time.current,
+      sync_error: nil
+    )
+  rescue StandardSite::Client::Error => e
+    update!(sync_status: :failed, sync_error: e.message)
+  end
+
+  def disable!
+    update!(sync_status: :disabled, sync_error: nil)
+  end
+
+  private
+
+    def set_rkey
+      self.rkey ||= post.token
+    end
+
+    def syncable?
+      post.kept? &&
+        post.published? &&
+        !post.pending? &&
+        !post.hidden? &&
+        post.published_at.present? &&
+        post.blog.standard_site_publication&.synced?
+    end
+end

--- a/app/models/standard_site/publication.rb
+++ b/app/models/standard_site/publication.rb
@@ -1,0 +1,56 @@
+class StandardSite::Publication < ApplicationRecord
+  include Rails.application.routes.url_helpers
+  include RoutingHelper
+
+  self.table_name = "standard_site_publications"
+
+  belongs_to :blog
+
+  enum :sync_status, { pending: 0, synced: 1, failed: 2, disabled: 3 }
+
+  validates :blog_id, uniqueness: true
+  validates :rkey, presence: true
+  validates :at_uri, format: { with: %r{\Aat://did:[^/]+/site\.standard\.publication/[^/]+\z} }, allow_blank: true
+
+  def record
+    {
+      "$type" => StandardSite::COLLECTION_PUBLICATION,
+      "url" => blog_home_url(blog).delete_suffix("/"),
+      "name" => blog.display_name,
+      "description" => description,
+      "preferences" => {
+        "showInDiscover" => blog.allow_search_indexing? && blog.user.search_indexable?
+      }
+    }.compact
+  end
+
+  def sync!
+    update!(sync_status: :pending, sync_error: nil)
+
+    result = StandardSite::Client.new(blog.standard_site_account).put_record(
+      collection: StandardSite::COLLECTION_PUBLICATION,
+      rkey: rkey,
+      record: record
+    )
+
+    update!(
+      at_uri: result.fetch("uri"),
+      cid: result.fetch("cid"),
+      sync_status: :synced,
+      last_synced_at: Time.current,
+      sync_error: nil
+    )
+  rescue StandardSite::Client::Error => e
+    update!(sync_status: :failed, sync_error: e.message)
+  end
+
+  private
+
+    def description
+      if blog.bio.present?
+        ActionView::Base.full_sanitizer.sanitize(blog.bio.to_s).squish.truncate(3000)
+      else
+        blog.display_name
+      end
+    end
+end

--- a/app/views/app/settings/index.html.erb
+++ b/app/views/app/settings/index.html.erb
@@ -70,6 +70,16 @@
       </div>
     <% end %>
 
+    <%= link_to app_settings_standard_site_path do %>
+      <div class="h-48 hover:bg-slate-100 dark:hover:bg-slate-700 hover:shadow-md border border-slate-200 dark:border-slate-600 p-5 rounded-lg">
+        <div class="mb-4">
+          <span class="text-4xl">🦋</span>
+        </div>
+        <h3 class="mb-2 text-xl font-bold dark:text-white">Bluesky</h3>
+        <p class="text-slate-500 dark:text-slate-400">Create Standard.site records for richer Bluesky previews</p>
+      </div>
+    <% end %>
+
     <%= link_to app_settings_account_edit_path do %>
       <div class="h-48 hover:bg-slate-100 dark:hover:bg-slate-700 hover:shadow-md border border-slate-200 dark:border-slate-600 p-5 rounded-lg">
         <div class="mb-4">

--- a/app/views/app/settings/standard_site/show.html.erb
+++ b/app/views/app/settings/standard_site/show.html.erb
@@ -1,0 +1,61 @@
+<h3 class="mb-2 font-bold text-xl">Bluesky / Standard.site</h3>
+
+<p class="text-slate-600 dark:text-slate-300">
+  Connect Bluesky so Pagecord can create Standard.site records for your posts. When someone shares a compatible Pagecord link on Bluesky, it can be rendered as a richer document preview.
+</p>
+
+<% unless @blog.user.has_premium_access? %>
+  <div class="mt-6">
+    <%= callout(:info) do %>
+      <%= link_to "Subscribe", app_settings_subscriptions_path, class: "underline font-medium" %> to use Standard.site.
+    <% end %>
+  </div>
+<% end %>
+
+<% if @blog.standard_site_account&.connected? %>
+  <div class="mt-6 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-6">
+    <p class="font-medium text-slate-900 dark:text-slate-100">Connected as <%= @blog.standard_site_account.handle %></p>
+    <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+      DID: <code class="rounded bg-white dark:bg-slate-900 px-1.5 py-0.5"><%= @blog.standard_site_account.did %></code>
+    </p>
+
+    <% if @blog.standard_site_publication&.at_uri.present? %>
+      <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        Publication: <code class="rounded bg-white dark:bg-slate-900 px-1.5 py-0.5"><%= @blog.standard_site_publication.at_uri %></code>
+      </p>
+    <% end %>
+
+    <% if @blog.standard_site_publication&.failed? %>
+      <p class="mt-4 text-sm text-red-600 dark:text-red-400"><%= @blog.standard_site_publication.sync_error %></p>
+    <% end %>
+
+    <div class="mt-6">
+      <%= button_to "Disconnect Bluesky", app_settings_standard_site_path, method: :delete, class: "btn-danger", data: { turbo_confirm: "Disconnect Bluesky? Pagecord will stop adding Standard.site verification metadata." } %>
+    </div>
+  </div>
+<% else %>
+  <div class="mt-6 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-6">
+    <%= form_with url: app_settings_standard_site_path, scope: :standard_site do |form| %>
+      <fieldset <%= "disabled" unless @blog.user.has_premium_access? %>>
+        <div>
+          <%= form.label :handle, "Bluesky handle", class: "block font-medium text-slate-900 dark:text-slate-100" %>
+          <%= form.text_field :handle, placeholder: "you.bsky.social", required: true, class: "mt-2 w-full rounded-lg border border-slate-300 dark:border-slate-600 dark:bg-slate-900 text-slate-800 dark:text-slate-200" %>
+        </div>
+
+        <div class="mt-4">
+          <%= form.label :app_password, "Bluesky app password", class: "block font-medium text-slate-900 dark:text-slate-100" %>
+          <%= form.password_field :app_password, required: true, class: "mt-2 w-full rounded-lg border border-slate-300 dark:border-slate-600 dark:bg-slate-900 text-slate-800 dark:text-slate-200" %>
+          <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            Create an app password in Bluesky settings. Pagecord stores the resulting AT session securely and never stores the app password itself.
+          </p>
+        </div>
+
+        <%= form.hidden_field :pds_url, value: "https://bsky.social" %>
+
+        <div class="mt-6">
+          <%= form.submit "Connect Bluesky", class: "btn-primary" %>
+        </div>
+      </fieldset>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -36,6 +36,14 @@
     <%= render "layouts/fediverse_identity" %>
     <%= yield :fediverse %>
 
+    <% if standard_site_publication_at_uri.present? %>
+      <link rel="site.standard.publication" href="<%= standard_site_publication_at_uri %>" />
+    <% end %>
+
+    <% if standard_site_document_at_uri.present? %>
+      <link rel="site.standard.document" href="<%= standard_site_document_at_uri %>" />
+    <% end %>
+
     <link rel="canonical" href="<%= canonical_url %>" />
 
     <%= render "layouts/rss" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,7 @@ Rails.application.routes.draw do
         end
 
         resource :api, only: [ :show, :create, :destroy ], controller: "api"
+        resource :standard_site, only: [ :show, :create, :destroy ], controller: "standard_site"
         resources :exports
 
         resources :sender_email_addresses, only: [ :create, :destroy ] do
@@ -261,6 +262,7 @@ Rails.application.routes.draw do
   end
 
   constraints(->(request) { !DomainConstraints.default_domain?(request) }) do
+    get "/.well-known/site.standard.publication", to: "blogs/standard_site_publications#show", as: :blog_standard_site_publication
     get "/robots.txt", to: "blogs/robots#show", as: :blog_robots, format: :text
     get "/sitemap.xml", to: "blogs/sitemaps#show", as: :blog_sitemap, format: :xml
     get "/", to: "blogs/posts#index", as: :blog_posts

--- a/db/migrate/20260603150000_create_standard_site_records.rb
+++ b/db/migrate/20260603150000_create_standard_site_records.rb
@@ -1,0 +1,37 @@
+class CreateStandardSiteRecords < ActiveRecord::Migration[8.2]
+  def change
+    create_table :standard_site_accounts do |t|
+      t.references :blog, null: false, foreign_key: true, index: { unique: true }
+      t.string :handle, null: false
+      t.string :did, null: false
+      t.string :pds_url, null: false, default: "https://bsky.social"
+      t.text :access_jwt_ciphertext
+      t.text :refresh_jwt_ciphertext
+      t.datetime :connected_at
+      t.datetime :disconnected_at
+      t.timestamps
+    end
+
+    create_table :standard_site_publications do |t|
+      t.references :blog, null: false, foreign_key: true, index: { unique: true }
+      t.string :at_uri
+      t.string :cid
+      t.string :rkey, null: false, default: "self"
+      t.integer :sync_status, null: false, default: 0
+      t.datetime :last_synced_at
+      t.text :sync_error
+      t.timestamps
+    end
+
+    create_table :standard_site_documents do |t|
+      t.references :post, null: false, foreign_key: true, index: { unique: true }
+      t.string :at_uri
+      t.string :cid
+      t.string :rkey, null: false
+      t.integer :sync_status, null: false, default: 0
+      t.datetime :last_synced_at
+      t.text :sync_error
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_02_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_03_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -367,6 +367,46 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_02_120000) do
     t.index ["status"], name: "index_spam_detections_on_status"
   end
 
+  create_table "standard_site_accounts", force: :cascade do |t|
+    t.bigint "blog_id", null: false
+    t.string "handle", null: false
+    t.string "did", null: false
+    t.string "pds_url", default: "https://bsky.social", null: false
+    t.text "access_jwt_ciphertext"
+    t.text "refresh_jwt_ciphertext"
+    t.datetime "connected_at"
+    t.datetime "disconnected_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["blog_id"], name: "index_standard_site_accounts_on_blog_id", unique: true
+  end
+
+  create_table "standard_site_documents", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.string "at_uri"
+    t.string "cid"
+    t.string "rkey", null: false
+    t.integer "sync_status", default: 0, null: false
+    t.datetime "last_synced_at"
+    t.text "sync_error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_standard_site_documents_on_post_id", unique: true
+  end
+
+  create_table "standard_site_publications", force: :cascade do |t|
+    t.bigint "blog_id", null: false
+    t.string "at_uri"
+    t.string "cid"
+    t.string "rkey", default: "self", null: false
+    t.integer "sync_status", default: 0, null: false
+    t.datetime "last_synced_at"
+    t.text "sync_error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["blog_id"], name: "index_standard_site_publications_on_blog_id", unique: true
+  end
+
   create_table "subscription_renewal_reminders", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "period", null: false
@@ -476,6 +516,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_02_120000) do
   add_foreign_key "posts", "blogs"
   add_foreign_key "sender_email_addresses", "blogs"
   add_foreign_key "spam_detections", "blogs"
+  add_foreign_key "standard_site_accounts", "blogs"
+  add_foreign_key "standard_site_documents", "posts"
+  add_foreign_key "standard_site_publications", "blogs"
   add_foreign_key "subscription_renewal_reminders", "subscriptions"
   add_foreign_key "subscriptions", "users"
   add_foreign_key "unengaged_follow_ups", "users"

--- a/test/controllers/app/settings/standard_site_controller_test.rb
+++ b/test/controllers/app/settings/standard_site_controller_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+
+class App::Settings::StandardSiteControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  setup do
+    @user = users(:joel)
+    @blog = @user.blog
+    login_as @user
+  end
+
+  test "should get show" do
+    get app_settings_standard_site_url
+
+    assert_response :success
+    assert_select "h3", text: "Bluesky / Standard.site"
+  end
+
+  test "connects bluesky and enqueues publication sync" do
+    StandardSite::Client.expects(:connect).with(
+      handle: "joel.bsky.social",
+      app_password: "app-password",
+      pds_url: "https://bsky.social"
+    ).returns({
+      "handle" => "joel.bsky.social",
+      "did" => "did:plc:joel123",
+      "accessJwt" => "access-token",
+      "refreshJwt" => "refresh-token"
+    })
+
+    assert_enqueued_with(job: StandardSite::SyncPublicationJob, args: [ @blog.id ]) do
+      post app_settings_standard_site_url, params: {
+        standard_site: {
+          handle: "joel.bsky.social",
+          app_password: "app-password",
+          pds_url: "https://bsky.social"
+        }
+      }
+    end
+
+    assert_redirected_to app_settings_standard_site_url
+    assert_equal "joel.bsky.social", @blog.reload.standard_site_account.handle
+    assert_equal "did:plc:joel123", @blog.standard_site_account.did
+    assert @blog.standard_site_publication.present?
+    assert_not_includes @blog.standard_site_account.access_jwt_ciphertext, "access-token"
+  end
+
+  test "does not connect for free users" do
+    user = users(:vivian)
+    login_as user
+
+    assert_no_enqueued_jobs do
+      post app_settings_standard_site_url, params: {
+        standard_site: {
+          handle: "vivian.bsky.social",
+          app_password: "app-password",
+          pds_url: "https://bsky.social"
+        }
+      }
+    end
+
+    assert_redirected_to app_settings_standard_site_url
+    assert_nil user.blog.reload.standard_site_account
+  end
+
+  test "disconnects bluesky and removes local standard site records" do
+    account = @blog.create_standard_site_account!(
+      handle: "joel.bsky.social",
+      did: "did:plc:joel123",
+      pds_url: "https://bsky.social",
+      connected_at: Time.current
+    )
+    account.access_jwt = "access-token"
+    account.refresh_jwt = "refresh-token"
+    account.save!
+
+    @blog.create_standard_site_publication!(at_uri: "at://did:plc:joel123/site.standard.publication/self", sync_status: :synced)
+    @blog.posts.first.create_standard_site_document!(
+      at_uri: "at://did:plc:joel123/site.standard.document/#{@blog.posts.first.token}",
+      rkey: @blog.posts.first.token,
+      sync_status: :synced
+    )
+
+    delete app_settings_standard_site_url
+
+    assert_redirected_to app_settings_standard_site_url
+    assert_nil @blog.reload.standard_site_account
+    assert_nil @blog.standard_site_publication
+    assert_equal 0, StandardSite::Document.where(post: @blog.all_posts).count
+  end
+end

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -766,6 +766,44 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'meta[name="fediverse:creator"][content="@joel@pagecord.com"]'
   end
 
+  test "should insert standard site publication and document links into the head" do
+    post = @blog.posts.visible.first
+    @blog.create_standard_site_publication!(
+      at_uri: "at://did:plc:joel123/site.standard.publication/self",
+      sync_status: :synced
+    )
+    post.create_standard_site_document!(
+      at_uri: "at://did:plc:joel123/site.standard.document/#{post.token}",
+      rkey: post.token,
+      sync_status: :synced
+    )
+
+    get blog_post_path(post.slug)
+
+    assert_response :success
+    assert_select 'link[rel="site.standard.publication"][href="at://did:plc:joel123/site.standard.publication/self"]'
+    assert_select "link[rel=\"site.standard.document\"][href=\"at://did:plc:joel123/site.standard.document/#{post.token}\"]"
+  end
+
+  test "should not insert standard site links before sync succeeds" do
+    post = @blog.posts.visible.first
+    @blog.create_standard_site_publication!(
+      at_uri: "at://did:plc:joel123/site.standard.publication/self",
+      sync_status: :failed
+    )
+    post.create_standard_site_document!(
+      at_uri: "at://did:plc:joel123/site.standard.document/#{post.token}",
+      rkey: post.token,
+      sync_status: :failed
+    )
+
+    get blog_post_path(post.slug)
+
+    assert_response :success
+    assert_select 'link[rel="site.standard.publication"]', count: 0
+    assert_select 'link[rel="site.standard.document"]', count: 0
+  end
+
   test "should include rel='me' link if Mastodon social navigation item is present" do
     mastodon_link = SocialNavigationItem.create!(
       blog: @blog,

--- a/test/controllers/blogs/standard_site_publications_controller_test.rb
+++ b/test/controllers/blogs/standard_site_publications_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class Blogs::StandardSitePublicationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @blog = blogs(:joel)
+    host! "#{@blog.subdomain}.#{Rails.application.config.x.domain}"
+  end
+
+  test "returns not found when standard site publication is not synced" do
+    get "/.well-known/site.standard.publication"
+
+    assert_response :not_found
+  end
+
+  test "returns synced publication at uri" do
+    @blog.create_standard_site_publication!(
+      at_uri: "at://did:plc:joel123/site.standard.publication/self",
+      sync_status: :synced
+    )
+
+    get "/.well-known/site.standard.publication"
+
+    assert_response :success
+    assert_equal "text/plain", response.media_type
+    assert_equal "at://did:plc:joel123/site.standard.publication/self", response.body
+  end
+
+  test "works on custom domains" do
+    blog = blogs(:annie)
+    host! blog.custom_domain
+    blog.create_standard_site_publication!(
+      at_uri: "at://did:plc:annie123/site.standard.publication/self",
+      sync_status: :synced
+    )
+
+    get "/.well-known/site.standard.publication"
+
+    assert_response :success
+    assert_equal "at://did:plc:annie123/site.standard.publication/self", response.body
+  end
+end

--- a/test/models/standard_site/document_test.rb
+++ b/test/models/standard_site/document_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class StandardSite::DocumentTest < ActiveSupport::TestCase
+  test "builds a document record from the post" do
+    blog = blogs(:joel)
+    post = posts(:one)
+    blog.create_standard_site_publication!(
+      at_uri: "at://did:plc:joel123/site.standard.publication/self",
+      sync_status: :synced
+    )
+    document = post.build_standard_site_document
+
+    record = document.record
+
+    assert_equal "site.standard.document", record["$type"]
+    assert_equal "at://did:plc:joel123/site.standard.publication/self", record["site"]
+    assert_equal "/the-art-of-street-photography", record["path"]
+    assert_equal post.display_title, record["title"]
+    assert_equal [ "photography" ], record["tags"]
+    assert_equal post.published_at.utc.iso8601(3), record["publishedAt"]
+  end
+
+  test "sync disables records for drafts" do
+    blog = blogs(:joel)
+    post = posts(:joel_draft)
+    document = post.create_standard_site_document!(rkey: post.token)
+    blog.create_standard_site_publication!(
+      at_uri: "at://did:plc:joel123/site.standard.publication/self",
+      sync_status: :synced
+    )
+
+    document.sync!
+
+    assert document.disabled?
+  end
+end

--- a/test/models/standard_site/publication_test.rb
+++ b/test/models/standard_site/publication_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class StandardSite::PublicationTest < ActiveSupport::TestCase
+  test "builds a publication record from the blog" do
+    blog = blogs(:joel)
+    publication = blog.build_standard_site_publication
+
+    record = publication.record
+
+    assert_equal "site.standard.publication", record["$type"]
+    assert_equal "http://joel.example.com", record["url"]
+    assert_equal blog.display_name, record["name"]
+    assert_equal true, record["preferences"]["showInDiscover"]
+  end
+
+  test "sync stores returned at uri and cid" do
+    blog = blogs(:joel)
+    account = blog.create_standard_site_account!(
+      handle: "joel.bsky.social",
+      did: "did:plc:joel123",
+      pds_url: "https://bsky.social",
+      connected_at: Time.current
+    )
+    account.access_jwt = "access-token"
+    account.refresh_jwt = "refresh-token"
+    account.save!
+
+    publication = blog.create_standard_site_publication!
+
+    StandardSite::Client.any_instance.expects(:put_record).with(
+      collection: "site.standard.publication",
+      rkey: "self",
+      record: publication.record
+    ).returns({
+      "uri" => "at://did:plc:joel123/site.standard.publication/self",
+      "cid" => "bafyreipublication"
+    })
+
+    publication.sync!
+
+    assert publication.synced?
+    assert_equal "at://did:plc:joel123/site.standard.publication/self", publication.at_uri
+    assert_equal "bafyreipublication", publication.cid
+  end
+end


### PR DESCRIPTION
## Summary

Adds experimental Standard.site support for Pagecord blogs:

- separate Standard.site account/publication/document tables
- Bluesky connection UI using an app password for this first pass
- server-side AT record writes through a small client boundary
- publication/document sync jobs
- .well-known publication verification endpoint
- blog head tags for Standard.site publication and document records

## Notes

This is intentionally marked draft because the connection layer uses Bluesky app passwords rather than full AT Protocol OAuth. The record models, jobs, verification endpoint, and metadata rendering are isolated so the auth path can be replaced later without changing the rest of the feature.

## Verification

- bundle exec rubocop --cache false app/models/standard_site.rb app/models/standard_site app/jobs/standard_site app/controllers/app/settings/standard_site_controller.rb app/controllers/blogs/standard_site_publications_controller.rb app/helpers/blogs_helper.rb app/models/blog.rb app/models/post.rb test/controllers/app/settings/standard_site_controller_test.rb test/controllers/blogs/standard_site_publications_controller_test.rb test/models/standard_site
- bin/rails test