### PR TITLE
Open avatars to all accounts

### DIFF
--- a/app/controllers/app/settings/about_controller.rb
+++ b/app/controllers/app/settings/about_controller.rb
@@ -6,6 +6,8 @@ class App::Settings::AboutController < AppController
     if @blog.update(about_params)
       redirect_to app_settings_path, notice: "About settings updated"
     else
+      # Discard the rejected upload so the form renders the existing avatar
+      @blog.attachment_changes.delete("avatar")
       render :index, status: :unprocessable_entity
     end
   end
@@ -13,9 +15,6 @@ class App::Settings::AboutController < AppController
   private
 
     def about_params
-      permitted_params = [ :bio, :title ]
-      permitted_params << :avatar if @blog.user.has_premium_access?
-
-      params.require(:blog).permit(permitted_params)
+      params.require(:blog).permit(:bio, :title, :avatar)
     end
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -9,6 +9,9 @@ class Blog < ApplicationRecord
   MAX_BLOGS_FREE = 1
   MAX_BLOGS_PAID = 2
 
+  AVATAR_CONTENT_TYPES = %w[ image/jpeg image/png image/webp ].freeze
+  AVATAR_MAX_SIZE = 5.megabytes
+
   has_many :all_posts, class_name: "Post", dependent: :destroy
   has_many :posts, -> { where(is_page: false) }, class_name: "Post"
   has_many :pages, -> { where(is_page: true) }, class_name: "Post"
@@ -29,6 +32,7 @@ class Blog < ApplicationRecord
 
   has_rich_text :bio
   validate :bio_length
+  validate :avatar_format
   validate :within_blog_limit, on: :create
 
   before_validation :downcase_subdomain
@@ -69,6 +73,18 @@ class Blog < ApplicationRecord
     def bio_length
       if bio.to_plain_text.length > 500
         errors.add(:bio, "is too long (maximum 500 characters)")
+      end
+    end
+
+    def avatar_format
+      return unless avatar.attachment&.new_record?
+
+      unless AVATAR_CONTENT_TYPES.include?(avatar.blob.content_type)
+        errors.add(:avatar, "must be a JPEG, PNG or WebP image")
+      end
+
+      if avatar.blob.byte_size > AVATAR_MAX_SIZE
+        errors.add(:avatar, "is too big (maximum 5MB)")
       end
     end
 

--- a/app/views/app/settings/about/_form.html.erb
+++ b/app/views/app/settings/about/_form.html.erb
@@ -23,41 +23,30 @@
       </p>
     <% end %>
 
-    <% avatar_disabled = @blog.user.on_free_plan? %>
     <%= settings_row "Avatar" do %>
-      <% if avatar_disabled %>
-        <div class="mb-4">
-          <%= callout(:info) do %>
-            <%= link_to "Subscribe", app_settings_subscriptions_path, class: "underline font-medium" %> to add an avatar to your blog.
+      <div class="text-start flex flex-col" id="blog-avatar">
+        <a href="#" data-action="click->avatar#open" title="Update your avatar">
+          <%= render "avatar", blog: @blog %>
+        </a>
+        <% if @blog.avatar&.attached? %>
+          <%= link_to app_blog_avatar_path(@blog), data: { turbo_method: :delete }, class: "flex items-center text-sm text-slate-500 hover:text-slate-800 dark:text-slate-400 hover:dark:text-slate-200 p-0 mt-1" do %>
+            <%= inline_svg_tag "icons/trash.svg", class: "w-4 h-4 me-1 " %>
+            Remove
           <% end %>
-        </div>
-      <% elsif @blog.user.on_trial? %>
-        <div class="mb-4"><%= trial_callout("Avatar") %></div>
-      <% end %>
-
-      <div class="<%= 'opacity-50 pointer-events-none' if avatar_disabled %>">
-        <div class="text-start flex flex-col" id="blog-avatar">
-          <a href="#" data-action="click->avatar#open" title="Update your avatar">
-            <%= render "avatar", blog: @blog %>
-          </a>
-          <% if @blog.avatar&.attached? %>
-            <%= link_to app_blog_avatar_path(@blog), data: { turbo_method: :delete }, class: "flex items-center text-sm text-slate-500 hover:text-slate-800 dark:text-slate-400 hover:dark:text-slate-200 p-0 mt-1" do %>
-              <%= inline_svg_tag "icons/trash.svg", class: "w-4 h-4 me-1 " %>
-              Remove
-            <% end %>
-          <% end %>
-        </div>
-
-        <%= form.file_field :avatar, class: "hidden", accept: "image/jpeg, image/png, image/webp", data: { avatar_target: "input" } %>
-
-        <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
-          <% if @blog.avatar&.attached? %>
-            Click the image to choose a new avatar, or Remove to delete it.
-          <% else %>
-            Click the icon to choose an avatar, then click Update.
-          <% end %>
-        </p>
+        <% end %>
       </div>
