### PR TITLE
Audit public blog CSRF flows

### DIFF
--- a/app/controllers/api/embeds_controller.rb
+++ b/app/controllers/api/embeds_controller.rb
@@ -3,6 +3,9 @@ require "nokogiri"
 
 class Api::EmbedsController < ApplicationController
   skip_before_action :domain_check
+  skip_forgery_protection only: :bandcamp
+
+  rate_limit to: 30, within: 1.minute, only: :bandcamp, with: :rate_limit_reached
 
   def bandcamp
     url = params[:url]
@@ -34,5 +37,9 @@ class Api::EmbedsController < ApplicationController
         meta_tag = doc.at("meta[property=\"og:video\"]")
         meta_tag&.attr("content")
       end
+    end
+
+    def rate_limit_reached
+      render json: { error: "Rate limit exceeded" }, status: :too_many_requests
     end
 end

--- a/app/javascript/embeds/bandcamp.js
+++ b/app/javascript/embeds/bandcamp.js
@@ -10,8 +10,7 @@ class Bandcamp extends MediaSite {
           const response = await fetch('/api/embeds/bandcamp', {
             method: 'POST',
             headers: {
-              'Content-Type': 'application/json',
-              'X-CSRF-Token': document.querySelector('[name="csrf-token"]').content
+              'Content-Type': 'application/json'
             },
             body: JSON.stringify({ url })
           })

--- a/app/views/blogs/contact_messages/_form.html.erb
+++ b/app/views/blogs/contact_messages/_form.html.erb
@@ -3,6 +3,7 @@
             url: contact_messages_path,
             method: :post,
             scope: :contact_message,
+            authenticity_token: false,
             class: "form-container" do |form| %>
 
     <%= render "/shared/spam_prevention" %>

--- a/app/views/blogs/email_subscribers/_form.html.erb
+++ b/app/views/blogs/email_subscribers/_form.html.erb
@@ -1,4 +1,7 @@
-<%= form_with url: email_subscribers_path, model: [EmailSubscriber.new], local: true,
+<%= form_with url: email_subscribers_path,
+      model: [EmailSubscriber.new],
+      local: true,
+      authenticity_token: false,
       class: "email-form-container" do |form| %>
   <div class="subscription-description">
     <%= t("email_subscribers.form.subscribe_description.#{@blog.email_delivery_mode}") %>

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <title><%= page_title %></title>
 

--- a/app/views/posts/replies/new.html.erb
+++ b/app/views/posts/replies/new.html.erb
@@ -9,6 +9,7 @@
           url: post_replies_path(@post),
           method: :post,
           scope: :reply,
+          authenticity_token: false,
           data: { turbo: false },
           class: "form-container" do |form| %>
 

--- a/test/controllers/api/embeds_controller_test.rb
+++ b/test/controllers/api/embeds_controller_test.rb
@@ -20,7 +20,9 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
 
     URI.stubs(:open).with(bandcamp_url, uri_open_options).returns(StringIO.new(mock_html))
 
-    post "/api/embeds/bandcamp", params: { url: bandcamp_url }
+    with_forgery_protection do
+      post "/api/embeds/bandcamp", params: { url: bandcamp_url }
+    end
 
     assert_response :success
     json_response = JSON.parse(response.body)
@@ -78,16 +80,6 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "https://bandcamp.com/EmbeddedPlayer/v=2/album=456/", json_response["embed_url"]
   end
 
-  test "should skip CSRF token verification" do
-    # This test ensures the endpoint works without CSRF tokens (important for API endpoints)
-    URI.stubs(:open).with(bandcamp_url, uri_open_options).returns(StringIO.new("<html></html>"))
-
-    post "/api/embeds/bandcamp", params: { url: bandcamp_url }
-
-    # Should not get InvalidAuthenticityToken error
-    assert_not_equal "ActionController::InvalidAuthenticityToken", response.body
-  end
-
   test "should cache resolved embed URLs" do
     Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
 
@@ -135,5 +127,17 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
         open_timeout: 2,
         read_timeout: 3
       }
+    end
+
+    def with_forgery_protection
+      base_setting = ActionController::Base.allow_forgery_protection
+      application_setting = ApplicationController.allow_forgery_protection
+
+      ActionController::Base.allow_forgery_protection = true
+      ApplicationController.allow_forgery_protection = true
+      yield
+    ensure
+      ActionController::Base.allow_forgery_protection = base_setting
+      ApplicationController.allow_forgery_protection = application_setting
     end
 end

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -72,7 +72,9 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     get blog_posts_path
 
     assert_response :success
+    assert_select "meta[name='csrf-token']", count: 0
     assert_select "turbo-frame#email_subscriber_form"
+    assert_select "input[name='authenticity_token']", count: 0
   end
 
   test "should not show email subscription form on index if show_subscription_in_header is false" do

--- a/test/controllers/posts/replies_controller_test.rb
+++ b/test/controllers/posts/replies_controller_test.rb
@@ -9,7 +9,9 @@ class Posts::RepliesControllerTest < ActionDispatch::IntegrationTest
   test "should get new reply form" do
     get new_post_reply_path(@post)
     assert_response :success
+    assert_select "meta[name='csrf-token']", count: 0
     assert_select "form[action=?]", post_replies_path(@post)
+    assert_select "input[name='authenticity_token']", count: 0
     assert_select "textarea#reply_message.autogrow"
   end
 

--- a/test/integration/custom_tags_rendering_test.rb
+++ b/test/integration/custom_tags_rendering_test.rb
@@ -646,8 +646,10 @@ class CustomTagsRenderingTest < ActionDispatch::IntegrationTest
     get blog_post_url(subdomain: @blog.subdomain, slug: page.slug)
 
     assert_response :success
+    assert_select "meta[name='csrf-token']", count: 0
     assert_select ".contact-form"
     assert_select "form[action='#{contact_messages_path}']"
+    assert_select "input[name='authenticity_token']", count: 0
   end
 
   test "contact_form tag renders nothing for non-premium user" do


### PR DESCRIPTION
## Summary

- Remove CSRF meta tags from the public blog layout.
- Stop generating hidden authenticity tokens for public blog subscription, contact, and reply forms.
- Make the Bandcamp embed proxy explicitly public, rate-limited, and independent of a CSRF token.
- Add focused coverage for public pages not exposing CSRF tokens and for Bandcamp working with forgery protection enabled.

## Impact

This keeps Rails CSRF tokens out of public blog pages so future custom JavaScript cannot read Pagecord app CSRF material from the blog surface. Existing public form protections remain the boundary: rate limits, spam timing/honeypot, Turnstile where enabled, signed reply form tokens, and upvote dedupe.

## Validation

- `bin/rails test test/controllers/api/embeds_controller_test.rb test/controllers/blogs/posts_controller_test.rb test/controllers/posts/replies_controller_test.rb test/integration/custom_tags_rendering_test.rb`
- `bundle exec rubocop --cache false app/controllers/api/embeds_controller.rb test/controllers/api/embeds_controller_test.rb test/controllers/blogs/posts_controller_test.rb test/controllers/posts/replies_controller_test.rb test/integration/custom_tags_rendering_test.rb`