### PR TITLE
Stop resolving attachment sgids when saving a post

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -46,14 +46,16 @@ class Post < ApplicationRecord
   after_commit :touch_blog, on: [ :create, :update, :destroy ]
 
   def content_present
-    has_content = content.body.present? && content.body.to_plain_text.strip.present?
-    has_attachments = content.body&.attachments&.any?
+    # Check the fragment Action Text has already parsed. to_plain_text and
+    # attachments resolve every embed's sgid, one blob query each, which is a
+    # heavy N+1 on image-heavy posts.
+    fragment = content.body&.fragment
+
+    has_content = fragment && fragment.source.text.strip.present?
+    has_attachments = fragment && fragment.find_all("action-text-attachment, img, video, audio").any?
 
     unless has_content || has_attachments
-      doc = Nokogiri::HTML::DocumentFragment.parse(content.body.to_s)
-      unless doc.css("img, video, audio").any?
-        errors.add(:content, "can't be blank")
-      end
+      errors.add(:content, "can't be blank")
     end
   end
 
@@ -172,7 +174,11 @@ class Post < ApplicationRecord
   # Used by content moderation. See also: text_summary (truncated version).
   def plain_text_content
     return "" unless content.body.present?
-    plain_text_from(content.to_s)
+    # Use stored Action Text HTML, not the rendered output: content.to_s
+    # resolves every embed's sgid (one blob query per attachment, ignoring
+    # preloads), while to_html is a plain round-trip. The attachment markers
+    # it leaves behind are stripped by plain_text_from anyway.
+    plain_text_from(content.body.to_html)
   end
 
   private

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -497,4 +497,50 @@ class PostTest < ActiveSupport::TestCase
 
     assert_not_equal original_updated_at, blog.reload.updated_at
   end
+
+  test "plain_text_from strips attachment markers, urls, and dynamic variables" do
+    html = %(<h1>Trip</h1><p>Photos [beach.jpg] from https://example.com {{author}}</p>)
+    assert_equal "Trip Photos from", Post.new(blog: blogs(:joel)).send(:plain_text_from, html)
+  end
+
+  test "plain_text_from drops figcaptions and treats breaks and blocks as spaces" do
+    html = %(<figure><img><figcaption>caption</figcaption></figure><p>One</p><p>Two<br>Three</p>)
+    assert_equal "One Two Three", Post.new(blog: blogs(:joel)).send(:plain_text_from, html)
+  end
+
+  test "plain_text_content returns the text and ignores attachment tags" do
+    post = blogs(:joel).posts.build(content: "<p>Caption</p>#{attachment_tag("gid://unresolved")}")
+    assert_equal "Caption", post.plain_text_content
+  end
+
+  test "content_present accepts text or attachments and rejects empty content" do
+    assert blogs(:joel).posts.build(content: "Just words").valid?
+    assert blogs(:joel).posts.build(content: attachment_tag("gid://unresolved")).valid?
+
+    empty = blogs(:joel).posts.build(content: "<div></div>")
+    assert_not empty.valid?
+    assert_includes empty.errors[:content], "can't be blank"
+  end
+
+  # These run on every post save, so they must check presence and extract text
+  # from the parsed HTML without resolving the embeds - one blob query each is
+  # an N+1 on image-heavy posts. Keep the sgid real: a fake one never resolves,
+  # so assert_no_queries would pass without guarding anything.
+  test "content_present and plain_text_content never resolve attachment sgids" do
+    blob = ActiveStorage::Blob.create_before_direct_upload!(
+      filename: "photo.jpg", byte_size: 1, checksum: "x", content_type: "image/jpeg"
+    )
+    post = blogs(:joel).posts.build(content: attachment_tag(blob.attachable_sgid) * 3)
+
+    assert_no_queries do
+      post.content_present
+      post.plain_text_content
+    end
+  end
+
+  private
+
+    def attachment_tag(sgid)
+      %(<action-text-attachment sgid="#{sgid}" content-type="image/jpeg"></action-text-attachment>)
+    end
 end


### PR DESCRIPTION
Saving a post resolved every embedded attachment's sgid several times over. `content_present` called `to_plain_text` (one blob query per image) and then `attachments` (another per image), and on the empty path re-parsed the rendered HTML to look for `img/video/audio`, resolving them a third time. `plain_text_content` went through `content.to_s`, which renders each attachment partial and resolves its sgid individually, ignoring any preloads.

### What changed

`content_present` reads the Nokogiri fragment `ActionText::Content` has already parsed, so it resolves nothing and re-parses nothing. The `img/video/audio` check folds into the same query: rendered `img` tags only ever come from `action-text-attachment` nodes, which the query catches, and raw tags pass through rendering unchanged.

`plain_text_content` uses the stored HTML via `to_html`, a plain Nokogiri round-trip. The attachment markers it leaves behind were already being stripped by `plain_text_from`.

App-level sgid resolution on create drops from 81 blob queries to 0.

### Notes for review

- The presence check deliberately does **not** use `plain_text_from`. That helper exists for text summaries and moderation, so it strips URLs and `{{ custom_tags }}` on purpose. As a presence check it rejects any post whose whole content is a bare link or a single custom tag, which breaks publishing a `{{ posts }}` index page.
- `Content#fragment` and `Fragment#source` are public attr_readers, but they are not heavily documented API. Worth a glance on Action Text upgrades.
- The dominant remaining cost is an O(n²) resolution inside Rails autosave via `ActionText::RichText#blank?`. That is framework-level and tracked separately.