### PR TITLE
Open avatars to all accounts with moderation

### DIFF
--- a/app/controllers/admin/moderation/avatars_controller.rb
+++ b/app/controllers/admin/moderation/avatars_controller.rb
@@ -1,0 +1,28 @@
+class Admin::Moderation::AvatarsController < AdminController
+  include Pagy::Method
+
+  def index
+    @pagy, @avatar_moderations = pagy(
+      AvatarModeration.needs_review
+                      .joins(blog: :user)
+                      .where(users: { discarded_at: nil })
+                      .includes(blog: :user)
+                      .order(moderated_at: :desc),
+      limit: 25
+    )
+    @total_unreviewed = AvatarModeration.needs_review.count
+  end
+
+  def dismiss
+    @avatar_moderation = AvatarModeration.find(params[:id])
+    @avatar_moderation.mark_as_reviewed!
+    redirect_to admin_moderation_avatars_path, notice: "Avatar kept and marked as reviewed"
+  end
+
+  def remove
+    @avatar_moderation = AvatarModeration.find(params[:id])
+    @avatar_moderation.blog.avatar.purge
+    @avatar_moderation.mark_as_reviewed!
+    redirect_to admin_moderation_avatars_path, notice: "Avatar removed"
+  end
+end

--- a/app/controllers/app/settings/about_controller.rb
+++ b/app/controllers/app/settings/about_controller.rb
@@ -4,6 +4,7 @@ class App::Settings::AboutController < AppController
 
   def update
     if @blog.update(about_params)
+      AvatarModerationJob.perform_later(@blog.id) if params.dig(:blog, :avatar).present?
       redirect_to app_settings_path, notice: "About settings updated"
     else
       render :index, status: :unprocessable_entity
@@ -13,9 +14,6 @@ class App::Settings::AboutController < AppController
   private
 
     def about_params
-      permitted_params = [ :bio, :title ]
-      permitted_params << :avatar if @blog.user.has_premium_access?
-
-      params.require(:blog).permit(permitted_params)
+      params.require(:blog).permit(:bio, :title, :avatar)
     end
 end

--- a/app/helpers/admin/moderation_helper.rb
+++ b/app/helpers/admin/moderation_helper.rb
@@ -11,4 +11,11 @@ module Admin::ModerationHelper
   def spam_detection_count
     @spam_detection_count ||= SpamDetection.needs_review.count
   end
+
+  def avatar_moderation_count
+    @avatar_moderation_count ||= AvatarModeration.needs_review
+                                                 .joins(blog: :user)
+                                                 .where(users: { discarded_at: nil })
+                                                 .count
+  end
 end

--- a/app/jobs/avatar_moderation_digest_job.rb
+++ b/app/jobs/avatar_moderation_digest_job.rb
@@ -1,0 +1,15 @@
+class AvatarModerationDigestJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    count = AvatarModeration.needs_review
+                            .joins(blog: :user)
+                            .where(users: { discarded_at: nil })
+                            .count
+
+    return if count.zero?
+
+    Rails.logger.info "[AvatarModeration] Sending digest: #{count} avatars need review"
+    AdminMailer.avatar_moderation_digest(count).deliver_later
+  end
+end

--- a/app/jobs/avatar_moderation_job.rb
+++ b/app/jobs/avatar_moderation_job.rb
@@ -1,0 +1,48 @@
+class AvatarModerationJob < ApplicationJob
+  queue_as :low
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
+  discard_on ActiveRecord::RecordNotUnique
+
+  def perform(blog_id)
+    blog = Blog.kept.find_by(id: blog_id)
+    return unless blog&.needs_avatar_moderation?
+
+    with_sentry_context(user: blog.user, blog: blog) do
+      Rails.logger.info "[AvatarModeration] Moderating avatar for #{blog.subdomain}"
+
+      moderator = ContentModerator.new(blog)
+      moderator.moderate
+
+      save_moderation_result!(blog, moderator.result)
+
+      log_result(moderator, blog)
+    end
+  end
+
+  private
+
+    def save_moderation_result!(blog, result)
+      moderation = blog.avatar_moderation || blog.build_avatar_moderation
+
+      moderation.update!(
+        status: result.status,
+        flags: result.flags,
+        category_scores: result.scores,
+        moderated_at: Time.current,
+        fingerprint: blog.avatar_moderation_fingerprint,
+        model_version: result.model_version,
+        reviewed_at: nil
+      )
+    end
+
+    def log_result(moderator, blog)
+      if moderator.error?
+        Rails.logger.warn "[AvatarModeration] Error #{blog.subdomain}: #{moderator.result.flags[:error]}"
+      elsif moderator.flagged?
+        Rails.logger.info "[AvatarModeration] FLAGGED #{blog.subdomain}: #{blog.avatar_moderation.flagged_categories.join(', ')}"
+      else
+        Rails.logger.info "[AvatarModeration] Clean #{blog.subdomain}"
+      end
+    end
+end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -21,4 +21,13 @@ class AdminMailer < CloudflareMailer
       subject: "Content Moderation: #{@count} posts need review"
     )
   end