+
+      <%= form.file_field :avatar, class: "hidden", accept: Blog::AVATAR_CONTENT_TYPES.join(", "), data: { avatar_target: "input" } %>
+
+      <div class="field-error"><%= @blog.errors[:avatar].first if @blog.errors[:avatar].any? %></div>
+
+      <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+        <% if @blog.avatar&.attached? %>
+          Click the image to choose a new avatar, or Remove to delete it.
+        <% else %>
+          Click the icon to choose an avatar, then click Update.
+        <% end %>
+      </p>
     <% end %>
   <% end %>
 

--- a/app/views/blogs/_titlebar.html.erb
+++ b/app/views/blogs/_titlebar.html.erb
@@ -1,5 +1,5 @@
 <div class="titlebar h-card p-author">
-  <% if @blog.avatar&.attached? && @blog.user.has_premium_access? %>
+  <% if @blog.avatar&.attached? %>
     <div class="avatar-container">
       <div class="avatar">
         <%= link_to blog_home_url(@blog), class: "u-url", aria: { label: "#{@blog.title} Home" } do %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -264,6 +264,10 @@
         </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
+          An avatar for your blog
+        </li>
+        <li class="flex items-center text-slate-700 dark:text-slate-300">
+          <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
           Create pages as well as blog posts
         </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
@@ -316,7 +320,7 @@
         </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
-          Image hosting &amp; avatar
+          Image hosting
         </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
@@ -553,7 +557,7 @@
             <div class="text-base md:font-bold text-slate-800 dark:text-slate-200">Avatar</div>
             <div class="hidden sm:block">Add a touch of your own personality while retaining that classic Pagecord minimal look 🧑‍🎨</div>
           </td>
-          <td></td>
+          <td class="text-center align-middle text-xl">✅</td>
           <td class="text-center align-middle text-xl">✅</td>
         </tr>
 

--- a/docs/help-guide/billing.md
+++ b/docs/help-guide/billing.md
@@ -19,7 +19,6 @@ Premium includes:
 - Email subscribers
 - Reply by email
 - Analytics
-- Avatar
 - Custom CSS
 - Human customer support
 

--- a/docs/help-guide/customising-your-blog.md
+++ b/docs/help-guide/customising-your-blog.md
@@ -20,7 +20,7 @@ By default, your blog title is your username (e.g. @joel). You can change it to 
 
 ### Avatar
 
-Premium feature. Upload an image that appears next to your blog title.
+Upload an image that appears next to your blog title. It's also used as your blog's favicon. JPEG, PNG or WebP, up to 5MB.
 
 ## Appearance
 

--- a/test/controllers/app/settings/about_controller_test.rb
+++ b/test/controllers/app/settings/about_controller_test.rb
@@ -18,20 +18,20 @@ class App::Settings::AboutControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should show avatar section if subscribed" do
+  test "should show avatar section" do
     get app_settings_about_index_url
 
     assert_select "h4", { count: 1, text: "Avatar" }
     assert_response :success
   end
 
-  test "should disable avatar section if not subscribed and not on trial" do
+  test "should show enabled avatar section even when not subscribed" do
     login_as users(:vivian)
 
     get app_settings_about_index_url
 
     assert_select "h4", { count: 1, text: "Avatar" }
-    assert_select ".opacity-50.pointer-events-none", count: 1
+    assert_select ".opacity-50.pointer-events-none", count: 0
     assert_response :success
   end
 
@@ -49,7 +49,7 @@ class App::Settings::AboutControllerTest < ActionDispatch::IntegrationTest
     assert_equal "New Title", @blog.reload.title
   end
 
-  test "should update avatar if subscribed" do
+  test "should update avatar" do
     file = fixture_file_upload("avatar.png", "image/png")
     patch app_settings_about_url(@blog), params: { blog: { avatar: file } }, as: :turbo_stream
 
@@ -57,7 +57,7 @@ class App::Settings::AboutControllerTest < ActionDispatch::IntegrationTest
     assert @blog.reload.avatar.attached?
   end
 
