### PR TITLE
Plausible signup attribution

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Authentication, CustomDomainHelper
+  include Authentication, CustomDomainHelper, AttributionTrackable
 
   before_action :domain_check
 

--- a/app/controllers/concerns/attribution_trackable.rb
+++ b/app/controllers/concerns/attribution_trackable.rb
@@ -1,0 +1,38 @@
+module AttributionTrackable
+  extend ActiveSupport::Concern
+
+  SIGNUP_ATTRIBUTION_PARAMS = %w[utm_source utm_campaign].freeze
+  SIGNUP_ATTRIBUTION_TTL = 24.hours
+
+  included do
+    before_action :capture_signup_attribution
+  end
+
+  private
+
+    def capture_signup_attribution
+      return unless DomainConstraints.default_domain?(request)
+      return if signup_attribution.present?
+
+      attribution = params.permit(*SIGNUP_ATTRIBUTION_PARAMS).to_h.compact_blank
+      return if attribution.blank?
+
+      session[:signup_attribution] = attribution.merge("expires_at" => SIGNUP_ATTRIBUTION_TTL.from_now.iso8601)
+    end
+
+    def signup_attribution
+      attribution = session[:signup_attribution]
+      return {} unless attribution.is_a?(Hash)
+
+      expires_at = Time.zone.parse(attribution["expires_at"].to_s)
+      if expires_at.blank? || expires_at.past?
+        session.delete(:signup_attribution)
+        return {}
+      end
+
+      attribution.slice(*SIGNUP_ATTRIBUTION_PARAMS)
+    rescue ArgumentError
+      session.delete(:signup_attribution)
+      {}
+    end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,6 +9,7 @@ class HomeController < ApplicationController
 
     def set_cache_headers
       return if logged_in?
+      return if signup_attribution.present?
 
       expires_in 0, public: true, "s-maxage": 1.hour.to_i, "stale-while-revalidate": 10.minutes.to_i
     end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -29,9 +29,12 @@ class SignupsController < ApplicationController
     @user.features = [ "lexxy" ] if ENV["LEXXY_FOR_NEW_USERS"]
 
     if signup_from_allowed_timezone && @user.save
+      attribution = signup_attribution
+      session.delete(:signup_attribution)
+
       AccountVerificationMailer.with(user: @user).verify.deliver_later
 
-      redirect_to thanks_signups_path
+      redirect_to thanks_signups_path(attribution)
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/public/privacy.html.erb
+++ b/app/views/public/privacy.html.erb
@@ -32,6 +32,7 @@
   <h3 id="retention-and-cookies" class="source-serif font-semibold text-2xl">4. Retention & Cookies</h3>
   <p><strong>Retention:</strong> We keep account data for as long as your account is active. Upon deletion, data is removed from active databases within 30 days. Billing records are kept for 6 years as required by UK tax law.</p>
   <p><strong>Cookies:</strong> We use essential cookies to maintain your session and security. We do not use third-party tracking or advertising cookies.</p>
+  <p>If you arrive via a campaign link, we may briefly keep the campaign source and campaign name in your first-party session so Plausible can count signup conversions. This is not stored on your account.</p>
 
   <h3 id="childrens-privacy" class="source-serif font-semibold text-2xl">5. Children's Privacy</h3>
   <p>Pagecord does not knowingly collect data from children under the age of 13. If you are a parent or guardian and believe your child has provided us with personal data, please contact us at <a href="mailto:hello@pagecord.com">hello@pagecord.com</a> for immediate deletion.</p>

--- a/app/views/public/privacy.html.erb
+++ b/app/views/public/privacy.html.erb
@@ -32,7 +32,7 @@
   <h3 id="retention-and-cookies" class="source-serif font-semibold text-2xl">4. Retention & Cookies</h3>
   <p><strong>Retention:</strong> We keep account data for as long as your account is active. Upon deletion, data is removed from active databases within 30 days. Billing records are kept for 6 years as required by UK tax law.</p>
   <p><strong>Cookies:</strong> We use essential cookies to maintain your session and security. We do not use third-party tracking or advertising cookies.</p>
