### PR TITLE
Update blog footer branding

### DIFF
--- a/app/assets/stylesheets/blogs.css
+++ b/app/assets/stylesheets/blogs.css
@@ -110,10 +110,15 @@ footer.blog-footer {
   margin-top: auto;
 }
 
-footer.blog-footer #brand svg {
-  width: 110px;
-  display: inline-flex;
-  color: var(--color-text-heading);
+footer.blog-footer .brand-credit {
+  color: var(--color-text);
+  font-size: 0.875em;
+}
+
+footer.blog-footer #brand {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }
 
 /* ============================= */

--- a/app/views/app/settings/appearance/_form.html.erb
+++ b/app/views/app/settings/appearance/_form.html.erb
@@ -85,7 +85,7 @@
       <div>
         <%= form.label :show_branding, "Show Pagecord branding", class: "text-slate-800 dark:text-slate-100" %>
         <p class="text-slate-500 text-sm">
-          When checked, the Pagecord logo will be displayed at the bottom of each page on your blog. Please consider
+          When checked, a Made with Pagecord credit will be displayed at the bottom of each page on your blog. Please consider
           keeping this on to help spread the word about Pagecord!
         </p>
       </div>

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -99,9 +99,7 @@
             <% end %>
 
             <% if @blog.show_branding? %>
-              <%= link_to "https://pagecord.com", id: "brand", aria: { label: "Pagecord Home" } do %>
-                <%= inline_svg_tag "logo-black.svg" %>
-              <% end %>
+              <span class="brand-credit">Made with <%= link_to "Pagecord", "https://pagecord.com", id: "brand" %></span>
             <% end %>
           </footer>
         <% end %>

--- a/docs/help-guide/custom-css.md
+++ b/docs/help-guide/custom-css.md
@@ -67,7 +67,7 @@ To help you know which elements to target, here is a visual map of the blog page
 │ │ └──────────────────────────────────────────────────┘ │ │
 │ │                                                      │ │
 │ │ ┌──────────────────────────────────────────────────┐ │ │
-│ │ │ .blog-footer (Pagecord branding)                 │ │ │
+│ │ │ .blog-footer (Custom footer and Pagecord credit) │ │ │
 │ │ └──────────────────────────────────────────────────┘ │ │
 │ └──────────────────────────────────────────────────────┘ │
 └──────────────────────────────────────────────────────────┘
@@ -89,6 +89,27 @@ For safety, Pagecord validates custom CSS before saving it:
 ## Examples
 
 Here are some examples of CSS snippets you can use to customise your blog.
+
+### Changing the Pagecord credit language
+
+The footer credit says "Made with Pagecord" by default. To translate the text while keeping only "Pagecord" as the link, hide the original words and add your own:
+
+```css
+footer.blog-footer .brand-credit {
+  font-size: 0;
+}
+
+footer.blog-footer .brand-credit::before {
+  content: "Feito com ";
+  font-size: 0.875rem;
+}
+
+footer.blog-footer #brand {
+  font-size: 0.875rem;
+}
+```
+
+For more control, hide Pagecord branding in Settings > Appearance and add your own custom footer.
 
 ### Changing the font
 

--- a/docs/help-guide/custom-footer.md
+++ b/docs/help-guide/custom-footer.md
@@ -12,11 +12,13 @@ Premium customers can add an HTML snippet to the footer of their blog. This is u
 
 To add your own custom HTML, head over to **Settings** → **Appearance** → **Custom footer**
 
-Your custom footer appears at the bottom of every blog page, above the Pagecord logo if you have branding enabled.
+Your custom footer appears at the bottom of every blog page, above the Made with Pagecord credit if you have branding enabled.
 
 ### A Quick Note
 
 Custom footer is intended for small, simple snippets. Pagecord checks that the HTML is safe before saving it, and snippets must be under 4KB. Customer support for writing or debugging custom HTML and CSS is limited.
+
+For custom or translated attribution text, hide Pagecord branding and add your own custom footer.
 
 ## What HTML is supported?
 

--- a/docs/help-guide/customising-your-blog.md
+++ b/docs/help-guide/customising-your-blog.md
@@ -68,7 +68,7 @@ Choose how posts appear on your home page:
 
 ### Branding
 
-Premium feature. Choose whether to hide the Pagecord logo at the bottom of your blog (please consider keeping it to spread the good word about Pagecord!)
+Premium feature. Choose whether to hide the Made with Pagecord credit at the bottom of your blog (please consider keeping it to spread the good word about Pagecord!)
 
 ### Custom footer
 

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -918,11 +918,12 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "time[datetime$='T19:45:00Z']"
   end
 
-  test "should pagecord branding" do
+  test "should show pagecord branding" do
     get blog_posts_path
 
     assert_response :success
-    assert_select "footer a[id=brand]", count: 1
+    assert_select "footer.blog-footer", text: /Made with Pagecord/
+    assert_select "footer a[id=brand]", text: "Pagecord", count: 1
   end
 
   test "should hide pagecord branding when show_branding off" do

--- a/test/fixtures/theme_templates.yml
+++ b/test/fixtures/theme_templates.yml
@@ -782,12 +782,11 @@ mozake:
     .email-form-container { display: block; text-align: revert; }
     .email-form-container fieldset { margin: 0.5em 0; padding: 0; }
 
-    /* Footer – text link instead of logo */
+    /* Footer */
     footer.blog-footer {
       margin-top: 2em; padding: 0; display: block;
     }
-    footer.blog-footer #brand svg { display: none; }
-    footer.blog-footer #brand::after { content: "Pagecord"; margin-bottom: 1em; display: block; }
+    footer.blog-footer .brand-credit { margin-bottom: 1em; display: block; }
 
     /* Misc */
     .tag-filter-notice { background: transparent; border: none; border-radius: 0; padding: 0; font-size: revert; color: revert; }


### PR DESCRIPTION
## Summary

- Replace the public blog footer logo with a text credit: `Made with Pagecord`, where only `Pagecord` is linked.
- Style the footer link with the current blog accent colour and underline.
- Document the Custom CSS translation approach and update branding/help copy.
- Update the Mozake theme fixture to target `.brand-credit` instead of the old SVG/pseudo-element footer hack.

## Notes

- The footer link stays as plain `https://pagecord.com`; no UTM/tracking params were added.
- Existing production ThemeTemplate rows are not migrated here. Mozake can be updated manually in production/admin from the fixture change.

## Checks

- `bin/rails test test/controllers/blogs/posts_controller_test.rb test/integration/custom_footer_html_rendering_test.rb test/controllers/app/settings/appearance_controller_test.rb`
- `bin/rails test test/controllers/app/settings/theme_garden_controller_test.rb test/controllers/admin/theme_templates_controller_test.rb`