### PR TITLE
Web view for post digests

### DIFF
--- a/app/controllers/blogs/post_digests_controller.rb
+++ b/app/controllers/blogs/post_digests_controller.rb
@@ -1,0 +1,10 @@
+class Blogs::PostDigestsController < Blogs::BaseController
+  def show
+    digest = PostDigest.find_by_masked_id(params[:masked_id])
+    @digest = @blog.post_digests.find(digest&.id)
+    @posts = @digest.posts.visible.for_blog_render.ordered_by_published
+
+    set_blog_cache_headers
+    fresh_when etag: [ @digest.id, @blog.updated_at ], last_modified: @blog.updated_at, public: true
+  end
+end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -18,6 +18,8 @@ module BlogsHelper
       else
         "#{blog_title(@post.blog)} - #{@post.display_date_in_user_timezone.to_formatted_s(:long)}"
       end
+    elsif @digest
+      "#{@digest.subject} - #{@blog.display_name}"
     elsif @blog
       blog_title(@blog)
     end
@@ -32,6 +34,8 @@ module BlogsHelper
   def meta_description
     if @post
       @post.summary(limit: 160)
+    elsif @digest
+      @digest.subject
     elsif @blog.present?
       blog_description(@blog)
     end

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -27,6 +27,10 @@ module RoutingHelper
     route_for_blog(blog, "blog_feed_xml", "url", options)
   end
 
+  def post_digest_url_for(digest)
+    blog_post_digest_url(digest.masked_id, host: host(digest.blog))
+  end
+
   def sitemap_url_for(blog)
     route_for_blog(blog, "blog_sitemap", "url")
   end

--- a/app/views/blogs/post_digests/show.html.erb
+++ b/app/views/blogs/post_digests/show.html.erb
@@ -1,0 +1,16 @@
+<%= render "blogs/header", hide_email_form: true %>
+
+<div class="digest" data-controller="media-embeds lightbox">
+  <% @posts.each do |post| %>
+    <article class="post h-entry">
+      <%= render "blogs/posts/post_title", post: post %>
+      <%= render "blogs/posts/post_content", post: post %>
+
+      <footer>
+        <%= link_to post_path(post), class: "post-date u-url", data: { turbo_frame: "_top" } do %>
+          <%= local_time post.published_at, format: published_at_date_format, class: "dt-published" %>
+        <% end %>
+      </footer>
+    </article>
+  <% end %>
+</div>

--- a/app/views/post_digest_mailer/weekly_digest.html.erb
+++ b/app/views/post_digest_mailer/weekly_digest.html.erb
@@ -4,6 +4,8 @@
   <hr>
 
   <p class="digest-footer">
+    <%= link_to t('email_subscribers.mailers.shared.view_digest_online'), post_digest_url_for(@digest) %>
+    <br><br>
     <%= t('email_subscribers.mailers.shared.footer', blog_name: @subscriber.blog.display_name) %>
     <br>
     <%= link_to t('email_subscribers.mailers.shared.unsubscribe_link'), email_subscriber_unsubscribe_url_for(@subscriber) %>

--- a/app/views/post_digest_mailer/weekly_digest.text.erb
+++ b/app/views/post_digest_mailer/weekly_digest.text.erb
@@ -5,6 +5,12 @@
 
 ----------
 
+<%= t('email_subscribers.mailers.shared.view_digest_online') %>
+
+<%= post_digest_url_for(@digest) %>
+
+----------
+
 <%= t('email_subscribers.mailers.shared.footer', blog_name: @subscriber.blog.display_name) %>
 
 <%= t('email_subscribers.mailers.shared.unsubscribe_text') %>

--- a/config/locales/email_subscribers.de.yml
+++ b/config/locales/email_subscribers.de.yml
@@ -24,6 +24,7 @@ de:
         unsubscribe_link: "Abmelden"
         unsubscribe_text: "Zum Abmelden klicke auf den folgenden Link:"
         view_online: "Diesen Beitrag online ansehen"
+        view_digest_online: "Diese E-Mail online ansehen"
       confirmation:
         subject: "Bestätige dein Abonnement bei %{blog_name}"
         message: "Bitte bestätige dein Abonnement bei %{blog_name}. Wenn du dich nicht anmelden wolltest, kannst du diese E-Mail ignorieren."

