### PR TITLE
Post upvotes with a button instead of a link

### DIFF
--- a/app/assets/stylesheets/blogs.css
+++ b/app/assets/stylesheets/blogs.css
@@ -435,7 +435,9 @@ footer.blog-footer #brand svg {
       align-items: center;
       gap: 0.5rem;
 
-      a {
+      a,
+      .upvote-form,
+      .upvote {
         display: flex;
         align-items: center;
       }

--- a/app/views/blogs/posts/_upvotes.html.erb
+++ b/app/views/blogs/posts/_upvotes.html.erb
@@ -1,11 +1,10 @@
-<%= link_to post_upvotes_path(post),
-            class: "upvote",
-            rel: "nofollow",
-            data: { turbo_method: :post, turbo_prefetch: false, controller: "upvote", action: "click->upvote#pulse", upvote_token_value: post.token },
-            title: "Click to like this post",
-            aria: { label: "Like this post" } do %>
+<%= button_to post_upvotes_path(post),
+              class: "upvote",
+              form_class: "upvote-form",
+              data: { controller: "upvote", action: "click->upvote#pulse", upvote_token_value: post.token },
+              title: "Click to like this post",
+              aria: { label: "Like this post" } do %>
   <%= inline_svg_tag "icons/heart.svg",
         class: "icon cursor-pointer upvote-heart",
         data: { upvote_target: "heart" } %>
 <% end %>
-

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -868,7 +868,10 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     get blog_posts_path
 
     assert_response :success
-    assert_select "a.upvote"
+    assert_select "button.upvote"
+    # A GET-shaped href to the POST-only upvotes route draws 404s from browsers
+    # following the link, so the button must never be an anchor.
+    assert_select "a[href*='/upvotes']", false
   end
 
   test "should not render upvotes for a non-subscriber" do

--- a/test/system/upvote_post_test.rb
+++ b/test/system/upvote_post_test.rb
@@ -11,13 +11,13 @@ class UpvotePostTest < ApplicationSystemTestCase
     use_subdomain(blog.subdomain)
     visit blog_post_path(post.slug)
 
-    find("a.upvote").click
+    find("button.upvote").click
     assert_selector ".upvote-heart[style*='fill']"  # JS sets fill color immediately
     sleep 0.5  # Allow request to complete
     assert_equal 1, post.upvotes.reload.count
 
     # Second click has no effect (already upvoted)
-    find("a.upvote").click
+    find("button.upvote").click
     sleep 0.5
     assert_equal 1, post.upvotes.reload.count
 


### PR DESCRIPTION
The upvote control was a `link_to` with `turbo_method: :post`, which renders an anchor carrying a GET-shaped href to a POST-only route. Ordinary browsers follow that href and get a 404.

`5a55089b` disabled Turbo prefetch on the assumption that prefetch was issuing those requests. It deployed on 07-15 at 16:07 and made no difference: 07-16 still logged 2,928 upvote 404s at a flat ~120/hour with no step down after the deploy, from ordinary browser user agents (iPhone, Windows, Mac). So prefetch was not the source; the href is.

`button_to` removes the href entirely. The rendered markup is now:

```html
<form class="upvote-form" method="post" action="/posts/19171aa0/upvotes">
  <button class="upvote" data-controller="upvote" ...>
```

### Notes

- **CSRF**: `Posts::UpvotesController` already calls `skip_forgery_protection`, since cached pages have no session cookie to verify against. `button_to` emits no authenticity token here, so the markup stays cacheable.
- **Stimulus**: `upvote#pulse` calls `event.preventDefault()` when the post is already upvoted, which suppresses a form submit exactly as it suppressed the link click.
- **CSS**: `.post-actions a` styled the anchor as a flex child, so the selector now also covers `.upvote-form` and `.upvote` to keep the heart aligned in the footer.

### Testing

- System tests pass in a real browser, covering the click, the second-click no-op, and the fill persisting across a refresh.
- The controller test now asserts `button.upvote` renders and that no anchor points at `/upvotes`, so the href cannot come back.