### PR TITLE
Add subscriber list CSV download

### DIFF
--- a/.agents/skills/fizzy/SKILL.md
+++ b/.agents/skills/fizzy/SKILL.md
@@ -52,7 +52,7 @@ Card descriptions should be sent as HTML, not Markdown. Fizzy stores description
 - Move to Not Now: `POST /$SLUG/cards/:card_number/not_now`
 - Toggle tag: `POST /$SLUG/cards/:card_number/taggings` with `{"tag_title":"bug"}`
 - Toggle assignment: `POST /$SLUG/cards/:card_number/assignments` with `{"assignee_id":"..."}`
-- Add comment: `POST /$SLUG/cards/:card_number/comments`
+- Add comment: `POST /$SLUG/cards/:card_number/comments` with `{"comment":{"body":"..."}}` (HTML/Action Text, same as descriptions; the key is `body`, not `content` or `description`)
 - List comments: `GET /$SLUG/cards/:card_number/comments`
 - Delete comment: `DELETE /$SLUG/cards/:card_number/comments/:comment_id` (returns 204; handy for cleaning up probe comments)
 - List boards: `GET /$SLUG/boards`

--- a/app/controllers/app/settings/subscribers_controller.rb
+++ b/app/controllers/app/settings/subscribers_controller.rb
@@ -1,0 +1,7 @@
+class App::Settings::SubscribersController < AppController
+  def index
+    send_data @blog.email_subscribers.confirmed.to_csv,
+      filename: "#{@blog.subdomain}-subscribers-#{Date.current.iso8601}.csv",
+      type: "text/csv"
+  end
+end

--- a/app/models/email_subscriber.rb
+++ b/app/models/email_subscriber.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 class EmailSubscriber < ApplicationRecord
   include Tokenable
 
@@ -7,6 +9,15 @@ class EmailSubscriber < ApplicationRecord
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :unconfirmed, -> { where(confirmed_at: nil) }
+
+  def self.to_csv
+    CSV.generate do |csv|
+      csv << %w[ email confirmed_at country ]
+      order(:created_at).each do |subscriber|
+        csv << [ subscriber.email, subscriber.confirmed_at&.iso8601, subscriber.country ]
+      end
+    end
+  end
 
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :email, uniqueness: { scope: :blog_id, message: "is already subscribed to this blog" }

--- a/app/views/app/settings/audience/index.html.erb
+++ b/app/views/app/settings/audience/index.html.erb
@@ -22,6 +22,12 @@
     <p>
       Your blog has <%= pluralize @blog.email_subscribers.confirmed.count, "email subscriber" %>.
     </p>
+    <% if @blog.email_subscribers.confirmed.any? %>
+      <%= link_to app_settings_subscribers_path(format: :csv), class: "btn-optional mt-3" do %>
+        <%= inline_svg_tag "icons/download.svg", class: "w-4 h-4" %>
+        <span class="ml-2">Download CSV</span>
+      <% end %>
+    <% end %>
   <% end %>
 
   <div data-controller="subscription-settings" class="mt-8">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
       namespace :settings do
         resources :about, only: [ :index, :update ]
         resources :audience, only: [ :index ]
+        resources :subscribers, only: [ :index ]
         resources :users, only: [ :update, :destroy ]
         resources :blogs, only: [ :index, :update ]
         resources :appearance, only: [ :index, :update ]

--- a/test/controllers/app/settings/subscribers_controller_test.rb
+++ b/test/controllers/app/settings/subscribers_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class App::Settings::SubscribersControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  setup do
+    @user = users(:joel)
+    @blog = @user.blog
+    login_as @user
+  end
+
+  test "downloads confirmed subscribers as CSV" do
+    get app_settings_subscribers_url(format: :csv)
+
+    assert_response :success
+    assert_equal "text/csv", @response.media_type
+    assert_match "fred@example.com", @response.body    # confirmed
+    assert_no_match "geoff@gmail.com", @response.body   # unconfirmed excluded
+  end
+end


### PR DESCRIPTION
Blog owners can now download their confirmed email subscribers as a CSV from Audience settings, for portability and migration to other tools.

## What

- New **Download CSV** button on the Audience settings page, shown when the blog has confirmed subscribers (gated the same way as the subscriber count).
- Exports **email, confirmed_at, country** for confirmed subscribers only.

## Approach

- `EmailSubscriber.to_csv` class method owns the CSV shape (callable on any relation/scope).
- `App::Settings::SubscribersController#index` streams it via `send_data` — a tiny, single-responsibility REST controller.
- No migration, no background job. Deliberately separate from the heavier `Export` flow so accessing subscribers stays cheap.

## Notes

- Endpoint is scoped to the current user's blog, so an owner only ever downloads their own list.
- Confirmed-only matches the count shown on the page and is the portable, opted-in set.