--- a/config/locales/email_subscribers.en.yml
+++ b/config/locales/email_subscribers.en.yml
@@ -24,6 +24,7 @@ en:
         unsubscribe_link: "Unsubscribe"
         unsubscribe_text: "Unsubscribe by clicking the link below:"
         view_online: "View this post online"
+        view_digest_online: "View this email online"
       confirmation:
         subject: "Confirm your subscription to %{blog_name}"
         message: "Please confirm your subscription to %{blog_name}. If you didn't intend to subscribe, you can ignore this email."

--- a/config/locales/email_subscribers.es.yml
+++ b/config/locales/email_subscribers.es.yml
@@ -24,6 +24,7 @@ es:
         unsubscribe_link: "Cancelar suscripción"
         unsubscribe_text: "Cancela tu suscripción haciendo clic en el enlace de abajo:"
         view_online: "Ver este artículo en línea"
+        view_digest_online: "Ver este email en línea"
       confirmation:
         subject: "Confirma tu suscripción a %{blog_name}"
         message: "Por favor confirma tu suscripción a %{blog_name}. Si no tenías intención de suscribirte, puedes ignorar este correo."

--- a/config/locales/email_subscribers.fr.yml
+++ b/config/locales/email_subscribers.fr.yml
@@ -24,6 +24,7 @@ fr:
         unsubscribe_link: "Se désabonner"
         unsubscribe_text: "Désabonne-toi en cliquant sur le lien ci-dessous :"
         view_online: "Voir cet article en ligne"
+        view_digest_online: "Voir cet email en ligne"
       confirmation:
         subject: "Confirme ton abonnement à %{blog_name}"
         message: "Confirme ton abonnement à %{blog_name}. Si tu n'avais pas l'intention de t'abonner, tu peux ignorer cet email."

--- a/config/locales/email_subscribers.id.yml
+++ b/config/locales/email_subscribers.id.yml
@@ -24,6 +24,7 @@ id:
         unsubscribe_link: "Batalkan langganan"
         unsubscribe_text: "Batalkan langganan dengan mengetuk tautan di bawah ini:"
         view_online: "Tampilkan pos ini secara online"
+        view_digest_online: "Tampilkan email ini secara online"
       confirmation:
         subject: "Konfirmasikan langgananmu pada %{blog_name}"
         message: "Mohon konfirmasi langgananmu pada %{blog_name}. Jika kamu tidak berniat untuk berlangganan, kamu dapat mengabaikan email ini."

--- a/config/locales/email_subscribers.ja.yml
+++ b/config/locales/email_subscribers.ja.yml
@@ -24,6 +24,7 @@ ja:
         unsubscribe_link: "登録を解除する"
         unsubscribe_text: "登録を解除するには、以下のリンクをクリックしてください。"
         view_online: "この投稿をWebで読む"
+        view_digest_online: "このメールをWebで読む"
       confirmation:
         subject: "%{blog_name}の登録を確認してください"
         message: "%{blog_name}の登録を確認してください。心当たりがない場合は、このメールを無視してください。"

--- a/config/locales/email_subscribers.nl.yml
+++ b/config/locales/email_subscribers.nl.yml
@@ -24,6 +24,7 @@ nl:
         unsubscribe_link: "Afmelden"
         unsubscribe_text: "Meld je af via de onderstaande link:"
         view_online: "Bekijk dit bericht online"
+        view_digest_online: "Bekijk deze e-mail online"
       confirmation:
         subject: "Bevestig je abonnement op %{blog_name}"
         message: "Bevestig je abonnement op %{blog_name}. Als je je niet hebt aangemeld, kun je deze e-mail negeren."

--- a/config/locales/email_subscribers.pt.yml
+++ b/config/locales/email_subscribers.pt.yml
@@ -24,6 +24,7 @@ pt:
         unsubscribe_link: "Cancelar assinatura"
         unsubscribe_text: "Cancele sua assinatura clicando no link abaixo:"
         view_online: "Ver esta postagem online"
+        view_digest_online: "Ver este e-mail online"
       confirmation:
         subject: "Confirme sua assinatura em %{blog_name}"
         message: "Por favor, confirme sua assinatura no %{blog_name}. Se você não queria assinar, pode ignorar este e-mail."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,6 +290,8 @@ Rails.application.routes.draw do
       post "embeds/bandcamp", to: "embeds#bandcamp"
     end
 
