### PR TITLE
Add Finnish translation

### DIFF
--- a/app/models/concerns/localisable.rb
+++ b/app/models/concerns/localisable.rb
@@ -1,7 +1,7 @@
 module Localisable
   extend ActiveSupport::Concern
 
-  SUPPORTED_LOCALES = %w[en es fr de nl pt ja id].freeze
+  SUPPORTED_LOCALES = %w[en es fr de nl pt ja id fi].freeze
 
   included do
     class_attribute :locale_optional, default: false
@@ -21,7 +21,8 @@ module Localisable
         [ "Nederlands", "nl" ],
         [ "Português", "pt" ],
         [ "日本語", "ja" ],
-        [ "Bahasa Indonesia", "id" ]
+        [ "Bahasa Indonesia", "id" ],
+        [ "Suomi", "fi" ]
       ]
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module Pagecord
     config.active_record.automatically_invert_plural_associations = true
 
     # Configure available locales
-    config.i18n.available_locales = [ :en, :es, :fr, :de, :nl, :pt, :ja, :id ]
+    config.i18n.available_locales = [ :en, :es, :fr, :de, :nl, :pt, :ja, :id, :fi ]
     config.i18n.default_locale = :en
 
     config.filter_parameters += [ :RawEmail, :Attachments, :HtmlBody, :TextBody, :Headers ]

--- a/config/locales/contact_form.fi.yml
+++ b/config/locales/contact_form.fi.yml
@@ -1,0 +1,5 @@
+fi:
+  contact_form:
+    mailer:
+      subject: "Uusi viesti henkilöltä %{name}"
+      intro: "Sait viestin blogin %{blog_name} yhteydenottolomakkeen kautta."

--- a/config/locales/dates.fi.yml
+++ b/config/locales/dates.fi.yml
@@ -1,0 +1,6 @@
+fi:
+  date:
+    formats:
+      post_date: "%d.%m.%Y"
+      post_date_short: "%d.%m"
+      month_day: "%d.%m"

--- a/config/locales/email_form.fi.yml
+++ b/config/locales/email_form.fi.yml
@@ -1,0 +1,14 @@
+fi:
+  email_form:
+    form:
+      name_label: "Nimesi"
+      email_label: "Sähköpostisi"
+      message_label: "Viesti"
+      submit_button: "Lähetä"
+    success_message: "Viesti lähetetty!"
+    error_message: "Viestin lähettämisessä tapahtui virhe."
+    rate_limit_message: "Olet lähettänyt liian monta viestiä liian nopeasti. Yritä myöhemmin uudelleen."
+    mailer:
+      from_label: "Lähettäjä"
+      footer: "Vastaa tähän sähköpostiin vastataksesi henkilölle %{name}."
+      footer_text: "Vastaa tähän sähköpostiin vastataksesi henkilölle %{name}."

--- a/config/locales/email_subscribers.fi.yml
+++ b/config/locales/email_subscribers.fi.yml
@@ -1,0 +1,44 @@
+fi:
+  email_subscribers:
+    form:
+      subscribe_description:
+        digest: "Tilaa viikoittainen kooste julkaisuista sähköpostiisi"
+        individual: "Tilaa uudet julkaisut sähköpostiisi"
+      email_placeholder: "Kirjoita sähköpostiosoitteesi..."
+      submit_button: "Tilaa"
+    create:
+      success_message: "Kiitos tilauksesta. Ellet ole jo tilaaja, vahvistusviesti on matkalla osoitteeseen %{email}"
+    confirmations:
+      success_message:
+        digest: "Tilauksesi blogiin %{blog_name} on vahvistettu. Saat viikoittaisen sähköpostikoosteen, kun uusia julkaisuja julkaistaan."
+        individual: "Tilauksesi blogiin %{blog_name} on vahvistettu. Saat sähköpostin, kun uusia julkaisuja julkaistaan."
+      unsubscribe_link: "Peru tilaus"
+    unsubscribes:
+      success_message: "Tilauksesi blogiin %{blog_name} on nyt peruttu 👋"
+      confirm_message: "Peruaksesi tilauksen blogiin %{blog_name}, napsauta alla olevaa linkkiä."
+      unsubscribe_button: "Peru tilaus"
+      not_found: "Sähköpostitilausta ei löytynyt"
+    mailers:
+      shared:
+        footer: "Olet tilannut uudet julkaisut blogista %{blog_name}."
+        unsubscribe_link: "Peru tilaus"
+        unsubscribe_text: "Peru tilaus napsauttamalla alla olevaa linkkiä:"
+        view_online: "Lue tämä julkaisu verkossa"
+      confirmation:
+        subject: "Vahvista tilauksesi blogiin %{blog_name}"
+        message: "Vahvista tilauksesi blogiin %{blog_name}. Jos et tarkoittanut tilata, voit ohittaa tämän viestin."
+        button: "Tilaa minut"
+      weekly_digest:
+        subject: "Uusia julkaisuja blogista %{blog_name} – %{date}"
+        footer: "Olet tilannut uudet julkaisut blogista %{blog_name}."
+        unsubscribe_link: "Peru tilaus"
+      individual:
+        default_subject: "Uusi julkaisu blogista %{blog_name} – %{date}"
+  posts:
+    read_more: "Lue lisää…"
+  replies:
+    form:
+      subject_label: "Aihe"
+      cancel_link: "Peruuta"
+    mailer:
+      intro: "Hienoa! Joku vastasi julkaisuusi"

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -150,6 +150,9 @@ class BlogTest < ActiveSupport::TestCase
     @blog.locale = "de"
     assert @blog.valid?
 
+    @blog.locale = "fi"
+    assert @blog.valid?
+
     @blog.locale = "invalid"
     assert_not @blog.valid?
     assert_includes @blog.errors.full_messages, "Locale invalid is not a supported locale"


### PR DESCRIPTION
## Summary

- Add Finnish translations for public blog dates, contact forms, email forms, subscriber emails, post read-more copy, and reply labels.
- Register Finnish as a supported locale so it can be selected and validated.
- Cover Finnish in the existing blog locale validation test.

## Validation

- `bin/rails test test/models/blog_test.rb test/models/post_test.rb`
- Rails runner check that Finnish locale keys match English for the touched namespaces