+
+  def avatar_moderation_digest(count)
+    @count = count
+
+    mail(
+      to: "hello@pagecord.com",
+      subject: "Avatar Moderation: #{@count} avatars need review"
+    )
+  end
 end

--- a/app/models/avatar_moderation.rb
+++ b/app/models/avatar_moderation.rb
@@ -1,0 +1,19 @@
+class AvatarModeration < ApplicationRecord
+  belongs_to :blog
+
+  enum :status, { clean: 0, flagged: 1, error: 2 }
+
+  scope :needs_review, -> { where(status: :flagged, reviewed_at: nil) }
+
+  def flagged_categories
+    flags.select { |_category, flagged| flagged }.keys
+  end
+
+  def mark_as_reviewed!
+    update!(reviewed_at: Time.current)
+  end
+
+  def reviewed?
+    reviewed_at.present?
+  end
+end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -1,6 +1,6 @@
 class Blog < ApplicationRecord
   include Discard::Model
-  include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, Blog::CustomFooter, StorageTrackable, Blog::Contactable, Blog::ApiKey, Blog::Spotlit
+  include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, Blog::CustomFooter, StorageTrackable, Blog::Contactable, Blog::ApiKey, Blog::Spotlit, Blog::Moderatable
 
   enum :layout, [ :stream_layout, :title_layout, :cards_layout ]
 

--- a/app/models/concerns/blog/moderatable.rb
+++ b/app/models/concerns/blog/moderatable.rb
@@ -1,0 +1,37 @@
+module Blog::Moderatable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :avatar_moderation, dependent: :destroy
+  end
+
+  def moderation_text_payload
+    nil
+  end
+
+  def moderation_image_payloads
+    return [] unless avatar.attached?
+
+    blob = avatar.blob
+    return [] unless blob.image?
+
+    base64_data = Base64.strict_encode64(blob.download)
+    content_type = blob.content_type || "image/jpeg"
+
+    [ {
+      type: "image_url",
+      image_url: { url: "data:#{content_type};base64,#{base64_data}" }
+    } ]
+  end
+
+  def needs_avatar_moderation?
+    return false unless avatar.attached?
+    return true if avatar_moderation.nil?
+
+    avatar_moderation.fingerprint != avatar_moderation_fingerprint
+  end
+
+  def avatar_moderation_fingerprint
+    avatar.attached? ? avatar.blob.checksum : nil
+  end
+end

--- a/app/models/content_moderator.rb
+++ b/app/models/content_moderator.rb
@@ -15,8 +15,8 @@ class ContentModerator
 
   attr_reader :result
 
-  def initialize(post)
-    @post = post
+  def initialize(subject)
+    @subject = subject
     @access_token = ENV["OPENAI_ACCESS_TOKEN"] ||
                     Rails.application.credentials.dig(:openai_access_token)
     @client = OpenAI::Client.new(access_token: @access_token) if @access_token.present?
@@ -30,14 +30,14 @@ class ContentModerator
     parse_response(response)
   rescue Faraday::BadRequestError => e
     body = e.response&.dig(:body) || "no response body"
