### PR TITLE
Add Polish (pl) translation

### DIFF
--- a/app/models/concerns/localisable.rb
+++ b/app/models/concerns/localisable.rb
@@ -1,7 +1,7 @@
 module Localisable
   extend ActiveSupport::Concern
 
-  SUPPORTED_LOCALES = %w[en id de es fr nl pt fi ja].freeze
+  SUPPORTED_LOCALES = %w[en id de es fr nl pl pt fi ja].freeze
 
   included do
     class_attribute :locale_optional, default: false
@@ -20,6 +20,7 @@ module Localisable
         [ "Español", "es" ],
         [ "Français", "fr" ],
         [ "Nederlands", "nl" ],
+        [ "Polski", "pl" ],
         [ "Português", "pt" ],
         [ "Suomi", "fi" ],
         [ "日本語", "ja" ]

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module Pagecord
     config.active_record.automatically_invert_plural_associations = true
 
     # Configure available locales
-    config.i18n.available_locales = [ :en, :id, :de, :es, :fr, :nl, :pt, :fi, :ja ]
+    config.i18n.available_locales = [ :en, :id, :de, :es, :fr, :nl, :pl, :pt, :fi, :ja ]
     config.i18n.default_locale = :en
 
     config.filter_parameters += [ :RawEmail, :Attachments, :HtmlBody, :TextBody, :Headers ]

--- a/config/locales/contact_form.pl.yml
+++ b/config/locales/contact_form.pl.yml
@@ -1,0 +1,5 @@
+pl:
+  contact_form:
+    mailer:
+      subject: "Nowa wiadomość od %{name}"
+      intro: "Otrzymałeś wiadomość przez formularz kontaktowy bloga %{blog_name}."

--- a/config/locales/dates.pl.yml
+++ b/config/locales/dates.pl.yml
@@ -1,0 +1,6 @@
+pl:
+  date:
+    formats:
+      post_date: "%d.%m.%Y"
+      post_date_short: "%d.%m"
+      month_day: "%d.%m"

--- a/config/locales/email_form.pl.yml
+++ b/config/locales/email_form.pl.yml
@@ -1,0 +1,14 @@
+pl:
+  email_form:
+    form:
+      name_label: "Twoje imię"
+      email_label: "Twój e-mail"
+      message_label: "Wiadomość"
+      submit_button: "Wyślij"
+    success_message: "Wiadomość wysłana!"
+    error_message: "Wystąpił problem podczas wysyłania wiadomości."
+    rate_limit_message: "Wysłałeś zbyt wiele wiadomości w zbyt krótkim czasie. Spróbuj ponownie później."
+    mailer:
+      from_label: "Od"
+      footer: "Odpowiedz na tego e-maila, aby napisać do %{name}."
+      footer_text: "Aby odpowiedzieć %{name}, po prostu odpowiedz na tego e-maila."

--- a/config/locales/email_subscribers.pl.yml
+++ b/config/locales/email_subscribers.pl.yml
@@ -1,0 +1,45 @@
+pl:
+  email_subscribers:
+    form:
+      subscribe_description:
+        digest: "Zasubskrybuj, aby otrzymywać cotygodniowy przegląd wpisów na swoją skrzynkę"
+        individual: "Zasubskrybuj, aby otrzymywać nowe wpisy e-mailem"
+      email_placeholder: "Wpisz swój e-mail..."
+      submit_button: "Subskrybuj"
+    create:
+      success_message: "Dziękujemy za subskrypcję. Jeśli nie subskrybujesz już, e-mail potwierdzający jest w drodze na adres %{email}"
+      rate_limit_message: "Zbyt wiele prób. Spróbuj ponownie później."
+    confirmations:
+      success_message:
+        digest: "Twoja subskrypcja bloga %{blog_name} została potwierdzona. Będziesz otrzymywać cotygodniowy przegląd, gdy pojawią się nowe wpisy."
+        individual: "Twoja subskrypcja bloga %{blog_name} została potwierdzona. Będziesz otrzymywać e-mail, gdy pojawią się nowe wpisy."
+      unsubscribe_link: "Anuluj subskrypcję"
+    unsubscribes:
+      success_message: "Subskrypcja bloga %{blog_name} została anulowana 👋"
+      confirm_message: "Aby anulować subskrypcję bloga %{blog_name}, kliknij poniższy link."
+      unsubscribe_button: "Anuluj subskrypcję"
+      not_found: "Nie znaleziono subskrypcji e-mail"
+    mailers:
+      shared:
+        footer: "Subskrybujesz nowe wpisy z bloga %{blog_name}."
+        unsubscribe_link: "Anuluj subskrypcję"
+        unsubscribe_text: "Anuluj subskrypcję, klikając poniższy link:"
+        view_online: "Zobacz ten wpis online"
+      confirmation:
+        subject: "Potwierdź subskrypcję bloga %{blog_name}"
+        message: "Potwierdź subskrypcję bloga %{blog_name}. Jeśli nie chciałeś subskrybować, możesz zignorować tego e-maila."
+        button: "Zasubskrybuj mnie"
+      weekly_digest:
+        subject: "Nowe wpisy z bloga %{blog_name} - %{date}"
+        footer: "Subskrybujesz nowe wpisy z bloga %{blog_name}."
+        unsubscribe_link: "Anuluj subskrypcję"
+      individual:
+        default_subject: "Nowy wpis z bloga %{blog_name} – %{date}"
+  posts:
+    read_more: "Czytaj dalej…"
+  replies:
+    form:
+      subject_label: "Temat"
+      cancel_link: "Anuluj"
+    mailer:
+      intro: "Hurra! Ktoś odpowiedział na Twój wpis"


### PR DESCRIPTION
Adds Polish as a supported interface language, matching the existing set of locales.

## Changes
- Register `:pl` in `config.i18n.available_locales` and add `pl` to `SUPPORTED_LOCALES`
- Add `Polski` to the language selector (`Localisable#available_locales`), ordered by native name before Português
- New locale files: `contact_form.pl.yml`, `dates.pl.yml`, `email_form.pl.yml`, `email_subscribers.pl.yml`

Covers the contact form, email subscription form, digest/confirmation mailers, replies, and date formats. Dates use the Polish `DD.MM.YYYY` convention. Key parity with the English files verified for all four files.

Fizzy: #347