### PR TITLE
Add Micropub publishing support

### DIFF
--- a/app/controllers/api/attachments_controller.rb
+++ b/app/controllers/api/attachments_controller.rb
@@ -6,9 +6,7 @@ class Api::AttachmentsController < Api::BaseController
 
     max_size = UploadLimits::CONTENT_TYPES[file.content_type]
 
-    unless max_size
-      return render json: { error: "Unsupported content type: #{file.content_type}" }, status: :unprocessable_entity
-    end
+    return render json: { error: "Unsupported content type: #{file.content_type}" }, status: :unprocessable_entity unless max_size
 
     if file.size > max_size
       return render json: { error: "File too large (max #{max_size / 1.megabyte}MB for #{file.content_type})" }, status: :unprocessable_entity
@@ -16,9 +14,15 @@ class Api::AttachmentsController < Api::BaseController
 
     blob = ActiveStorage::Blob.create_and_upload!(io: file, filename: file.original_filename, content_type: file.content_type)
 
-    render json: {
-      attachable_sgid: blob.attachable_sgid,
-      url: url_for(blob)
-    }, status: :created
+    render_blob blob
   end
+
+  private
+
+    def render_blob(blob)
+      render json: {
+        attachable_sgid: blob.attachable_sgid,
+        url: url_for(blob)
+      }, status: :created
+    end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -34,7 +34,22 @@ class Api::BaseController < ActionController::API
         Current.blog = Blog.find_by_api_key(token)
       end
 
-      render json: { error: "Unauthorized" }, status: :unauthorized unless Current.blog
+      authenticate_with_access_token if allow_access_token_parameter? && !Current.blog
+
+      unauthorized unless Current.blog
+    end
+
+    def allow_access_token_parameter?
+      false
+    end
+
+    def unauthorized
+      render json: { error: "Unauthorized" }, status: :unauthorized
+    end
+
+    def authenticate_with_access_token
+      token = request.request_parameters[:access_token]
+      Current.blog = Blog.find_by_api_key(token) if token.present?
     end
 
     def require_premium

--- a/app/controllers/api/micropub/media_controller.rb
+++ b/app/controllers/api/micropub/media_controller.rb
@@ -1,0 +1,12 @@
+class Api::Micropub::MediaController < Api::AttachmentsController
+  private
+
+    def allow_access_token_parameter?
+      true
+    end
+
+    def render_blob(blob)
+      response.headers["Location"] = url_for(blob)
+      head :created
+    end
+end

