### PR TITLE
Restore Lexxy sentence capitalisation after focus

### DIFF
--- a/app/javascript/controllers/lexxy_controller.js
+++ b/app/javascript/controllers/lexxy_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
   connect() {
     this.element.addEventListener("lexxy:file-accept", this.#validateFile)
     this.element.addEventListener("lexxy:editor-initialized", this.#syncTypingAttributes)
+    this.element.addEventListener("focusin", this.#syncTypingAttributesAfterFocus)
     this.#installClipboardPasteOverride()
     this.#syncTypingAttributes()
   }
@@ -20,6 +21,7 @@ export default class extends Controller {
   disconnect() {
     this.element.removeEventListener("lexxy:file-accept", this.#validateFile)
     this.element.removeEventListener("lexxy:editor-initialized", this.#syncTypingAttributes)
+    this.element.removeEventListener("focusin", this.#syncTypingAttributesAfterFocus)
     this.#restoreClipboardPaste()
   }
 
@@ -72,6 +74,11 @@ export default class extends Controller {
         editorContent.setAttribute(attribute, this.element.getAttribute(attribute))
       }
     }
+  }
+
+  #syncTypingAttributesAfterFocus = () => {
+    this.#syncTypingAttributes()
+    requestAnimationFrame(this.#syncTypingAttributes)
   }
 
   #pastePreferringImageFiles = (event) => {

--- a/test/system/lexxy_editor_test.rb
+++ b/test/system/lexxy_editor_test.rb
@@ -17,6 +17,10 @@ class LexxyEditorTest < ApplicationSystemTestCase
     assert_equal "sentences", editor_content_attribute("autocapitalize")
     assert_equal "on", editor_content_attribute("autocorrect")
     assert_equal "true", editor_content_attribute("spellcheck")
+
+    find("lexxy-editor .lexxy-editor__content").click
+
+    assert_selector "lexxy-editor .lexxy-editor__content[autocapitalize='sentences']", wait: 2
   end
 
   private


### PR DESCRIPTION
## Summary

- Re-sync Lexxy typing attributes when focus enters the editor
- Keep `autocapitalize="sentences"` on the inner contenteditable after Lexical's focus handling
- Extend the Lexxy editor system test to assert the focused editor keeps sentence capitalisation

## Test

- `bin/rails test test/system/lexxy_editor_test.rb`