-    Rails.logger.error("[ContentModeration] Bad request for post #{@post.id}: #{body}")
+    Rails.logger.error("[ContentModeration] Bad request for #{subject_label}: #{body}")
     error_result("Invalid request to moderation API: #{body}")
   rescue Faraday::Error => e
     body = e.response&.dig(:body) rescue nil
-    Rails.logger.error("[ContentModeration] API error for post #{@post.id}: #{e.class} - #{e.message} - #{body}")
+    Rails.logger.error("[ContentModeration] API error for #{subject_label}: #{e.class} - #{e.message} - #{body}")
     error_result("Moderation API error")
   rescue StandardError => e
-    Rails.logger.error("[ContentModeration] Unexpected error for post #{@post.id}: #{e.class} - #{e.message}")
+    Rails.logger.error("[ContentModeration] Unexpected error for #{subject_label}: #{e.class} - #{e.message}")
     error_result("Unexpected error")
   end
 
@@ -55,8 +55,12 @@ class ContentModerator
 
   private
 
+    def subject_label
+      "#{@subject.class.name.underscore} #{@subject.id}"
+    end
+
     def has_content?
-      @post.moderation_text_payload.present? || @post.moderation_image_payloads.any?
+      @subject.moderation_text_payload.present? || @subject.moderation_image_payloads.any?
     end
 
     # OpenAI moderation API only allows 1 image per request, so we make
@@ -64,16 +68,16 @@ class ContentModerator
     def call_moderation_api
       all_results = []
 
-      if @post.moderation_text_payload.present?
-        text_kb = (@post.moderation_text_payload.bytesize / 1024.0).round(1)
-        Rails.logger.info("[ContentModeration] Moderating text for post #{@post.id}: #{text_kb}KB")
-        response = moderate_input({ type: "text", text: @post.moderation_text_payload })
+      if @subject.moderation_text_payload.present?
+        text_kb = (@subject.moderation_text_payload.bytesize / 1024.0).round(1)
+        Rails.logger.info("[ContentModeration] Moderating text for #{subject_label}: #{text_kb}KB")
+        response = moderate_input({ type: "text", text: @subject.moderation_text_payload })
         all_results.concat(response.dig("results") || [])
       end
 
-      @post.moderation_image_payloads.each_with_index do |image_payload, index|
+      @subject.moderation_image_payloads.each_with_index do |image_payload, index|
         image_kb = (image_payload.dig(:image_url, :url).bytesize / 1024.0).round(1)
-        Rails.logger.info("[ContentModeration] Moderating image #{index + 1} for post #{@post.id}: #{image_kb}KB")
+        Rails.logger.info("[ContentModeration] Moderating image #{index + 1} for #{subject_label}: #{image_kb}KB")
         response = moderate_input(image_payload)
         all_results.concat(response.dig("results") || [])
       end

--- a/app/views/admin/moderation/avatars/index.html.erb
+++ b/app/views/admin/moderation/avatars/index.html.erb
@@ -1,0 +1,59 @@
+<%= render "admin/moderation/shared/tabs" %>
+
+<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-x-auto">
+  <div class="bg-slate-50 dark:bg-slate-700/50 border-b border-slate-200 dark:border-slate-700 px-6 py-4 flex items-center gap-3">
+    <span class="text-lg font-bold text-slate-900 dark:text-slate-50"><%= @total_unreviewed %></span>
+    <span class="text-sm text-slate-500 dark:text-slate-400"><%= "avatar".pluralize(@total_unreviewed) %> flagged for review</span>
+  </div>
+
+  <% if @avatar_moderations.any? %>
+    <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+      <thead>
+        <tr>
+          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Avatar</th>
+          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Blog</th>
+          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Flagged</th>
+          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Moderated</th>
+          <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+        <% @avatar_moderations.each do |moderation| %>
+          <tr>
+            <td class="py-3 px-6">
+              <% if moderation.blog.avatar.attached? %>
+                <%= image_tag resized_image_url(moderation.blog.avatar, width: 96, height: 96), class: "w-12 h-12 rounded-full object-cover", alt: "Avatar" %>
+              <% end %>
+            </td>
+            <td class="whitespace-nowrap py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-50">
+              <%= link_to blog_home_url(moderation.blog), target: "_blank", rel: "noopener", class: "font-medium underline" do %>
+                @<%= moderation.blog.subdomain %>
+              <% end %>
+            </td>
+            <td class="py-3 px-6 text-sm text-slate-500 dark:text-slate-400 max-w-md">
+              <%= moderation.flagged_categories.join(", ") %>
+            </td>
+            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400">
+              <%= moderation.moderated_at&.to_formatted_s(:short) %>
+            </td>
+            <td class="whitespace-nowrap py-3 px-6 text-end text-sm">
+              <div class="flex justify-end space-x-2">
+                <%= button_to "Keep",
+                    dismiss_admin_moderation_avatar_path(moderation),
+                    method: :post,
+                    class: "btn-primary py-1" %>
+                <%= button_to "Remove",
+                    remove_admin_moderation_avatar_path(moderation),
+                    method: :post,
+                    class: "btn-danger py-1",
+                    form: { data: { turbo_confirm: "Remove this avatar?" } } %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= render "app/shared/pagy_nav" %>
+  <% end %>
+</div>