--- a/app/controllers/api/micropub_controller.rb
+++ b/app/controllers/api/micropub_controller.rb
@@ -1,0 +1,227 @@
+class Api::MicropubController < Api::BaseController
+  include RoutingHelper
+
+  BLOB_URL_PATTERN = %r{/active_storage/blobs/(?:redirect|proxy)/([^/]+)/}.freeze
+
+  skip_before_action :authenticate, :require_premium, only: :query
+  before_action :advertise_micropub_endpoint, only: :query
+  before_action :authenticate_source_query, only: :query, if: :source_query?
+
+  rescue_from BadRequestError do |e|
+    invalid_request e.message
+  end
+
+  def create
+    case request_body[:action]
+    when "update" then update_post
+    when "delete" then delete_post
+    when nil, "" then create_post
+    else               invalid_request "Unsupported action"
+    end
+  end
+
+  def query
+    case params[:q]
+    when nil, "", "config" then render json: config_response
+    when "syndicate-to" then render json: syndicate_to_response
+    when "source" then render json: source_response(find_post!)
+    else               invalid_request "Unsupported query"
+    end
+  end
+
+  private
+
+    def request_body
+      request.request_parameters
+    end
+
+    def allow_access_token_parameter?
+      true
+    end
+
+    def unauthorized
+      render json: { error: access_token_submitted? ? "insufficient_scope" : "unauthorized" }, status: :unauthorized
+    end
+
+    def access_token_submitted?
+      request.authorization.present? || request.request_parameters[:access_token].present?
+    end
+
+    def source_query?
+      params[:q] == "source"
+    end
+
+    def advertise_micropub_endpoint
+      response.headers["Link"] = %(<#{micropub_endpoint_url}>; rel="micropub")
+    end
+
+    def authenticate_source_query
+      authenticate
+      require_premium if Current.blog
+    end
+
+    def config_response
+      syndicate_to_response.merge(
+        "media-endpoint" => "#{micropub_endpoint_url}/media",
+        "post-status" => %w[published draft]
+      )
+    end
+
+    def syndicate_to_response
+      { "syndicate-to" => [] }
+    end
+
+    def create_post
+      attrs = Micropub::PostParams.new(params).to_h
+      validate_status! attrs
+      attrs[:content] = resolve_blob_images(attrs[:content]) if attrs[:content]
+      post = Current.blog.posts.create(attrs.merge(source: :api))
+
+      if post.persisted?
+        response.headers["Location"] = micropub_post_url(post)
+        head :created
+      else
+        invalid_request post.errors.full_messages.first, status: :unprocessable_entity
+      end
+    end
+
+    def update_post
+      post = find_post!
+      original_url = micropub_post_url(post)
+
+      if post.update(unchanged_content_skipped(update_attributes(post), post))
+        updated_url = micropub_post_url(post)
+        response.headers["Location"] = updated_url if updated_url != original_url
+        head updated_url != original_url ? :created : :ok
+      else
+        invalid_request post.errors.full_messages.first, status: :unprocessable_entity
+      end
+    end
+
+    def delete_post
+      find_post!.discard!
+      head :ok
+    end
+
+    def update_attributes(post)
+      attrs = Micropub::PostParams.new(request_body[:replace]).to_h
+      validate_status! attrs
+      attrs[:content] = resolve_blob_images(attrs[:content]) if attrs[:content]
+      tag_list = updated_tag_list(post)
+      attrs[:tag_list] = tag_list if tag_list
+      attrs
+    end
+
+    def updated_tag_list(post)
+      replace = property_values(:replace, :category)
+      added = property_values(:add, :category)
+      deleted = property_values(:delete, :category)
+      return if replace.empty? && added.empty? && deleted.empty?
+
+      ((replace.presence || post.tag_list) + added - deleted).uniq
+    end
+
+    def property_values(operation, property)
+      values = request_body[operation]
+      return [] unless values.respond_to?(:key?)
+
+      Array(values[property])
+    end
+
+    def find_post!
+      raise ActiveRecord::RecordNotFound unless post_url_belongs_to_blog?
+
+      Current.blog.posts.kept.find_by!(slug: slug_from_url)
+    end
+
+    def micropub_post_url(post)
+      post.draft? ? edit_app_post_url(post, host: Rails.application.config.x.domain) : post_url(post)
+    end
+
+    def slug_from_url
+      path = requested_post_url.path.delete_prefix("/").chomp("/")
+      path.delete_prefix("posts/")
+    end
+
+    def requested_post_url
+      @requested_post_url ||= URI.parse(params[:url].to_s)
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def post_url_belongs_to_blog?
+      blog_url_hosts.include?(requested_post_url&.host&.downcase)
+    end
+
+    def blog_url_hosts
+      [
+        "#{Current.blog.subdomain}.#{Rails.application.config.x.domain}",
+        Current.blog.custom_domain
+      ].compact_blank.map(&:downcase)
+    end
+
+    def source_response(post)
+      selected = Array(params[:properties]).presence
+      properties = source_properties(post)
+      properties = properties.slice(*selected) if selected
+
+      selected ? { properties: properties } : { type: [ "h-entry" ], properties: properties }
+    end
+
+    def source_properties(post)
+      {
+        "name" => [ post.title ].compact,
+        "content" => [ source_content(post) ],
+        "category" => post.tag_list,
+        "post-status" => [ post.status ],
+        "published" => [ post.published_at&.iso8601 ].compact,
+        "mp-slug" => [ post.slug ]
+      }.select { |_key, values| values.present? }
+    end
+
+    def source_content(post)
+      html = post.content.body.to_html
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      elements = doc.children.select(&:element?)
+
+      if elements.one? && elements.first.name == "p" && elements.first.element_children.empty?
+        elements.first.text
+      else
+        { html: html }
+      end
+    end
+
+    # Micropub clients reference uploaded images by blob URL returned from the
+    # media endpoint. Convert those <img> tags to Action Text attachments so the
+    # blob remains associated with the saved post.
+    def resolve_blob_images(html)
+      return html unless html&.match?(BLOB_URL_PATTERN)
+
+      doc = Nokogiri::HTML::DocumentFragment.parse(html)
+      doc.css("img").each do |img|
+        next unless blob = blob_from_url(img["src"])
+
+        node = img.parent&.name == "figure" ? img.parent : img
+        node.replace attachment_preview_node(blob, img["src"], attributes: { caption: img["alt"] })
+      end
+      doc.to_html
+    end
+
+    def blob_from_url(url)
+      signed_id = url.to_s[BLOB_URL_PATTERN, 1]
+      ActiveStorage::Blob.find_signed(signed_id) if signed_id
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      nil
+    end
+
+    def invalid_request(description, status: :bad_request)
+      render json: { error: "invalid_request", error_description: description }, status: status
+    end
+
+    def validate_status!(attrs)
+      return unless attrs[:status].present?
+      return if Post.statuses.key?(attrs[:status])
+
+      raise BadRequestError, "'#{attrs[:status]}' is not a valid status"
+    end
+end

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -43,6 +43,10 @@ module RoutingHelper
     email_subscriber_one_click_unsubscribe_url(email_subscriber.token, host: host(email_subscriber.blog))
   end
 
+  def micropub_endpoint_url
+    micropub_url(host: "api.#{Rails.application.config.x.domain}")
+  end
+
   private
 
     def route_for_blog(blog, route_name, type, options = {})

--- a/app/models/micropub/post_params.rb
+++ b/app/models/micropub/post_params.rb
@@ -1,0 +1,82 @@
+class Micropub::PostParams
+  ATTRIBUTE_MAP = {
+    "name" => :title,
+    "mp-slug" => :slug,
+    "published" => :published_at,
+    "post-status" => :status
+  }.freeze
+
+  def initialize(params)
+    @params = params || {}
+  end
+
+  def to_h
+    attrs = ATTRIBUTE_MAP.each_with_object({}) do |(key, attr), h|
+      value = property(key)
+      h[attr] = value if value.present?
+    end
+
+    tags = properties_for("category")
+    content = content_html
+    attrs[:tag_list] = tags if tags.any?
+    attrs[:content] = content if content.present?
+    attrs
+  end
+
+  private
+
+    # Micropub accepts flat form posts ({ content: "..." }) and mf2 JSON
+    # ({ properties: { content: ["..."] } }). Prefer properties when present.
+    def properties
+      @properties ||= @params[:properties].presence || @params
+    end
+
+    def property(key)
+      value = properties[key]
+      value.is_a?(Array) ? value.first : value
+    end
+
+    def properties_for(key)
+      value = properties[key]
+      return [] if value.nil?
+
+      value.is_a?(Array) ? value : [ value ]
+    end
+
+    def content_html
+      [ body_html, *photo_html ].compact_blank.join("\n")
+    end
+
+    def body_html
+      case value = property("content")
+      when nil then nil
+      when ActionController::Parameters, Hash then content_from_hash(value)
+      else Post::Markdown.render(value.to_s).last
+      end
+    end
+
+    def content_from_hash(value)
+      html = value[:html] || value["html"]
+      return html.to_s.presence if html.present?
+
+      text = value[:value] || value["value"]
+      Post::Markdown.render(text.to_s).last if text.present?
+    end
+
+    def photo_html
+      properties_for("photo").filter_map do |photo|
+        url, alt = photo_url_and_alt(photo)
+        next if url.blank?
+
+        %(<img src="#{ERB::Util.html_escape(url)}" alt="#{ERB::Util.html_escape(alt)}">)
+      end
+    end
+
+    def photo_url_and_alt(photo)
+      if photo.is_a?(ActionController::Parameters) || photo.is_a?(Hash)
+        [ (photo[:value] || photo["value"]).to_s, (photo[:alt] || photo["alt"]).to_s ]
+      else
+        [ photo.to_s, "" ]
+      end
+    end
+end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -4,12 +4,13 @@
   <% elsif blob.audio? %>
     <%= audio_tag rails_public_blob_url(blob), preload: "auto", controls: "controls", class: "attachment__audio w-full" %>
   <% elsif blob.image? %>
+    <% image_alt = blob.try(:caption).presence || "Uploaded image" %>
     <% if blob.content_type == "image/gif" %>
-      <%= image_tag rails_public_blob_url(blob), alt: "Uploaded image" %>
+      <%= image_tag rails_public_blob_url(blob), alt: image_alt %>
     <% else %>
       <% width, height = local_assigns[:in_gallery] ? [800, 600] : [1600, 1200] %>
       <% lightbox_image_url = resized_image_url(blob, width: 1600, height: 1200) %>
-      <%= image_tag resized_image_url(blob, width: width, height: height), alt: "Uploaded image", data: { lightbox_full_url: lightbox_image_url } %>
+      <%= image_tag resized_image_url(blob, width: width, height: height), alt: image_alt, data: { lightbox_full_url: lightbox_image_url } %>
     <% end %>
   <% end %>
 

--- a/app/views/app/settings/api/show.html.erb
+++ b/app/views/app/settings/api/show.html.erb
@@ -76,6 +76,7 @@ curl -X POST https://api.pagecord.com/attachments \
 
     <p class="mt-4">
       Read the full <%= link_to "API documentation", "https://help.pagecord.com/api", class: "underline", target: "_blank" %> for all available endpoints.
+      You can also publish from Micropub-compatible writing apps such as iA Writer using the <%= link_to "Micropub guide", "https://help.pagecord.com/micropub", class: "underline", target: "_blank" %>.
     </p>
   </div>
 <% end %>

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -39,6 +39,9 @@
     <link rel="canonical" href="<%= canonical_url %>" />
 
     <%= render "layouts/rss" %>
+    <% if @blog&.user&.has_premium_access? %>
+      <link rel="micropub" href="<%= micropub_endpoint_url %>">
+    <% end %>
     <%= render "layouts/favicons" %>
 
     <%= font_preload_links %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,6 +266,9 @@ Rails.application.routes.draw do
       resources :pages, only: [ :index, :show, :create, :update, :destroy ], param: :token
       resource :home_page, only: [ :show, :create, :update, :destroy ]
       resources :attachments, only: [ :create ]
+      post "/micropub", to: "micropub#create"
+      get "/micropub", to: "micropub#query", as: nil
+      post "/micropub/media", to: "micropub/media#create"
     end
   end
 

--- a/docs/help-guide/index.md
+++ b/docs/help-guide/index.md
@@ -77,6 +77,7 @@ Use the Pagecord API to manage your blog programmatically, publish from the comm
 - [API](api.md)
 - [Publishing with the Pagecord CLI](pagecord-cli.md)
 - [Publishing from Obsidian](obsidian.md)
+- [Publishing with Micropub](micropub.md)
 
 ## Account & Billing
 

--- a/docs/help-guide/micropub.md
+++ b/docs/help-guide/micropub.md
@@ -1,0 +1,151 @@
+---
+title: "Publishing with Micropub"
+published: true
+published_at: 2026-06-21T00:00:00+00:00
+---
+
+Micropub lets compatible writing apps publish posts to your Pagecord blog. It is useful if you write in an app such as iA Writer and want to send drafts or published posts straight to Pagecord.
+
+Micropub uses your Pagecord API key, so it is a Premium feature.
+
+<div>
+{{ table_of_contents | heading: "Table of Contents" }}
+</div>
+
+## Setup
+
+First, [enable the API](/api) in your Pagecord blog settings and copy your API key.
+
+Your Micropub endpoint is:
+
+```text
+https://api.pagecord.com/micropub
+```
+
+Your media endpoint is:
+
+```text
+https://api.pagecord.com/micropub/media
+```
+
+Pagecord includes a `<link rel="micropub">` tag in your blog HTML, so apps that support endpoint discovery can find the endpoint from your blog URL.
+
+If an app asks for a profile, site, or blog URL, enter your public blog URL. If it explicitly asks for a Micropub endpoint, enter the API URL above.
+
+## Using iA Writer
+
+iA Writer has built-in Micropub support on Mac, iPhone, and iPad.
+
+1. Generate or copy your Pagecord API key from Settings > API.
+2. In iA Writer, go to Settings > Publishing.
+3. Add a Micropub account.
+4. Choose manual token entry.
+5. Enter your blog URL, for example `https://example.pagecord.com`, and paste your Pagecord API key. Do not enter `https://api.pagecord.com/micropub` unless iA Writer explicitly asks for a Micropub endpoint.
+6. In the Micropub publishing options, set the format to Markdown.
+
+You can then publish from iA Writer as a draft or published post, depending on the options iA Writer shows for your device.
+
+## Supported Features
+
+Pagecord supports creating and updating posts with:
+
+- Title
+- Markdown or HTML content
+- Draft or published status
+- Tags
+- Slug
+- Published date
+- Image uploads through the media endpoint
+- Image descriptions from apps, stored as captions
+
+Pagecord does not currently support cross-posting targets through Micropub. The `syndicate-to` response is intentionally empty.
+
+## Authentication
+
+Send your API key as a Bearer token:
+
+```text
+Authorization: Bearer YOUR_API_KEY
+```
+
+Micropub form requests may also send the same token as `access_token`.
+
+## Creating Posts
+
+Form-encoded request:
+
+```text
+POST /micropub
+Content-Type: application/x-www-form-urlencoded
+
+h=entry&name=My+Post&content=Hello+**world**&category[]=writing
+```
+
+JSON request:
+
+```json
+{
+  "type": ["h-entry"],
+  "properties": {
+    "name": ["My Post"],
+    "content": ["Hello **world**"],
+    "category": ["writing"],
+    "post-status": ["draft"]
+  }
+}
+```
+
+On success, Pagecord returns `201 Created` with a `Location` header pointing to the post.
+
+## Updating Posts
+
+Updates use JSON and require the post URL.
+
+```json
+{
+  "action": "update",
+  "url": "https://example.pagecord.com/my-post",
+  "replace": {
+    "content": ["Updated **content**"],
+    "post-status": ["published"]
+  }
+}
+```
+
+Tags can be added or removed:
+
+```json
+{
+  "action": "update",
+  "url": "https://example.pagecord.com/my-post",
+  "add": {
+    "category": ["notes"]
+  },
+  "delete": {
+    "category": ["draft"]
+  }
+}
+```
+
+## Images
+
+Upload images before creating or updating a post:
+
+```text
+POST /micropub/media
+Content-Type: multipart/form-data
+
+file=@photo.jpg
+```
+
+On success, Pagecord returns `201 Created` with a `Location` header. Use that URL in your Markdown content or as a Micropub `photo` property.
+
+## Source Queries
+
+Apps can ask Pagecord for a post's source properties:
+
+```text
+GET /micropub?q=source&url=https://example.pagecord.com/my-post
+```
+
+To request specific properties only, add `properties[]=name&properties[]=content`.

--- a/test/controllers/api/micropub_controller_test.rb
+++ b/test/controllers/api/micropub_controller_test.rb
@@ -1,0 +1,377 @@
+require "test_helper"
+
+class Api::MicropubControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "api.example.com"
+
+    @blog = blogs(:joel)
+    @user = users(:joel)
+    @user.update!(trial_ends_at: 30.days.from_now)
+
+    @post = posts(:one)
+  end
+
+  test "returns unauthorized without token" do
+    post "/micropub", params: { h: "entry", name: "Test", content: "Hello" }
+
+    assert_response :unauthorized
+    assert_equal "unauthorized", JSON.parse(response.body)["error"]
+  end
+
+  test "returns unauthorized with invalid token" do
+    post "/micropub", params: { h: "entry", name: "Test", content: "Hello" }, headers: auth_header("bad-token")
+
+    assert_response :unauthorized
+    assert_equal "insufficient_scope", JSON.parse(response.body)["error"]
+  end
+
+  test "accepts access token form parameter" do
+    post "/micropub", params: {
+      h: "entry", name: "Form Token", content: "Hello", access_token: "test_api_key_for_fixtures"
+    }
+
+    assert_response :created
+  end
+
+  test "returns forbidden without premium access" do
+    @user.subscription.destroy!
+    @user.update!(trial_ends_at: nil)
+
+    post "/micropub", params: { h: "entry", name: "Test", content: "Hello" }, headers: auth_header
+
+    assert_response :forbidden
+  end
+
+  test "creates a post from form encoded params" do
+    assert_difference "Post.count" do
+      post "/micropub",
+        params: { h: "entry", name: "Hello World", content: "Some **content**" },
+        headers: auth_header
+    end
+
+    assert_response :created
+    assert_includes response.headers["Location"], "hello-world"
+
+    created_post = @blog.posts.find_by(slug: "hello-world")
+    assert_equal "Hello World", created_post.title
+    assert_includes created_post.content.body.to_html, "<strong>content</strong>"
+  end
+
+  test "returns edit location for draft posts" do
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "Draft Post" ],
+          content: [ "Hello" ],
+          "post-status": [ "draft" ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    created_post = @blog.posts.find_by!(token: response.headers["Location"].split("/")[-2])
+    assert_equal edit_app_post_url(created_post, host: "example.com"), response.headers["Location"]
+  end
+
+  test "creates a draft post with tags and custom slug" do
+    post "/micropub",
+      params: {
+        h: "entry",
+        name: "Draft Post",
+        content: "Hello",
+        "category[]": [ "ruby", "rails" ],
+        "mp-slug": "custom-slug",
+        "post-status": "draft"
+      },
+      headers: auth_header
+
+    assert_response :created
+    created_post = @blog.posts.find_by(slug: "custom-slug")
+    assert created_post.draft?
+    assert_equal %w[rails ruby], created_post.tag_list
+  end
+
+  test "creates a post from mf2 json" do
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "mf2 Post" ],
+          content: [ { html: "<p>Hello from iA Writer</p>" } ],
+          "post-status": [ "draft" ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    created_post = @blog.posts.find_by(slug: "mf2-post")
+    assert_equal "mf2 Post", created_post.title
+    assert created_post.draft?
+    assert_includes created_post.content.body.to_html, "Hello from iA Writer"
+  end
+
+  test "creates a post from mf2 content value" do
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "mf2 Value Post" ],
+          content: [ { value: "Hello **from value**" } ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    created_post = @blog.posts.find_by(slug: "mf2-value-post")
+    assert_includes created_post.content.body.to_html, "<strong>from value</strong>"
+  end
+
+  test "rejects invalid post status" do
+    post "/micropub",
+      params: { h: "entry", content: "Hello", "post-status": "queued" },
+      headers: auth_header
+
+    assert_response :bad_request
+    assert_equal "invalid_request", JSON.parse(response.body)["error"]
+  end
+
+  test "media endpoint uploads file and returns location" do
+    file = fixture_file_upload("space.jpg", "image/jpeg")
+
+    assert_difference -> { ActiveStorage::Blob.count } do
+      post "/micropub/media", params: { file: file }, headers: auth_header
+    end
+
+    assert_response :created
+    assert_includes response.headers["Location"], "/rails/active_storage/blobs/"
+    assert_empty response.body
+  end
+
+  test "media endpoint accepts access token form parameter" do
+    file = fixture_file_upload("space.jpg", "image/jpeg")
+
+    assert_difference -> { ActiveStorage::Blob.count } do
+      post "/micropub/media", params: { file: file, access_token: "test_api_key_for_fixtures" }
+    end
+
+    assert_response :created
+    assert_includes response.headers["Location"], "/rails/active_storage/blobs/"
+  end
+
+  test "creates post with uploaded media url as action text attachment" do
+    file = fixture_file_upload("space.jpg", "image/jpeg")
+    post "/micropub/media", params: { file: file }, headers: auth_header
+    media_url = response.headers["Location"]
+
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "Photo Post" ],
+          content: [ "A photo" ],
+          photo: [ { value: media_url, alt: "Stars" } ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    created_post = @blog.posts.find_by(slug: "photo-post")
+    stored_html = created_post.content.body.to_html
+    assert_includes stored_html, "action-text-attachment"
+    assert_includes stored_html, 'caption="Stars"'
+  end
+
+  test "updates a post with replace and returns created when url changes" do
+    post "/micropub",
+      params: {
+        action: "update",
+        url: "http://joel.example.com/#{@post.slug}",
+        replace: {
+          name: [ "New Title" ],
+          "mp-slug": [ "new-slug" ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    assert_includes response.headers["Location"], "new-slug"
+    assert_equal "New Title", @post.reload.title
+    assert_equal "new-slug", @post.slug
+  end
+
+  test "adds and deletes tags via update" do
+    @post.update!(tag_list: [ "photography", "travel" ])
+
+    post "/micropub",
+      params: {
+        action: "update",
+        url: "http://joel.example.com/#{@post.slug}",
+        add: { category: [ "newtag" ] },
+        delete: { category: [ "travel" ] }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :ok
+    assert_includes @post.reload.tag_list, "newtag"
+    assert_includes @post.tag_list, "photography"
+    assert_not_includes @post.tag_list, "travel"
+  end
+
+  test "deletes a post" do
+    post "/micropub",
+      params: { action: "delete", url: "http://joel.example.com/#{@post.slug}" }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :ok
+    assert @post.reload.discarded?
+  end
+
+  test "update rejects urls from other hosts" do
+    assert_no_changes -> { @post.reload.title } do
+      post "/micropub",
+        params: {
+          action: "update",
+          url: "http://elsewhere.example.com/#{@post.slug}",
+          replace: { name: [ "Wrong Host" ] }
+        }.to_json,
+        headers: auth_header.merge("Content-Type" => "application/json")
+    end
+
+    assert_response :not_found
+  end
+
+  test "config query returns media endpoint and empty syndication targets" do
+    get "/micropub", params: { q: "config" }, headers: auth_header
+
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal "http://api.example.com/micropub/media", json["media-endpoint"]
+    assert_equal [], json["syndicate-to"]
+    assert_equal %w[published draft], json["post-status"]
+  end
+
+  test "config query advertises micropub endpoint" do
+    get "/micropub", params: { q: "config" }
+
+    assert_response :ok
+    assert_equal '<http://api.example.com/micropub>; rel="micropub"', response.headers["Link"]
+  end
+
+  test "blank query returns public config for client setup" do
+    get "/micropub"
+
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal "http://api.example.com/micropub/media", json["media-endpoint"]
+    assert_equal [], json["syndicate-to"]
+  end
+
+  test "config query does not require authentication" do
+    get "/micropub", params: { q: "config" }
+
+    assert_response :ok
+  end
+
+  test "syndicate to query returns empty targets" do
+    get "/micropub", params: { q: "syndicate-to" }, headers: auth_header
+
+    assert_response :ok
+    assert_equal({ "syndicate-to" => [] }, JSON.parse(response.body))
+  end
+
+  test "source query requires authentication" do
+    get "/micropub", params: { q: "source", url: "http://joel.example.com/#{@post.slug}" }
+
+    assert_response :unauthorized
+  end
+
+  test "source query returns post properties" do
+    get "/micropub", params: { q: "source", url: "http://joel.example.com/#{@post.slug}" }, headers: auth_header
+
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal [ "h-entry" ], json["type"]
+    assert_equal [ @post.title ], json["properties"]["name"]
+    assert_equal [ @post.slug ], json["properties"]["mp-slug"]
+  end
+
+  test "source query returns simple content as text" do
+    post "/micropub",
+      params: {
+        h: "entry",
+        content: "Test of querying the endpoint for the source content",
+        "category[]": [ "micropub", "test" ]
+      },
+      headers: auth_header
+
+    created_post = @blog.posts.find_by!(slug: response.headers["Location"].split("/").last)
+
+    get "/micropub", params: { q: "source", url: "http://joel.example.com/#{created_post.slug}" }, headers: auth_header
+
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_not json["properties"].key?("name")
+    assert_equal [ "Test of querying the endpoint for the source content" ], json["properties"]["content"]
+    assert_equal %w[micropub test], json["properties"]["category"]
+  end
+
+  test "source query filters requested properties" do
+    get "/micropub",
+      params: {
+        q: "source",
+        url: "http://joel.example.com/#{@post.slug}",
+        "properties[]": [ "name", "content", "mp-slug", "post-status" ]
+      },
+      headers: auth_header
+
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_not json.key?("type")
+    assert_equal %w[content mp-slug name post-status], json["properties"].keys.sort
+    assert_equal [ @post.slug ], json["properties"]["mp-slug"]
+    assert_equal [ @post.status ], json["properties"]["post-status"]
+  end
+
+  test "source query accepts posts path urls" do
+    get "/micropub", params: { q: "source", url: "http://joel.example.com/posts/#{@post.slug}" }, headers: auth_header
+
+    assert_response :ok
+  end
+
+  test "source query accepts custom domain urls" do
+    @blog.update!(custom_domain: "joel.test")
+
+    get "/micropub", params: { q: "source", url: "http://joel.test/#{@post.slug}" }, headers: auth_header
+
+    assert_response :ok
+  end
+
+  test "source query rejects urls from other hosts" do
+    get "/micropub", params: { q: "source", url: "http://elsewhere.example.com/#{@post.slug}" }, headers: auth_header
+
+    assert_response :not_found
+  end
+
+  test "unknown query returns bad request" do
+    get "/micropub", params: { q: "unknown" }, headers: auth_header
+
+    assert_response :bad_request
+    assert_equal "invalid_request", JSON.parse(response.body)["error"]
+  end
+
+  test "unknown action returns bad request" do
+    post "/micropub",
+      params: { action: "undelete", url: "http://joel.example.com/#{@post.slug}" }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :bad_request
+    assert_equal "invalid_request", JSON.parse(response.body)["error"]
+  end
+
+  private
+
+    def auth_header(token = "test_api_key_for_fixtures")
+      { "Authorization" => "Bearer #{token}" }
+    end
+end


### PR DESCRIPTION
## Summary

Adds Micropub support for publishing to Pagecord from compatible writing apps such as iA Writer.

This includes:
- Micropub create, update, delete, config, syndication, and source-query endpoints
- A Micropub media endpoint backed by the existing API attachment upload flow
- Bearer-token and Micropub form `access_token` authentication
- Blog `<link rel="micropub">` discovery for premium/trial users
- Draft `Location` responses pointing to the app edit URL instead of a public 404ing slug
- Action Text attachment conversion for uploaded Micropub media, preserving image alt text as captions
- Help guide documentation and API settings link

## Notes

The implementation was tested against Micropub.rocks during development. The final fixes in this branch address source-query response shape and Micropub-style authentication errors expected by the validator.

## Checks

- `bin/rails test test/controllers/api/micropub_controller_test.rb`
- `bin/rails test test/controllers/api test/helpers/routing_helper_test.rb`
- `bundle exec rubocop --cache false app/controllers/api/base_controller.rb app/controllers/api/micropub_controller.rb test/controllers/api/micropub_controller_test.rb`
- `bundle exec rubocop --cache false app/controllers/api/micropub_controller.rb app/models/micropub/post_params.rb test/controllers/api/micropub_controller_test.rb`