+    get "/digests/:masked_id", to: "blogs/post_digests#show", as: :blog_post_digest
+
     get "/:slug", to: "blogs/posts#show", as: :blog_post
 
     resources :email_subscribers, controller: "blogs/email_subscribers", only: [ :create, :destroy ]

--- a/test/controllers/blogs/post_digests_controller_test.rb
+++ b/test/controllers/blogs/post_digests_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Blogs::PostDigestsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @blog = blogs(:joel)
+    @digest = post_digests(:one)
+    host! "#{@blog.subdomain}.#{Rails.application.config.x.domain}"
+  end
+
+  test "shows digest posts" do
+    get blog_post_digest_path(@digest.masked_id)
+
+    assert_response :success
+    assert_includes @response.body, "The Art of Street Photography"
+    assert_includes @response.body, "The Beauty of Landscape Photography"
+  end
+
+  test "returns not found for invalid masked id" do
+    get blog_post_digest_path("unknown")
+
+    assert_response :not_found
+  end
+
+  test "returns not found for digest from another blog" do
+    host! "vivian.#{Rails.application.config.x.domain}"
+
+    get blog_post_digest_path(@digest.masked_id)
+
+    assert_response :not_found
+  end
+
+  test "does not show posts that are no longer public" do
+    @digest.digest_posts.create!(post: posts(:joel_hidden))
+
+    get blog_post_digest_path(@digest.masked_id)
+
+    assert_response :success
+    assert_no_match "A Hidden Thought", @response.body
+  end
+end

--- a/test/mailers/post_digest_mailer_test.rb
+++ b/test/mailers/post_digest_mailer_test.rb
@@ -25,15 +25,29 @@ class PostDigestMailerTest < ActionMailer::TestCase
     assert_equal email_subscriber.token, email.header["X-PM-Metadata-SubscriberToken"].to_s
   end
 
+  test "digest email includes link to view digest online" do
+    digest = post_digests(:one)
+    email_subscriber = email_subscribers(:one)
+    expected_url = "http://#{digest.blog.subdomain}.#{Rails.application.config.x.domain}/digests/#{digest.masked_id}"
+
+    email = PostDigestMailer.with(subscriber: email_subscriber, digest: digest).weekly_digest
+
+    assert_includes email.html_part.body.encoded, "View this email online"
+    assert_includes email.html_part.body.encoded, expected_url
+    assert_includes email.text_part.body.encoded, "View this email online"
+    assert_includes email.text_part.body.encoded, expected_url
+  end
+
   test "digest email with custom blog domain" do
     blog = blogs(:joel)
     blog.update!(custom_domain: "custom.example.com")
     email_subscriber = email_subscribers(:one)
-    posts = [ posts(:one) ]
+    digest = post_digests(:one)
 
-    email = PostDigestMailer.with(subscriber: email_subscriber, digest: post_digests(:one)).weekly_digest
+    email = PostDigestMailer.with(subscriber: email_subscriber, digest: digest).weekly_digest
 
     assert_match "custom.example.com", email.body.encoded
+    assert_match "http://custom.example.com/digests/#{digest.masked_id}", email.body.encoded
   end
 
   test "digest email unwraps image attachments" do


### PR DESCRIPTION
## Summary

Adds a shareable web view for post digests so weekly digest emails can include a “View this email online” link.

## Changes

- Adds `/digests/:masked_id` on blog domains, scoped through the current blog.
- Renders digest posts with the normal blog layout and only includes posts that are still public.
- Adds `post_digest_url_for` and digest-specific page metadata.
- Adds weekly digest HTML/text links plus locale strings for existing email subscriber locales.
- Covers valid, invalid, cross-blog, hidden-post, and mailer-link cases.

## Validation

- `bin/rails test test/controllers/blogs/post_digests_controller_test.rb test/mailers/post_digest_mailer_test.rb test/models/post_digest_test.rb`
- `bundle exec rubocop app/controllers/blogs/post_digests_controller.rb app/helpers/blogs_helper.rb app/helpers/routing_helper.rb test/controllers/blogs/post_digests_controller_test.rb test/mailers/post_digest_mailer_test.rb`
- `git diff --check`