--- a/app/views/admin/moderation/shared/_tabs.html.erb
+++ b/app/views/admin/moderation/shared/_tabs.html.erb
@@ -13,4 +13,11 @@
       <span class="ml-1.5 px-2 py-0.5 text-xs font-medium rounded-full bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300"><%= content_moderation_count %></span>
     <% end %>
   <% end %>
+  <%= link_to admin_moderation_avatars_path,
+      class: "pb-3 text-sm font-medium #{controller_name == 'avatars' ? 'border-b-2 border-slate-900 dark:border-slate-100 text-slate-900 dark:text-slate-100' : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'}" do %>
+    Avatars
+    <% if avatar_moderation_count > 0 %>
+      <span class="ml-1.5 px-2 py-0.5 text-xs font-medium rounded-full bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300"><%= avatar_moderation_count %></span>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/admin_mailer/avatar_moderation_digest.html.erb
+++ b/app/views/admin_mailer/avatar_moderation_digest.html.erb
@@ -1,0 +1,7 @@
+<p>
+  <strong><%= @count %></strong> <%= "avatar".pluralize(@count) %> flagged for review.
+</p>
+
+<p>
+  <%= link_to "Review in Admin Panel", admin_moderation_avatars_url %>
+</p>

--- a/app/views/app/settings/about/_form.html.erb
+++ b/app/views/app/settings/about/_form.html.erb
@@ -30,20 +30,9 @@
     <%= styled_text_field(form, :title, class: "mt-4 w-full") %>
   </div>
 
-  <% avatar_disabled = @blog.user.on_free_plan? %>
   <h3 class="mt-8 font-bold text-lg mb-2">Avatar</h3>
 
-  <% if avatar_disabled %>
-    <div class="mb-4">
-      <%= callout(:info) do %>
-        <%= link_to "Subscribe", app_settings_subscriptions_path, class: "underline font-medium" %> to add an avatar to your blog.
-      <% end %>
-    </div>
-  <% else %>
-    <div class="mb-4"><%= trial_callout("Avatar") %></div>
-  <% end %>
-
-  <div class="<%= 'opacity-50 pointer-events-none' if avatar_disabled %>">
+  <div>
     <p>
       <% if @blog.avatar&.attached? %>
         Click the image to select a new avatar, or click 'Remove' to delete the existing one.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,6 +223,13 @@ Rails.application.routes.draw do
             post :confirm
           end
         end
+
+        resources :avatars, only: [ :index ] do
+          member do
+            post :dismiss
+            post :remove
+          end
+        end
       end
     end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -82,6 +82,10 @@ every :day, at: "8:00 am" do
   runner "ContentModerationDigestJob.perform_later"
 end
 
+every :day, at: "8:05 am" do
+  runner "AvatarModerationDigestJob.perform_later"
+end
+
 every :day, at: "3:30 am" do
   runner "Posts::EmptyTrashJob.perform_later"
 end

