### PR TITLE
Remove references to retired Bluesky account

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,9 +10,6 @@
       <%= link_to "https://github.com/lylo/pagecord" do %>
         <%= inline_svg_tag "icons/social/github.svg", class: "w-4 h-4 hover:text-slate-900 dark:hover:text-slate-100", title: "Follow Pagecord on Github" %>
       <% end %>
-      <%= link_to "https://bsky.app/profile/pagecord.com" do %>
-        <%= inline_svg_tag "icons/social/bluesky.svg", class: "w-4 h-4 hover:text-[#1185fe]", title: "Follow Pagecord on Bluesky" %>
-      <% end %>
     </div>
   </div>
 

--- a/docs/help-guide/support.md
+++ b/docs/help-guide/support.md
@@ -17,7 +17,3 @@ GitHub is the best place to report bugs, request features, or raise general issu
 [https://github.com/lylo/pagecord/issues](https://github.com/lylo/pagecord/issues)
 
 This keeps everything visible and trackable, and means other users can benefit from the discussion too. If you don't have an account, worry not – just send me an email.
-
-## Social Media
-
-Pagecord has an account on [Bluesky](https://bsky.app/profile/pagecord.com) but it's only checked periodically – it's not intended for support. If you definitely want a prompt response, please use email or file a GitHub issue instead.


### PR DESCRIPTION
Ditches the Pagecord Bluesky account (`@pagecord.com` / bsky.app/profile/pagecord.com), which is being retired.

Removes the two places that link to the account:
- Footer "Follow Pagecord on Bluesky" icon link
- The "Social Media" section in the support help guide (existed only to point at that account)

Leaves the customer-facing Bluesky *feature* untouched (post embeds, social navigation items, referrer mapping, and the related help docs), since that has nothing to do with the account.

Fizzy: https://app.fizzy.do/6102591/cards/373