-  <p>If you arrive via a campaign link, we may briefly keep the campaign source and campaign name in your first-party session so Plausible can count signup conversions. This is not stored on your account.</p>
+  <p>If you arrive via a campaign link, we may briefly keep campaign details in your first-party session so Plausible can count signup conversions. This is not stored on your account.</p>
 
   <h3 id="childrens-privacy" class="source-serif font-semibold text-2xl">5. Children's Privacy</h3>
   <p>Pagecord does not knowingly collect data from children under the age of 13. If you are a parent or guardian and believe your child has provided us with personal data, please contact us at <a href="mailto:hello@pagecord.com">hello@pagecord.com</a> for immediate deletion.</p>

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -9,6 +9,20 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", text: "A blog you'll actually keep updated"
   end
 
+  test "should publicly cache unattributed home page" do
+    get root_path
+
+    assert_response :success
+    assert_includes @response.headers["Cache-Control"], "s-maxage=3600"
+  end
+
+  test "should not publicly cache attributed home page" do
+    get root_path, params: { utm_source: "reddit", utm_campaign: "obsidian_blog" }
+
+    assert_response :success
+    assert_not_includes @response.headers["Cache-Control"] || "", "s-maxage"
+  end
+
   test "should render home page when logged in" do
     user = users(:joel)
     login_as user

--- a/test/controllers/signups_controller_test.rb
+++ b/test/controllers/signups_controller_test.rb
@@ -15,6 +15,62 @@ class SignupsControllerTest < ActionDispatch::IntegrationTest
     assert_not User.last.marketing_consent
   end
 
+  test "should preserve signup attribution for plausible goal page" do
+    get root_url, params: {
+      utm_source: "reddit",
+      utm_campaign: "obsidian_blog",
+      utm_content: "ignored"
+    }
+
+    assert_difference("User.count") do
+      assert_emails 1 do
+        post signups_url, params: {
+          user: { email: "test@example.com", blogs_attributes: [ { subdomain: "testuser" } ] },
+          rendered_at: signed_rendered_at
+        }
+      end
+    end
+
+    assert_redirected_to thanks_signups_path(utm_source: "reddit", utm_campaign: "obsidian_blog")
+
+    assert_difference("User.count") do
+      assert_emails 1 do
+        post signups_url, params: {
+          user: { email: "second@example.com", blogs_attributes: [ { subdomain: "seconduser" } ] },
+          rendered_at: signed_rendered_at
+        }
+      end
+    end
+
+    assert_redirected_to thanks_signups_path
+  end
+
+  test "should keep signup attribution after validation failure" do
+    get root_url, params: { utm_source: "reddit", utm_campaign: "obsidian_blog" }
+
+    assert_no_difference("User.count") do
+      assert_emails 0 do
+        post signups_url, params: {
+          user: { email: "test@example.com", blogs_attributes: [ { subdomain: " invalid.subdomain" } ] },
+          rendered_at: signed_rendered_at
+        }
+      end
+    end
+
+    assert_response :unprocessable_entity
+
+    assert_difference("User.count") do
+      assert_emails 1 do
+        post signups_url, params: {
+          user: { email: "test@example.com", blogs_attributes: [ { subdomain: "testuser" } ] },
+          rendered_at: signed_rendered_at
+        }
+      end
+    end
+
+    assert_redirected_to thanks_signups_path(utm_source: "reddit", utm_campaign: "obsidian_blog")
+  end
+
   test "should capture signup attribution fields" do
     assert_difference("User.count") do
       post signups_url, params: { user: { email: "test@example.com", blogs_attributes: [ { subdomain: "testuser" } ], signup_referrer: "https://pagecord.com/pagecord_vs_substack", signup_source_note: "Hacker News" }, rendered_at: signed_rendered_at }


### PR DESCRIPTION
## Summary

- Capture `utm_source` and `utm_campaign` in a short-lived first-party session attribution value.
- Redirect successful signups to `/signups/thanks` with the captured UTM params so Plausible can attribute the existing pageview goal.
- Avoid public homepage caching while attribution is present and clarify the privacy policy language.

## Validation

- `bin/rails test test/controllers/home_controller_test.rb test/controllers/signups_controller_test.rb test/controllers/public_controller_test.rb`
- `RUBOCOP_CACHE_ROOT=/private/tmp/rubocop_cache bundle exec rubocop app/controllers/application_controller.rb app/controllers/concerns/attribution_trackable.rb app/controllers/home_controller.rb app/controllers/signups_controller.rb test/controllers/home_controller_test.rb test/controllers/signups_controller_test.rb`

Fizzy: https://app.fizzy.do/6102591/cards/334