--- a/db/migrate/20260706120000_create_avatar_moderations.rb
+++ b/db/migrate/20260706120000_create_avatar_moderations.rb
@@ -1,0 +1,18 @@
+class CreateAvatarModerations < ActiveRecord::Migration[8.2]
+  def change
+    create_table :avatar_moderations do |t|
+      t.references :blog, null: false, foreign_key: true, index: { unique: true }
+      t.integer :status, null: false, default: 0
+      t.jsonb :flags, default: {}
+      t.jsonb :category_scores, default: {}
+      t.string :fingerprint
+      t.string :model_version
+      t.datetime :moderated_at
+      t.datetime :reviewed_at
+
+      t.timestamps
+    end
+
+    add_index :avatar_moderations, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_02_130000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_06_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -74,6 +74,21 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_02_130000) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "avatar_moderations", force: :cascade do |t|
+    t.bigint "blog_id", null: false
+    t.integer "status", default: 0, null: false
+    t.jsonb "flags", default: {}
+    t.jsonb "category_scores", default: {}
+    t.string "fingerprint"
+    t.string "model_version"
+    t.datetime "moderated_at"
+    t.datetime "reviewed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["blog_id"], name: "index_avatar_moderations_on_blog_id", unique: true
+    t.index ["status"], name: "index_avatar_moderations_on_status"
   end
 
   create_table "blog_exports", force: :cascade do |t|
@@ -452,6 +467,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_02_130000) do
   add_foreign_key "access_requests", "users"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "avatar_moderations", "blogs"
   add_foreign_key "blog_exports", "blogs"
   add_foreign_key "blog_spotlight_exclusions", "blogs"
   add_foreign_key "blogs", "posts", column: "home_page_id", on_delete: :nullify

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,20 @@
 Rake.application["db:fixtures:load"].invoke
