### PR TITLE
Stop blocking AI crawlers in robots.txt

### DIFF
--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -54,10 +54,6 @@
       By default, your blog can be found through search engines and may be featured in the Pagecord Spotlight and Shuffle. Untick the box below to opt out – we'll serve a <tt>/robots.txt</tt> that discourages search engines, and exclude your blog from Spotlight and Shuffle.
     </p>
 
-    <p class="mt-4 text-slate-500 dark:text-slate-400">
-      (Note: All blogs are configured to discourage AI crawlers)
-    </p>
-
     <div class="mt-6">
       <div class="flex gap-3">
         <div class="flex h-6 shrink-0 items-center">

--- a/app/views/blogs/robots/show.text.erb
+++ b/app/views/blogs/robots/show.text.erb
@@ -1,6 +1,5 @@
 <% if @blog.allow_search_indexing && @blog.user.search_indexable? %>
 # Blog robots.txt for <%= @blog.subdomain %>
-# Last updated: May 2025
 
 # Allow all user agents
 User-agent: *
@@ -8,59 +7,6 @@ Allow: /
 
 # Sitemap location
 Sitemap: <%= sitemap_url_for(@blog) %>
-
-# Block AI crawlers
-User-agent: Anthropic-AI
-Disallow: /
-
-User-agent: Applebot-Extended
-Disallow: /
-
-User-agent: Baiduspider
-Disallow: /
-
-User-agent: Bytespider
-Disallow: /
-
-User-agent: CCBot
-Disallow: /
-
-User-agent: ChatGPT-User
-Disallow: /
-
-User-agent: Claude-Crawler
-Disallow: /
-
-User-agent: Claude-Web
-Disallow: /
-
-User-agent: cohere-ai
-Disallow: /
-
-User-agent: DotBot
-Disallow: /
-
-User-agent: FacebookBot
-Disallow: /
-
-User-agent: GPTBot
-Disallow: /
-
-User-agent: Google-Extended
-Disallow: /
-
-User-agent: Omgili
-Disallow: /
-
-User-agent: Omgilibot
-Disallow: /
-
-User-agent: Perplexity
-Disallow: /
-
-User-agent: PetalBot
-Disallow: /
-
 <% else %>
 User-agent: *
 Disallow: /

--- a/app/views/public/robots.text.erb
+++ b/app/views/public/robots.text.erb
@@ -1,9 +1,6 @@
 # Blog robots.txt for Pagecord
-# Last updated: May 2025
 
-# Allow all user agents.
-# It's ok for AI agents to crawl pagecord.com since all blogs are now on subdomains and
-# default blocking AI crawlers.
+# Allow all user agents
 User-agent: *
 Allow: /
 

--- a/docs/help-guide/seo-and-discovery.md
+++ b/docs/help-guide/seo-and-discovery.md
@@ -23,5 +23,3 @@ If you're on Mastodon or another Fediverse platform, you can enter your Fedivers
 ## Discoverability
 
 By default, your blog can be found through search engines and may be featured in the Pagecord Spotlight and Shuffle. If you'd prefer to keep things low-key, untick the "Make my blog discoverable" box – Pagecord will serve a `robots.txt` that discourages search engines, and exclude your blog from Spotlight and Shuffle.
-
-All Pagecord blogs are automatically configured to discourage AI crawlers regardless of this setting.

--- a/test/controllers/blogs/robots_controller_test.rb
+++ b/test/controllers/blogs/robots_controller_test.rb
@@ -16,8 +16,7 @@ class Blogs::RobotsControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, "Blog robots.txt for #{@blog.subdomain}"
     assert_includes @response.body, "Allow: /"
     assert_includes @response.body, "Sitemap:"
-    assert_includes @response.body, "User-agent: GPTBot"
-    assert_includes @response.body, "Disallow: /"
+    refute_includes @response.body, "Disallow: /"
   end
 
   test "should get robots.txt for custom domain" do
@@ -29,8 +28,7 @@ class Blogs::RobotsControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, "Blog robots.txt for #{blog.subdomain}"
     assert_includes @response.body, "Allow: /"
     assert_includes @response.body, "Sitemap:"
-    assert_includes @response.body, "User-agent: GPTBot"
-    assert_includes @response.body, "Disallow: /"
+    refute_includes @response.body, "Disallow: /"
   end
 
   test "should disallow all indexing" do


### PR DESCRIPTION
Removes the hardcoded list of blocked AI crawler user-agents from the per-blog `robots.txt`.

## Behaviour

- **Search indexing on** → `Allow: /` for all user agents, plus the sitemap. No named crawler is blocked.
- **Search indexing off** → unchanged, `Disallow: /` for everything.

## Why

- The blocklist only affects compliant crawlers, which are the ones that increasingly cite and link back. It did nothing about non-compliant scrapers, so it gave false comfort while opting blogs out of AI answer surfaces.
- It was a maintenance treadmill of ~17 user-agent tokens that go stale monthly (the file still read "Last updated: May 2025").
- The honest control remains the master switch: to stay out of crawlers' way, turn off discoverability or make the blog private.

Also updates the settings-form note, the SEO help guide, and the stale rationale comment on the apex `robots.txt`.

## Note on #938

This does **not** specifically address the Bubbles request in #938. Bubbles was never in the blocklist, so it could already crawl any blog with indexing enabled. This change resolves the broader intent (let AI crawl) rather than that literal case.