-  test "should not update avatar if not subscribed" do
+  test "should update avatar even when not subscribed" do
     login_as users(:vivian)
     non_subscribed_blog = users(:vivian).blog
 
@@ -65,6 +65,17 @@ class App::Settings::AboutControllerTest < ActionDispatch::IntegrationTest
     patch app_settings_about_url(non_subscribed_blog), params: { blog: { avatar: file } }, as: :turbo_stream
 
     assert_redirected_to app_settings_url
-    assert_not non_subscribed_blog.reload.avatar.attached?
+    assert non_subscribed_blog.reload.avatar.attached?
+  end
+
+  test "should not update avatar with a non-image disguised as an image" do
+    file = Rack::Test::UploadedFile.new(
+      StringIO.new("<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"),
+      "image/png", original_filename: "avatar.png"
+    )
+    patch app_settings_about_url(@blog), params: { blog: { avatar: file } }, as: :turbo_stream
+
+    assert_response :unprocessable_entity
+    assert_not @blog.reload.avatar.attached?
   end
 end

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -19,6 +19,19 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".stream_layout", count: 1
   end
 
+  test "should render the avatar for a blog on the free plan" do
+    free_blog = blogs(:vivian)
+    assert free_blog.user.on_free_plan?
+
+    free_blog.avatar.attach(io: file_fixture("avatar.png").open, filename: "avatar.png", content_type: "image/png")
+    host_subdomain! free_blog.subdomain
+
+    get blog_posts_path
+
+    assert_response :success
+    assert_select ".avatar-container .avatar img", count: 1
+  end
+
   test "should render a list of post titles" do
     @blog.title_layout!
 

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -58,6 +58,28 @@ class BlogTest < ActiveSupport::TestCase
     assert_not @blog.valid?
   end
 
+  test "should accept a valid avatar" do
+    @blog.avatar = { io: file_fixture("avatar.png").open, filename: "avatar.png", content_type: "image/png" }
+
+    assert @blog.valid?
+  end
+
+  test "should reject an avatar disguised as an image" do
+    @blog.avatar = { io: StringIO.new("<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"),
+                     filename: "avatar.png", content_type: "image/png" }
+
+    assert_not @blog.valid?
+    assert_includes @blog.errors[:avatar], "must be a JPEG, PNG or WebP image"
+  end
+
+  test "should reject an avatar that is too big" do
+    @blog.avatar = { io: file_fixture("avatar.png").open, filename: "avatar.png", content_type: "image/png" }
+    @blog.avatar.blob.stubs(:byte_size).returns(Blog::AVATAR_MAX_SIZE + 1)
+
+    assert_not @blog.valid?
+    assert_includes @blog.errors[:avatar], "is too big (maximum 5MB)"
+  end
+
   test "should store subdomain in lowercase" do
     @blog.subdomain = "JOEL"
     @blog.save


### PR DESCRIPTION
## Why

Avatars are cosmetic personalisation, not image hosting. Themes, tags, custom home pages and RSS are all free; an avatar is a smaller lever than a colour theme, so the Premium gate looks misfiled.

They also don't appear to sell subscriptions. Of 172 paying subscribers, 105 have an avatar, but only 19 set one before they paid – the other 82% set it afterwards, mostly in the first week. It's a setup step, not a purchase motivator.

## What changed

- `about_controller` permits `:avatar` for everyone (was gated on `has_premium_access?`).
- `blogs/_titlebar` renders the avatar regardless of plan. Without this the upload would have succeeded but never displayed, while still leaking into the favicon and OG image, which were never gated.
- Removed the "Subscribe to add an avatar" callout, the disabled state, and the trial callout (which claimed avatars were premium).
- Added content type and size validation to `Blog#avatar`. There were no server-side checks at all – the form's `accept` attribute is only a client-side hint.
- Fixed a 500 when an upload is rejected: the rejected blob stayed assigned and the avatar partial tried to build a variant from it.
- Updated pricing page and help guide copy.

## Behaviour changes

- Free accounts can set an avatar, and it renders on their blog.
- Avatars previously set during a trial stop being hidden once the trial lapses, so some existing blogs will show an avatar again on deploy.
- Non-images and files over 5MB are now rejected with a form error rather than silently accepted.

## Notes

Avatars remain unmoderated – #1087 is the alternative that adds moderation. Worth knowing that every new signup already gets a 14-day trial, so any account can already upload a public avatar today; this widens that to lapsed accounts rather than opening it up from scratch.