+
+# A flagged avatar so /admin/moderation/avatars has something to review locally.
+if (blog = Blog.find_by(subdomain: "vivian"))
+  unless blog.avatar.attached?
+    blog.avatar.attach(
+      io: File.open(Rails.root.join("test/fixtures/files/avatar.png")),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+  end
+
+  blog.avatar_moderation&.destroy
+  blog.create_avatar_moderation!(
+    status: :flagged,
+    flags: { "sexual" => true },
+    category_scores: { "sexual" => 0.92 },
+    moderated_at: Time.current
+  )
+end

--- a/test/controllers/admin/moderation/avatars_controller_test.rb
+++ b/test/controllers/admin/moderation/avatars_controller_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Admin::Moderation::AvatarsControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  setup do
+    login_as users(:joel)
+    @blog = blogs(:vivian)
+    @blog.avatar.attach(
+      io: File.open(Rails.root.join("test", "fixtures", "files", "avatar.png")),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+    @moderation = @blog.create_avatar_moderation!(
+      status: :flagged,
+      flags: { "sexual" => true },
+      moderated_at: Time.current
+    )
+  end
+
+  test "index lists flagged avatars" do
+    get admin_moderation_avatars_url
+
+    assert_response :success
+    assert_select "table"
+    assert_includes @response.body, "@#{@blog.subdomain}"
+  end
+
+  test "dismiss keeps the avatar and marks it reviewed" do
+    post dismiss_admin_moderation_avatar_url(@moderation)
+
+    assert_redirected_to admin_moderation_avatars_path
+    assert @blog.reload.avatar.attached?
+    assert @moderation.reload.reviewed?
+  end
+
+  test "remove purges the avatar and marks it reviewed" do
+    post remove_admin_moderation_avatar_url(@moderation)
+
+    assert_redirected_to admin_moderation_avatars_path
+    assert_not @blog.reload.avatar.attached?
+    assert @moderation.reload.reviewed?
+  end
+end

--- a/test/controllers/app/settings/about_controller_test.rb
+++ b/test/controllers/app/settings/about_controller_test.rb
@@ -17,20 +17,20 @@ class App::Settings::AboutControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should show avatar section if subscribed" do
+  test "should show avatar section" do
     get app_settings_about_index_url
 
     assert_select "h3", { count: 1, text: "Avatar" }
     assert_response :success
   end
 
-  test "should disable avatar section if not subscribed and not on trial" do
+  test "should show enabled avatar section even when not subscribed" do
     login_as users(:vivian)
 
     get app_settings_about_index_url
 
     assert_select "h3", { count: 1, text: "Avatar" }
-    assert_select ".opacity-50.pointer-events-none", count: 1
+    assert_select ".opacity-50.pointer-events-none", count: 0
     assert_response :success
   end
 
@@ -48,15 +48,18 @@ class App::Settings::AboutControllerTest < ActionDispatch::IntegrationTest
     assert_equal "New Title", @blog.reload.title
   end
 
-  test "should update avatar if subscribed" do
+  test "should update avatar and enqueue moderation" do
     file = fixture_file_upload("avatar.png", "image/png")
-    patch app_settings_about_url(@blog), params: { blog: { avatar: file } }, as: :turbo_stream
+
+    assert_enqueued_with(job: AvatarModerationJob) do
+      patch app_settings_about_url(@blog), params: { blog: { avatar: file } }, as: :turbo_stream
+    end
 
     assert_redirected_to app_settings_url
     assert @blog.reload.avatar.attached?
   end
 
-  test "should not update avatar if not subscribed" do
+  test "should update avatar even when not subscribed" do
     login_as users(:vivian)
     non_subscribed_blog = users(:vivian).blog
 
@@ -64,6 +67,6 @@ class App::Settings::AboutControllerTest < ActionDispatch::IntegrationTest
     patch app_settings_about_url(non_subscribed_blog), params: { blog: { avatar: file } }, as: :turbo_stream
 
     assert_redirected_to app_settings_url
-    assert_not non_subscribed_blog.reload.avatar.attached?
+    assert non_subscribed_blog.reload.avatar.attached?
   end
 end

--- a/test/jobs/avatar_moderation_job_test.rb
+++ b/test/jobs/avatar_moderation_job_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+require "mocha/minitest"
+
+class AvatarModerationJobTest < ActiveJob::TestCase
+  setup do
+    @original_token = ENV["OPENAI_ACCESS_TOKEN"]
+    ENV["OPENAI_ACCESS_TOKEN"] = "test_token"
+    @blog = blogs(:joel)
+    @blog.avatar.attach(
+      io: File.open(Rails.root.join("test", "fixtures", "files", "avatar.png")),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+  end
+
+  teardown do
+    ENV["OPENAI_ACCESS_TOKEN"] = @original_token
+  end
+
+  def stub_result(status:, flags:, scores:)
+    result = ContentModerator::Result.new(status: status, flags: flags, scores: scores, model_version: "test")
+    ContentModerator.any_instance.stubs(:moderate)
+    ContentModerator.any_instance.stubs(:result).returns(result)
+    ContentModerator.any_instance.stubs(:error?).returns(status == :error)
+    ContentModerator.any_instance.stubs(:flagged?).returns(status == :flagged)
+  end
+
+  test "skips non-existent blogs" do
+    ContentModerator.any_instance.expects(:moderate).never
+    AvatarModerationJob.perform_now(999999)
+  end
+
+  test "skips blogs without an avatar" do
+    @blog.avatar.purge
+    ContentModerator.any_instance.expects(:moderate).never
+    AvatarModerationJob.perform_now(@blog.id)
+  end
+
+  test "skips blogs whose avatar was already moderated" do
+    @blog.create_avatar_moderation!(status: :clean, fingerprint: @blog.avatar_moderation_fingerprint)
+    ContentModerator.any_instance.expects(:moderate).never
+    AvatarModerationJob.perform_now(@blog.id)
+  end
+
+  test "moderates and stores a clean result" do
+    stub_result(status: :clean, flags: { "sexual" => false }, scores: { "sexual" => 0.01 })
+
+    AvatarModerationJob.perform_now(@blog.id)
+
+    moderation = @blog.reload.avatar_moderation
+    assert moderation.clean?
+    assert_not_nil moderation.moderated_at
+    assert_equal @blog.avatar_moderation_fingerprint, moderation.fingerprint
+  end
+
+  test "moderates and stores a flagged result without removing the avatar" do
+    stub_result(status: :flagged, flags: { "sexual" => true }, scores: { "sexual" => 0.9 })
+
+    AvatarModerationJob.perform_now(@blog.id)
+
+    moderation = @blog.reload.avatar_moderation
+    assert moderation.flagged?
+    assert @blog.avatar.attached?
+    assert_includes AvatarModeration.needs_review, moderation
+  end
+
+  test "stores an error result" do
+    stub_result(status: :error, flags: { error: "boom" }, scores: {})
+
+    AvatarModerationJob.perform_now(@blog.id)
+
+    assert @blog.reload.avatar_moderation.error?
+  end
+end

--- a/test/models/concerns/blog/moderatable_test.rb
+++ b/test/models/concerns/blog/moderatable_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class Blog::ModeratableTest < ActiveSupport::TestCase
+  setup do
+    @blog = blogs(:joel)
+  end
+
+  def attach_avatar
+    @blog.avatar.attach(
+      io: File.open(Rails.root.join("test", "fixtures", "files", "avatar.png")),
+      filename: "avatar.png",
+      content_type: "image/png"
+    )
+  end
+
+  test "moderation_image_payloads is empty without an avatar" do
+    assert_equal [], @blog.moderation_image_payloads
+  end
+
+  test "moderation_image_payloads builds a base64 image payload from the avatar" do
+    attach_avatar
+
+    payloads = @blog.moderation_image_payloads
+
+    assert_equal 1, payloads.size
+    assert_equal "image_url", payloads.first[:type]
+    assert_match %r{\Adata:image/png;base64,}, payloads.first.dig(:image_url, :url)
+  end
+
+  test "moderation_text_payload is nil" do
+    assert_nil @blog.moderation_text_payload
+  end
+
+  test "needs_avatar_moderation? is false without an avatar" do
+    refute @blog.needs_avatar_moderation?
+  end
+
+  test "needs_avatar_moderation? is true when no moderation record exists" do
+    attach_avatar
+    assert @blog.needs_avatar_moderation?
+  end
+
+  test "needs_avatar_moderation? is false when fingerprint matches" do
+    attach_avatar
+    @blog.create_avatar_moderation!(status: :clean, fingerprint: @blog.avatar_moderation_fingerprint)
+
+    refute @blog.needs_avatar_moderation?
+  end
+
+  test "needs_avatar_moderation? is true when fingerprint differs" do
+    attach_avatar
+    @blog.create_avatar_moderation!(status: :clean, fingerprint: "stale")
+
+    assert @blog.needs_avatar_moderation?
+  end
+end


### PR DESCRIPTION
## What

Opens the avatar feature to **all** accounts (previously Premium-only) and closes the moderation gap that opening it up creates: uploaded avatars were previously checked by nothing.

## How it works

- **Gate removed** — `about_controller` permits `:avatar` for everyone; the "Subscribe to add an avatar" UI gate is gone.
- **Moderation on upload** — uploading an avatar enqueues `AvatarModerationJob`, which runs the image through the existing OpenAI `omni-moderation-latest` service (`ContentModerator`, now generic over its subject rather than post-specific).
- **Result stored** in a new blog-scoped `AvatarModeration` record, mirroring the existing `SpamDetection` pattern.
- **Flagged avatars stay visible** until an admin explicitly removes them (deliberate: no display-gating, less front-end state, fewer support tickets). They surface in a new **`/admin/moderation/avatars`** tab (Keep / Remove) with a count badge, and in a **daily digest email**.

## Design note

Built as a parallel system (`AvatarModeration` alongside `ContentModeration`) rather than making moderation polymorphic. Polymorphism would collapse the model and job but not the admin UI (a flagged post and a flagged avatar render nothing alike) or the triggers (cron sweep vs on-upload), and it would cost a live-table backfill plus reconciling two different review lifecycles. The one expensive shared piece, the moderation engine, is already shared.

## Testing locally

`bin/rails db:seed` adds a flagged avatar for `@vivian`, then visit `/admin/moderation/avatars` (make your user an admin). See the branch commit for details.

## Checks

- `brakeman`, `rubocop`, `importmap audit`, `bin/rails test` (1641 runs) all green.
- ⚠️ **System tests not run** — Selenium could not launch Chrome in the dev sandbox. Please run `bin/rails test:system` in a browser-capable environment before merge.

## Follow-ups (out of scope)

- Existing avatars (all currently Premium) are not retroactively moderated; only new/changed ones are. A one-off backfill sweep could be added if wanted.