### PR TITLE
Document API response formats

### DIFF
--- a/docs/help-guide/api.md
+++ b/docs/help-guide/api.md
@@ -31,6 +31,45 @@ Invalid or missing tokens return `401 Unauthorized`. A revoked or expired premiu
 
 The API allows 60 requests per minute per blog. Exceeding this returns `429 Too Many Requests`.
 
+## Response format
+
+Successful responses return JSON, except delete requests, which return `204 No Content`.
+
+List endpoints return arrays:
+
+```json
+[
+  {
+    "token": "abc123",
+    "title": "My post",
+    "slug": "my-post",
+    "status": "published",
+    "published_at": "2026-03-11T12:00:00.000Z",
+    "canonical_url": null,
+    "tag_list": ["rails", "ruby"],
+    "hidden": false,
+    "locale": "en",
+    "created_at": "2026-03-11T12:00:00.000Z",
+    "updated_at": "2026-03-11T12:00:00.000Z",
+    "content": "<p>Hello world</p>"
+  }
+]
+```
+
+Create requests return `201 Created` with the created resource. Get and update requests return `200 OK` with the requested or updated resource.
+
+Post responses include:
+
+- `token` – stable API identifier for future get, update, and delete requests
+- `title`, `slug`, `status`, `published_at`, `canonical_url`, `tag_list`, `hidden`, and `locale`
+- `created_at` and `updated_at`
+- `content` – stored HTML, including canonical Action Text attachment tags where relevant
+
+Page and home page responses include the same fields, plus:
+
+- `is_page` – always `true`
+- `is_home_page` – whether the page is currently set as the blog home page
+
 ## Posts
 
 ### List posts
@@ -48,11 +87,15 @@ Returns published posts by default, newest first. Filter with query parameters:
 
 Paginated results include a `Link` header with the URL for the next page (following [RFC 5988](https://tools.ietf.org/html/rfc5988)) and an `X-Total-Count` header with the total number of records. When the `Link` header is absent, you're on the last page.
 
+Returns `200 OK` with an array of post objects.
+
 ### Get a post
 
 ```
 GET /posts/:token
 ```
+
+Returns `200 OK` with a post object. Returns `404 Not Found` if the token does not match one of your posts.
 
 ### Create a post
 
@@ -73,13 +116,15 @@ Parameters:
 - `hidden` – `true` to hide from the feed
 - `locale` – post language code
 
+Returns `201 Created` with the created post object. Returns `422 Unprocessable Entity` when validation fails.
+
 ### Update a post
 
 ```
 PATCH /posts/:token
 ```
 
-Accepts the same parameters as create.
+Accepts the same parameters as create. Returns `200 OK` with the updated post object.
 
 ### Delete a post
 
@@ -95,6 +140,8 @@ Pass `permanent=true` to delete immediately and irrevocably:
 DELETE /posts/:token?permanent=true
 ```
 
+Returns `404 Not Found` if the token does not match one of your posts.
+
 ## Pages
 
 ### List pages
@@ -105,11 +152,15 @@ GET /pages
 
 Returns published pages by default, newest first. Accepts the same filter parameters as posts (`status`, `published_after`, `published_before`, `page`). Pagination works the same way via `Link` and `X-Total-Count` headers.
 
+Returns `200 OK` with an array of page objects.
+
 ### Get a page
 
 ```
 GET /pages/:token
 ```
+
+Returns `200 OK` with a page object. Returns `404 Not Found` if the token does not match one of your pages.
 
 ### Create a page
 
@@ -117,14 +168,15 @@ GET /pages/:token
 POST /pages
 ```
 
-Accepts the same parameters as posts.
-
+Accepts the same parameters as posts. Returns `201 Created` with the created page object.
 
 ### Update a page
 
 ```
 PATCH /pages/:token
 ```
+
+Accepts the same parameters as posts. Returns `200 OK` with the updated page object.
 
 ### Delete a page
 
@@ -140,6 +192,8 @@ Pass `permanent=true` to delete immediately and irrevocably:
 DELETE /pages/:token?permanent=true
 ```
 
+Returns `404 Not Found` if the token does not match one of your pages.
+
 ## Home page
 
 A blog can have a single home page – a special page that replaces the default post feed.
@@ -150,7 +204,7 @@ A blog can have a single home page – a special page that replaces the default 
 GET /home_page
 ```
 
-Returns `404` if no home page is set.
+Returns `200 OK` with the home page object. Returns `404 Not Found` if no home page is set.
 
 ### Create a home page
 
@@ -158,13 +212,15 @@ Returns `404` if no home page is set.
 POST /home_page
 ```
 
-Accepts the same parameters as posts. Creates a new page and sets it as the home page. If a home page already exists, the API returns `422 Unprocessable Entity`.
+Accepts the same parameters as posts. Creates a new page and sets it as the home page. Returns `201 Created` with the created home page object. If a home page already exists, the API returns `422 Unprocessable Entity`.
 
 ### Update the home page
 
 ```
 PATCH /home_page
 ```
+
+Accepts the same parameters as posts. Returns `200 OK` with the updated home page object. Returns `404 Not Found` if no home page is set.
 
 ### Remove the home page
 
@@ -173,6 +229,8 @@ DELETE /home_page
 ```
 
 Unlinks the home page from the blog but keeps the underlying page. Returns `204 No Content`.
+
+Returns `404 Not Found` if no home page is set.
 
 ## Attachments
 
@@ -237,6 +295,26 @@ The `content` field returned by `GET`, `POST`, and `PATCH` responses contains th
 
 Unsupported content types or files exceeding the size limit return `422 Unprocessable Entity`.
 
+Other attachment errors:
+
+```json
+{ "error": "No file provided" }
+```
+
+```json
+{ "error": "Unsupported content type: text/plain" }
+```
+
+```json
+{ "error": "File too large (max 10MB for image/jpeg)" }
+```
+
+Using an invalid attachment `sgid` in post, page, or home page content returns `400 Bad Request`:
+
+```json
+{ "error": "Attachment sgid must reference an ActiveStorage::Blob" }
+```
+
 ## Markdown & front matter
 
 Set `content_format` to `markdown` on any create or update endpoint to send Markdown instead of HTML. The API converts it to HTML before saving.
@@ -261,17 +339,23 @@ Malformed YAML front matter returns `422` with an error message.
 
 ## Error responses
 
-All errors return a JSON object with an `error` or `errors` key:
+All errors return a JSON object with an `error` or `errors` key. Single errors use `error`:
 
 ```json
 { "error": "Unauthorized" }
 ```
 
+Validation errors use `errors`:
+
+```json
+{ "errors": ["Title can't be blank"] }
+```
+
 | Status | Meaning |
 |--------|---------|
-| 400 | Bad request – invalid timestamp, out-of-range page, or invalid status value |
+| 400 | Bad request – invalid timestamp, out-of-range page, invalid status value, or invalid attachment sgid |
 | 401 | Missing or invalid API key |
 | 403 | Premium subscription required |
 | 404 | Resource not found |
-| 422 | Validation failed – includes invalid front matter |
+| 422 | Validation failed, invalid front matter, missing file, unsupported file type, or oversized file |
 | 429 | Rate limit exceeded |


### PR DESCRIPTION
## Summary

- Document shared API response shapes for posts, pages, and home pages
- Add per-endpoint success status notes
- Expand attachment and validation error response examples

## Tests

- `git diff --check`