### PR TITLE
Update docs for Ubicloud/Falkenstein migration

### DIFF
--- a/app/views/public/faq.html.erb
+++ b/app/views/public/faq.html.erb
@@ -74,7 +74,7 @@
       "name": "Where is my data stored?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Pagecord is hosted on servers run by Hetzner, in their Nuremberg, Germany data centre. Blog posts are stored in a database there. Images are stored in Cloudflare's R2 Object Storage in their Western Europe data centre. Pagecord traffic is proxied through Cloudflare for additional security and performance."
+        "text": "Pagecord is hosted on servers run by Hetzner, in their Falkenstein, Germany data centre. Blog posts are stored in a managed Postgres database (Ubicloud) in the same region. Images are stored in Cloudflare's R2 Object Storage in their Western Europe data centre. Pagecord traffic is proxied through Cloudflare for additional security and performance."
       }
     }
   ]
@@ -152,7 +152,7 @@
 
   <h3 id="data-storage" class="source-serif text-2xl font-semibold">Where is my data stored?</h3>
   <p>
-    Pagecord is hosted on servers run by <a href="https://hetzner.cloud/?ref=cZJ4pqOEU3g9" class="home-link">Hetzner</a>, in their <a href="https://www.hetzner.com/unternehmen/rechenzentrum/" class="home-link">Nuremberg, Germany data centre</a>. Your blogs posts are stored in a database here. Any images you attach to your posts (Premium customers) are stored in <a href="https://www.cloudflare.com/en-gb/developer-platform/products/r2/" class="home-link">Cloudflare's R2 Object Storage</a>, in their Western Europe (WEUR) data centre. Database backups are also stored in R2.
+    Pagecord is hosted on servers run by <a href="https://hetzner.cloud/?ref=cZJ4pqOEU3g9" class="home-link">Hetzner</a>, in their <a href="https://www.hetzner.com/unternehmen/rechenzentrum/" class="home-link">Falkenstein, Germany data centre</a>. Your blog posts are stored in a managed Postgres database, run by <a href="https://www.ubicloud.com" class="home-link">Ubicloud</a> in the same region. Any images you attach to your posts (Premium customers) are stored in <a href="https://www.cloudflare.com/en-gb/developer-platform/products/r2/" class="home-link">Cloudflare's R2 Object Storage</a>, in their Western Europe (WEUR) data centre. Database backups are also stored in R2.
   </p>
   <p>
     Pagecord traffic is proxied through Cloudflare to provide additional security and performance benefits for

--- a/app/views/public/privacy.html.erb
+++ b/app/views/public/privacy.html.erb
@@ -20,6 +20,7 @@
   <ul>
     <li><strong>Paddle:</strong> Payments & Billing</li>
     <li><strong>Hetzner:</strong> Server Infrastructure (Germany)</li>
+    <li><strong>Ubicloud:</strong> Managed database (Germany)</li>
     <li><strong>Cloudflare / R2:</strong> Security, image storage (Western Europe - WEUR), and some transactional emails</li>
     <li><strong>Postmark / Mailpace:</strong> Transactional Emails</li>
     <li><strong>AppSignal / Sentry:</strong> Error Monitoring</li>

--- a/architecture.md
+++ b/architecture.md
@@ -1,18 +1,18 @@
 # Pagecord Architecture
 
-Pagecord is a minimal blogging app where you create posts simply by sending emails. It's a Rails app hosted on a single Hetzner instance via [Hatchbox](https://hatchbox.io). This is not super-scalable, but it's currently a side project so 🤷‍♂️
+Pagecord is a fully featured personal website and blogging app. It's a Rails app hosted by Hetzner, in Falkenstein, Germany.
 
 ## Web app
 
-Pagecord is a web app that uses [Rails](https://rubyonrails.org) 8 and associated tech like Turbo, Stimulus and Import Maps. It uses [Tailwind CSS](https://tailwindcss.com) for styling. It runs on Ruby 4.0.5.
+Pagecord is a web app that uses [Rails](https://rubyonrails.org) 8 and associated tech like Turbo, Stimulus and Import Maps. It runs on Ruby 4.0.5. It uses Memcached for caching.
 
 ## Database
 
-Currently the database is Postgres which runs on a Hetzner server, thanks to Hatchbox. It's not a managed service, but WAL files are continuously replicated to Cloudflare R2 via WAL-G, enabling point-in-time recovery.
+The database is managed Postgres 18 on [Ubicloud](https://www.ubicloud.com), running in the same Falkenstein region as the app. Ubicloud handles daily backups and 7-day point-in-time recovery.A weekly `pg_dump` is pushed to Cloudflare R2 for good measure.
 
 ## Background Jobs
 
-Pagecord uses ActiveJob for background jobs, which are configured to use Sidekiq, which requires Redis. I'll probably move this to SolidQueue at some point.
+Pagecord uses ActiveJob for background jobs, which are configured to use Sidekiq, which requires Redis.
 
 ### Cloudflare R2
 
@@ -20,13 +20,11 @@ Images are processed by ActiveStorage and stored on [Cloudflare R2](https://deve
 
 ### Hatchbox
 
-Pagecord uses Hatchbox to manage deployments. Everything runs on a single Hetzner server. As Pagecord makes more profit, I might move the app to DigitalOcean droplets and use a managed database.
+Pagecord uses Hatchbox to manage deployments.
 
 ### Custom domains / SSL
 
-Premium accounts can apply a custom domain to their blog. Pagecord does this by using the Hatchbox API. Internally, Hatchbox uses [Caddy](https://caddyserver.com/).
-
-Ideally I would run a separate server and create a reverse proxy using Caddy, detaching custom domains from the underlying app hosting. I'm avoiding the overhead of hosting costs and sysadmin work, but it'll bite me at some point I know.
+Premium accounts can apply a custom domain to their blog. SSL certification is handled by [Caddy](https://caddyserver.com/).
 
 ### DNS & Edge Caching
 


### PR DESCRIPTION
architecture.md, FAQ, and privacy policy now reflect managed Postgres on Ubicloud and the Falkenstein data centre. Adds Ubicloud as a database sub-processor.