### PR TITLE
Support +draft delivery address to save email posts as drafts

### DIFF
--- a/app/mailboxes/posts_mailbox.rb
+++ b/app/mailboxes/posts_mailbox.rb
@@ -3,6 +3,7 @@ class PostsMailbox < ApplicationMailbox
     return unless mail.to.present? && mail.from.present?
 
     recipient = ENV["PAGECORD_RECIPIENT"] || mail.to.first.downcase
+    status = recipient.sub!(/\+draft@/, "@") ? :draft : :published
     from = ENV["PAGECORD_FROM"] || mail.from.first.downcase
 
     reply_to = if ENV["PAGECORD_REPLYTO"]
@@ -31,6 +32,7 @@ class PostsMailbox < ApplicationMailbox
           blog.posts.create!(
             title: title,
             content: content,
+            status: status,
             source: :email,
             attachments: parser.attachments,
             tag_list: parser.tags,

--- a/docs/help-guide/posting-by-email.md
+++ b/docs/help-guide/posting-by-email.md
@@ -22,6 +22,12 @@ Send an email to your posting address:
 
 Your post is published immediately.
 
+## Saving as a draft
+
+If you'd rather save a post without publishing it, add `+draft` to your delivery address, just before the `@`. So `myblog_abc123@post.pagecord.com` becomes `myblog_abc123+draft@post.pagecord.com`.
+
+The post is created as a draft, ready for you to review, edit and publish from the app whenever you're ready.
+
 ## Formatting
 
 The email body is converted to rich text. You can use basic HTML formatting if your email client supports it (most do).
@@ -61,5 +67,5 @@ If your post doesn't appear:
 
 - Check the email was sent from the right email address. This must be the email address you signed up with! This is the most common issue people face. You can add up to three additional sender email addresses in the settings so you can publish from different addresses.Look in your spam folder for any bounce messages
 
-Posts from email are published immediately – there's no draft state. If you need to edit, you can do so in the app after it's published.
+Posts from email are published immediately, unless you send them to your `+draft` address (see above). If you need to edit, you can do so in the app at any time.
 

--- a/test/mailboxes/posts_mailbox_test.rb
+++ b/test/mailboxes/posts_mailbox_test.rb
@@ -21,6 +21,21 @@ class PostsMailboxTest < ActionMailbox::TestCase
     assert_equal "email", user.blog.posts.last.source
   end
 
+  test "should save as draft when delivered to the +draft address" do
+    user = users(:joel)
+
+    assert_difference -> { user.blog.posts.count }, 1 do
+      receive_inbound_email_from_mail \
+        to: user.blog.delivery_email.sub("@", "+draft@"),
+        from: user.email,
+        reply_to: user.email,
+        subject: "Hello world!",
+        body: "Hello?"
+    end
+
+    assert user.blog.posts.last.draft?
+  end
+
   test "should receive valid HTML mail from HEY" do
     user = users(:joel)
     raw_mail = File.read(Rails.root.join("test/fixtures/emails/hey.eml"))


### PR DESCRIPTION
Adds plus-addressing support so posts emailed to `myblog_abc123+draft@post.pagecord.com` are saved as drafts instead of being published immediately.

## How it works

The `+draft` tag is stripped from the recipient before the blog lookup (so the existing delivery-email match is unchanged), and the post is created with `status: :draft`. Any other email publishes as normal (posts default to `published`).

This is standard plus-addressing and already passes through the mailbox routing regex, so no routing changes were needed.

## Changes

- `app/mailboxes/posts_mailbox.rb` — detect/strip `+draft`, set post status accordingly
- `docs/help-guide/posting-by-email.md` — new "Saving as a draft" section; corrected the "no draft state" note
- `test/mailboxes/posts_mailbox_test.rb` — test covering the `+draft` address

Closes https://app.fizzy.do/6102591/cards/362