### PR TITLE
Identity links (rel=me) beyond Mastodon

### DIFF
--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -28,6 +28,7 @@ class App::Settings::BlogsController < AppController
       permitted_params = [
         :subdomain,
         :fediverse_author_attribution,
+        :rel_me_links,
         :allow_search_indexing,
         :google_site_verification,
         :seo_title,

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -1,6 +1,6 @@
 class Blog < ApplicationRecord
   include Discard::Model
-  include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, Blog::CustomFooter, StorageTrackable, Blog::Contactable, Blog::ApiKey, Blog::Spotlit
+  include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, Blog::CustomFooter, StorageTrackable, Blog::Contactable, Blog::ApiKey, Blog::Spotlit, Blog::RelMe
 
   enum :layout, [ :stream_layout, :title_layout, :cards_layout ]
 

--- a/app/models/concerns/blog/rel_me.rb
+++ b/app/models/concerns/blog/rel_me.rb
@@ -3,21 +3,17 @@ module Blog::RelMe
 
   MAX_REL_ME_LINKS = 10
 
-  # Platforms whose profiles participate in rel=me verification, either by
-  # emitting rel=me on profile links or by verifying links back to this blog
-  REL_ME_PLATFORMS = %w[ Email GitHub Mastodon Pixelfed Threads ].freeze
-
   included do
     validate :rel_me_links_valid
   end
 
-  # Explicit identity links (one per line) when set, otherwise inferred from
+  # Explicit identity links (one per line) combined with those inferred from
   # social navigation items. Emitted as <link rel="me"> in the blog head.
   def rel_me_urls
-    urls = explicit_rel_me_links.presence ||
-      social_navigation_items.ordered.where(platform: REL_ME_PLATFORMS).map(&:link_url)
+    urls = explicit_rel_me_links +
+      social_navigation_items.ordered.where.not(platform: "RSS").map(&:link_url)
 
-    urls.select { |url| valid_rel_me_url?(url) }
+    urls.uniq.select { |url| valid_rel_me_url?(url) }
   end
 
   private

--- a/app/models/concerns/blog/rel_me.rb
+++ b/app/models/concerns/blog/rel_me.rb
@@ -7,11 +7,13 @@ module Blog::RelMe
     validate :rel_me_links_valid
   end
 
-  # Explicit identity links (one per line) combined with those inferred from
-  # social navigation items. Emitted as <link rel="me"> in the blog head.
+  # Explicit identity links (one per line) combined with social navigation
+  # item links. RSS (the blog's own feed) and Web (an arbitrary site, not
+  # necessarily the author's) are not inferred. Emitted as <link rel="me">
+  # in the blog head.
   def rel_me_urls
     urls = explicit_rel_me_links +
-      social_navigation_items.ordered.where.not(platform: "RSS").map(&:link_url)
+      social_navigation_items.ordered.where.not(platform: %w[RSS Web]).map(&:link_url)
 
     urls.uniq.select { |url| valid_rel_me_url?(url) }
   end

--- a/app/models/concerns/blog/rel_me.rb
+++ b/app/models/concerns/blog/rel_me.rb
@@ -1,0 +1,56 @@
+module Blog::RelMe
+  extend ActiveSupport::Concern
+
+  MAX_REL_ME_LINKS = 10
+
+  # Platforms whose profiles participate in rel=me verification, either by
+  # emitting rel=me on profile links or by verifying links back to this blog
+  REL_ME_PLATFORMS = %w[ Email GitHub Mastodon Pixelfed Threads ].freeze
+
+  included do
+    validate :rel_me_links_valid
+  end
+
+  # Explicit identity links (one per line) when set, otherwise inferred from
+  # social navigation items. Emitted as <link rel="me"> in the blog head.
+  def rel_me_urls
+    urls = explicit_rel_me_links.presence ||
+      social_navigation_items.ordered.where(platform: REL_ME_PLATFORMS).map(&:link_url)
+
+    urls.select { |url| valid_rel_me_url?(url) }
+  end
+
+  private
+
+    def explicit_rel_me_links
+      rel_me_links.to_s.lines.map(&:strip).reject(&:blank?).uniq
+    end
+
+    def rel_me_links_valid
+      links = explicit_rel_me_links
+
+      if links.size > MAX_REL_ME_LINKS
+        errors.add(:rel_me_links, "can include at most #{MAX_REL_ME_LINKS} links")
+      end
+
+      links.each do |link|
+        unless valid_rel_me_url?(link)
+          errors.add(:rel_me_links, "includes an invalid URL: #{link}")
+        end
+      end
+    end
+
+    def valid_rel_me_url?(url)
+      uri = URI.parse(url)
+      case uri.scheme
+      when "http", "https"
+        uri.host.present?
+      when "mailto"
+        uri.to.match?(URI::MailTo::EMAIL_REGEXP)
+      else
+        false
+      end
+    rescue URI::Error
+      false
+    end
+end

--- a/app/models/social_navigation_item.rb
+++ b/app/models/social_navigation_item.rb
@@ -8,8 +8,6 @@ class SocialNavigationItem < NavigationItem
 
   before_validation :set_label_from_platform, if: -> { platform.present? && label.blank? }
 
-  scope :mastodon, -> { where(platform: "Mastodon") }
-
   def link_url
     email? ? "mailto:#{url}" : url
   end

--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -95,6 +95,19 @@
         </p>
       <% end %>
 
+      <%= settings_row "Identity Links (rel=me)" do %>
+        <fieldset>
+          <%= form.text_area :rel_me_links,
+              rows: 4,
+              placeholder: "https://mastodon.social/@you\nhttps://github.com/you",
+              class: "form-field md:w-full font-mono text-sm" %>
+          <%= field_error(@blog, :rel_me_links) %>
+        </fieldset>
+        <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          Links to your profiles elsewhere on the web, one per line. Services like Mastodon, Threads and IndieAuth use these to verify that this blog is yours – your profile there must also link back to this blog. Leave blank to use your social navigation links on services that support verification.
+        </p>
+      <% end %>
+
       <%= settings_row "Google Site Verification" do %>
         <fieldset>
           <%= styled_text_field(form, :google_site_verification, placeholder: "e.g. Gzm-PA_FXh231_cgsIxY_h9OgR6r8DZ", class: "md:w-full", data: { controller: "google-site-verification", action: "paste->google-site-verification#paste" }) %>

--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -104,7 +104,7 @@
           <%= field_error(@blog, :rel_me_links) %>
         </fieldset>
         <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
-          Links to your profiles elsewhere on the web, one per line. Services like Mastodon, Threads and IndieAuth use these to verify that this blog is yours – your profile there must also link back to this blog. Your social navigation links are included automatically.
+          Links to your profiles elsewhere on the web, one per line. Services like Mastodon, Threads and IndieAuth use these to verify that this blog is yours – your profile there must also link back to this blog. Social navigation links are included automatically, except generic web links and your RSS feed.
         </p>
       <% end %>
 

--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -104,7 +104,7 @@
           <%= field_error(@blog, :rel_me_links) %>
         </fieldset>
         <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
-          Links to your profiles elsewhere on the web, one per line. Services like Mastodon, Threads and IndieAuth use these to verify that this blog is yours – your profile there must also link back to this blog. Leave blank to use your social navigation links on services that support verification.
+          Links to your profiles elsewhere on the web, one per line. Services like Mastodon, Threads and IndieAuth use these to verify that this blog is yours – your profile there must also link back to this blog. Your social navigation links are included automatically.
         </p>
       <% end %>
 

--- a/app/views/layouts/_fediverse_identity.html.erb
+++ b/app/views/layouts/_fediverse_identity.html.erb
@@ -1,4 +1,0 @@
-<% mastodon_link = @blog.social_navigation_items.mastodon.first %>
-<% if mastodon_link.present? %>
-  <link href="<%= mastodon_link.url %>" rel="me">
-<% end %>

--- a/app/views/layouts/_identity_links.html.erb
+++ b/app/views/layouts/_identity_links.html.erb
@@ -1,0 +1,3 @@
+<% @blog.rel_me_urls.each do |url| %>
+  <link href="<%= url %>" rel="me">
+<% end %>

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -33,7 +33,7 @@
 
     <%= render "layouts/structured_data" %>
 
-    <%= render "layouts/fediverse_identity" %>
+    <%= render "layouts/identity_links" %>
     <%= yield :fediverse %>
 
     <link rel="canonical" href="<%= canonical_url %>" />

--- a/db/migrate/20260720100539_add_rel_me_links_to_blogs.rb
+++ b/db/migrate/20260720100539_add_rel_me_links_to_blogs.rb
@@ -1,0 +1,5 @@
+class AddRelMeLinksToBlogs < ActiveRecord::Migration[8.2]
+  def change
+    add_column :blogs, :rel_me_links, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_20_100539) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -131,6 +131,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_13_120000) do
     t.string "width", default: "standard", null: false
     t.text "custom_footer_html"
     t.boolean "external_links_in_new_tab", default: false, null: false
+    t.text "rel_me_links"
     t.index ["api_key_digest"], name: "index_blogs_on_api_key_digest", unique: true
     t.index ["custom_domain"], name: "index_blogs_on_custom_domain", unique: true, where: "(custom_domain IS NOT NULL)"
     t.index ["home_page_id"], name: "index_blogs_on_home_page_id"

--- a/docs/help-guide/index.md
+++ b/docs/help-guide/index.md
@@ -70,6 +70,12 @@ Let readers subscribe to your blog using an RSS reader.
 
 - [RSS feeds](rss-feeds.md)
 
+## IndieWeb
+
+Pagecord blogs are marked up with microformats so that IndieWeb tools can understand your content.
+
+- [Microformats](microformats.md)
+
 ## API & Integrations
 
 Use the Pagecord API to manage your blog programmatically, publish from the command line, or publish directly from tools like Obsidian.

--- a/docs/help-guide/microformats.md
+++ b/docs/help-guide/microformats.md
@@ -1,0 +1,25 @@
+---
+title: "Microformats"
+published: false
+---
+Every Pagecord blog is marked up with [microformats](https://microformats.org) – small HTML conventions that let machines understand your content, not just humans. You don't need to do anything; it's built into every blog, free or premium.
+
+## What Pagecord marks up
+
+- **Posts** use `h-entry`, identifying the title (`p-name`), permalink (`u-url`), publication date (`dt-published`) and content (`e-content`).
+- **Your post stream** uses `h-feed`, so tools can treat your home page as a feed of entries.
+- **Your blog itself** uses `h-card` – the online equivalent of a business card – with your blog's name, URL and avatar.
+- **Identity links** use `rel="me"` to declare that profiles elsewhere on the web belong to you. See [SEO & Discovery](seo-and-discovery.md).
+
+## What's it good for?
+
+Microformats are a cornerstone of the IndieWeb. Tools that understand them can do useful things with your blog without any screen-scraping:
+
+- IndieWeb feed readers can present your posts properly – title, author, date and content – because your stream is a parseable `h-feed`.
+- Mastodon, Threads and other services use `rel="me"` to verify that your blog and your profiles belong to the same person.
+- Services like [IndieLogin](https://indielogin.com) can sign you in with your own domain.
+- Publishing tools that speak [Micropub](micropub.md) build on the same ideas.
+
+## See what a machine sees
+
+Paste your blog's URL into the [microformats parser at pin13.net](https://pin13.net/mf2/) to see exactly what IndieWeb tools can read from it.

--- a/docs/help-guide/seo-and-discovery.md
+++ b/docs/help-guide/seo-and-discovery.md
@@ -26,7 +26,7 @@ Identity links tell other services that profiles elsewhere on the web belong to 
 
 Add one URL per line (e.g. `https://mastodon.social/@you` or `https://github.com/you`). For verification to work, your profile on that service must also link back to your blog – on Mastodon, add your blog URL to your profile metadata and re-save it.
 
-Your social navigation links are included automatically (everything except your RSS feed), so you only need to add links here that aren't already in your navigation.
+Your social navigation links are included automatically, except your RSS feed and any generic "Web" links (which might point at a site that isn't yours) – so you only need to add links here that aren't already covered.
 
 ## Discoverability
 

--- a/docs/help-guide/seo-and-discovery.md
+++ b/docs/help-guide/seo-and-discovery.md
@@ -26,7 +26,7 @@ Identity links tell other services that profiles elsewhere on the web belong to 
 
 Add one URL per line (e.g. `https://mastodon.social/@you` or `https://github.com/you`). For verification to work, your profile on that service must also link back to your blog – on Mastodon, add your blog URL to your profile metadata and re-save it.
 
-Leave this blank and Pagecord will use your social navigation links instead, for services that support verification: Mastodon, Pixelfed, GitHub, Threads and Email.
+Your social navigation links are included automatically (everything except your RSS feed), so you only need to add links here that aren't already in your navigation.
 
 ## Discoverability
 

--- a/docs/help-guide/seo-and-discovery.md
+++ b/docs/help-guide/seo-and-discovery.md
@@ -28,6 +28,8 @@ Add one URL per line (e.g. `https://mastodon.social/@you` or `https://github.com
 
 Your social navigation links are included automatically, except your RSS feed and any generic "Web" links (which might point at a site that isn't yours) – so you only need to add links here that aren't already covered.
 
+rel=me is one of several [microformats](microformats.md) built into every Pagecord blog.
+
 ## Discoverability
 
 By default, your blog can be found through search engines and may be featured in the Pagecord Spotlight and Shuffle. If you'd prefer to keep things low-key, untick the "Make my blog discoverable" box – Pagecord will serve a `robots.txt` that discourages search engines, and exclude your blog from Spotlight and Shuffle.

--- a/docs/help-guide/seo-and-discovery.md
+++ b/docs/help-guide/seo-and-discovery.md
@@ -20,6 +20,14 @@ Just paste the verification code (or the full meta tag – Pagecord will extract
 
 If you're on Mastodon or another Fediverse platform, you can enter your Fediverse username (e.g. `@you@mastodon.social`) so that your posts are attributed to you when shared on those platforms.
 
+## Identity Links (rel=me)
+
+Identity links tell other services that profiles elsewhere on the web belong to the same person as your blog. Mastodon, Threads and IndieAuth use them to verify you – this is what gets you the green verified tick on a Mastodon profile.
+
+Add one URL per line (e.g. `https://mastodon.social/@you` or `https://github.com/you`). For verification to work, your profile on that service must also link back to your blog – on Mastodon, add your blog URL to your profile metadata and re-save it.
+
+Leave this blank and Pagecord will use your social navigation links instead, for services that support verification: Mastodon, Pixelfed, GitHub, Threads and Email.
+
 ## Discoverability
 
 By default, your blog can be found through search engines and may be featured in the Pagecord Spotlight and Shuffle. If you'd prefer to keep things low-key, untick the "Make my blog discoverable" box – Pagecord will serve a `robots.txt` that discourages search engines, and exclude your blog from Spotlight and Shuffle.

--- a/test/controllers/app/settings/blogs_controller_test.rb
+++ b/test/controllers/app/settings/blogs_controller_test.rb
@@ -21,6 +21,8 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h4", { count: 1, text: "Fediverse Author Attribution" }
     assert_select "p", text: /Your full Fediverse handle, not your profile URL/
     assert_select "input[name='blog[fediverse_author_attribution]'][placeholder='e.g. @you@mastodon.social']"
+    assert_select "h4", { count: 1, text: "Identity Links (rel=me)" }
+    assert_select "textarea[name='blog[rel_me_links]']"
     assert_response :success
   end
 
@@ -127,6 +129,20 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to app_settings_url
     assert_equal "@example@mastodon.social", @blog.reload.fediverse_author_attribution
+  end
+
+  test "should update rel me links" do
+    patch app_settings_blog_url(@blog), params: { blog: { rel_me_links: "https://github.com/joel\nhttps://mastodon.social/@joel" } }, as: :turbo_stream
+
+    assert_redirected_to app_settings_url
+    assert_equal "https://github.com/joel\nhttps://mastodon.social/@joel", @blog.reload.rel_me_links
+  end
+
+  test "should not update rel me links with invalid URLs" do
+    patch app_settings_blog_url(@blog), params: { blog: { rel_me_links: "not a url" } }, as: :turbo_stream
+
+    assert_response :unprocessable_entity
+    assert_nil @blog.reload.rel_me_links
   end
 
   test "should update google site verification" do

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -824,19 +824,31 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'meta[name="fediverse:creator"][content="@joel@pagecord.com"]'
   end
 
-  test "should include rel='me' link if Mastodon social navigation item is present" do
-    mastodon_link = SocialNavigationItem.create!(
-      blog: @blog,
-      platform: "Mastodon",
-      url: "https://mas.to/@joel_on_pagecord"
-    )
+  test "should include rel='me' links for social navigation items that support verification" do
+    blog = blogs(:saul)
+    host_subdomain! blog.subdomain
 
     get blog_posts_path
 
-    assert_select "link[rel=\"me\"][href=\"#{mastodon_link.url}\"]"
+    assert_select "link[rel=\"me\"]", count: 3
+    assert_select "link[rel=\"me\"][href=\"https://mas.to/@saul\"]"
+    assert_select "link[rel=\"me\"][href=\"https://github.com/saul\"]"
+    assert_select "link[rel=\"me\"][href=\"mailto:saul@example.com\"]"
   end
 
-  test "should not include rel='me' link if Mastodon social navigation item is not present" do
+  test "should include rel='me' links from identity links instead of social navigation items" do
+    blog = blogs(:saul)
+    blog.update!(rel_me_links: "https://micro.blog/saul")
+    host_subdomain! blog.subdomain
+
+    get blog_posts_path
+
+    assert_select "link[rel=\"me\"]", count: 1
+    assert_select "link[rel=\"me\"][href=\"https://micro.blog/saul\"]"
+  end
+
+  test "should not include rel='me' link if no social navigation items support verification" do
+    # joel's only social navigation item is Bluesky, which doesn't use rel=me
     get blog_posts_path
 
     assert_select "link[rel=\"me\"]", count: 0

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -824,31 +824,42 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'meta[name="fediverse:creator"][content="@joel@pagecord.com"]'
   end
 
-  test "should include rel='me' links for social navigation items that support verification" do
+  test "should include rel='me' links for social navigation items" do
     blog = blogs(:saul)
     host_subdomain! blog.subdomain
 
     get blog_posts_path
 
-    assert_select "link[rel=\"me\"]", count: 3
+    assert_select "link[rel=\"me\"]", count: 5
     assert_select "link[rel=\"me\"][href=\"https://mas.to/@saul\"]"
     assert_select "link[rel=\"me\"][href=\"https://github.com/saul\"]"
     assert_select "link[rel=\"me\"][href=\"mailto:saul@example.com\"]"
+    assert_select "link[rel=\"me\"][href=\"https://example.com\"]"
+    assert_select "link[rel=\"me\"][href=\"https://x.com/saul\"]"
   end
 
-  test "should include rel='me' links from identity links instead of social navigation items" do
+  test "should include rel='me' links from identity links alongside social navigation items" do
     blog = blogs(:saul)
     blog.update!(rel_me_links: "https://micro.blog/saul")
     host_subdomain! blog.subdomain
 
     get blog_posts_path
 
-    assert_select "link[rel=\"me\"]", count: 1
+    assert_select "link[rel=\"me\"]", count: 6
     assert_select "link[rel=\"me\"][href=\"https://micro.blog/saul\"]"
+    assert_select "link[rel=\"me\"][href=\"https://mas.to/@saul\"]"
   end
 
-  test "should not include rel='me' link if no social navigation items support verification" do
-    # joel's only social navigation item is Bluesky, which doesn't use rel=me
+  test "should include rel='me' link for any social profile platform" do
+    # joel's only social navigation item is Bluesky
+    get blog_posts_path
+
+    assert_select "link[rel=\"me\"][href=\"https://bsky.app/profile/joel.example.com\"]"
+  end
+
+  test "should not include rel='me' link if no identity links or social navigation items are present" do
+    @blog.social_navigation_items.destroy_all
+
     get blog_posts_path
 
     assert_select "link[rel=\"me\"]", count: 0

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -830,11 +830,10 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
 
     get blog_posts_path
 
-    assert_select "link[rel=\"me\"]", count: 5
+    assert_select "link[rel=\"me\"]", count: 4
     assert_select "link[rel=\"me\"][href=\"https://mas.to/@saul\"]"
     assert_select "link[rel=\"me\"][href=\"https://github.com/saul\"]"
     assert_select "link[rel=\"me\"][href=\"mailto:saul@example.com\"]"
-    assert_select "link[rel=\"me\"][href=\"https://example.com\"]"
     assert_select "link[rel=\"me\"][href=\"https://x.com/saul\"]"
   end
 
@@ -845,7 +844,7 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
 
     get blog_posts_path
 
-    assert_select "link[rel=\"me\"]", count: 6
+    assert_select "link[rel=\"me\"]", count: 5
     assert_select "link[rel=\"me\"][href=\"https://micro.blog/saul\"]"
     assert_select "link[rel=\"me\"][href=\"https://mas.to/@saul\"]"
   end

--- a/test/fixtures/navigation_items.yml
+++ b/test/fixtures/navigation_items.yml
@@ -26,3 +26,51 @@ joel_hidden:
   post: contact
   label: "Contact"
   position: 4
+
+saul_social_mastodon:
+  type: SocialNavigationItem
+  blog: saul
+  label: "Mastodon"
+  platform: "Mastodon"
+  url: "https://mas.to/@saul"
+  position: 1
+
+saul_social_github:
+  type: SocialNavigationItem
+  blog: saul
+  label: "GitHub"
+  platform: "GitHub"
+  url: "https://github.com/saul"
+  position: 2
+
+saul_social_email:
+  type: SocialNavigationItem
+  blog: saul
+  label: "Email"
+  platform: "Email"
+  url: "saul@example.com"
+  position: 3
+
+saul_social_rss:
+  type: SocialNavigationItem
+  blog: saul
+  label: "RSS"
+  platform: "RSS"
+  url: "https://saul.pagecord.com/feed.xml"
+  position: 4
+
+saul_social_web:
+  type: SocialNavigationItem
+  blog: saul
+  label: "Web"
+  platform: "Web"
+  url: "https://example.com"
+  position: 5
+
+saul_social_x:
+  type: SocialNavigationItem
+  blog: saul
+  label: "X"
+  platform: "X"
+  url: "https://x.com/saul"
+  position: 6

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -280,25 +280,34 @@ class BlogTest < ActiveSupport::TestCase
     blog.update!(title: "New Title")
   end
 
-  test "rel_me_urls should infer from social navigation items that support verification" do
-    assert_equal [ "https://mas.to/@saul", "https://github.com/saul", "mailto:saul@example.com" ],
+  test "rel_me_urls should infer from social navigation items" do
+    assert_equal [ "https://mas.to/@saul", "https://github.com/saul", "mailto:saul@example.com", "https://example.com", "https://x.com/saul" ],
       blogs(:saul).rel_me_urls
   end
 
-  test "rel_me_urls should prefer explicit links over social navigation items" do
+  test "rel_me_urls should combine explicit links with social navigation items" do
     blog = blogs(:saul)
     blog.rel_me_links = "https://micro.blog/saul"
 
-    assert_equal [ "https://micro.blog/saul" ], blog.rel_me_urls
+    assert_equal [ "https://micro.blog/saul", "https://mas.to/@saul", "https://github.com/saul", "mailto:saul@example.com", "https://example.com", "https://x.com/saul" ], blog.rel_me_urls
+  end
+
+  test "rel_me_urls should not duplicate links that are both explicit and inferred" do
+    blog = blogs(:saul)
+    blog.rel_me_links = "https://github.com/saul"
+
+    assert_equal [ "https://github.com/saul", "https://mas.to/@saul", "mailto:saul@example.com", "https://example.com", "https://x.com/saul" ], blog.rel_me_urls
   end
 
   test "rel_me_urls should parse explicit links one per line" do
+    @blog.social_navigation_items.destroy_all
     @blog.rel_me_links = "  https://github.com/joel \n\nhttps://mastodon.social/@joel\nhttps://github.com/joel\n"
 
     assert_equal [ "https://github.com/joel", "https://mastodon.social/@joel" ], @blog.rel_me_urls
   end
 
   test "rel_me_urls should filter out invalid schemes" do
+    @blog.social_navigation_items.destroy_all
     @blog.rel_me_links = "javascript:alert(1)\nhttps://github.com/joel"
 
     assert_equal [ "https://github.com/joel" ], @blog.rel_me_urls

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -279,4 +279,48 @@ class BlogTest < ActiveSupport::TestCase
 
     blog.update!(title: "New Title")
   end
+
+  test "rel_me_urls should infer from social navigation items that support verification" do
+    assert_equal [ "https://mas.to/@saul", "https://github.com/saul", "mailto:saul@example.com" ],
+      blogs(:saul).rel_me_urls
+  end
+
+  test "rel_me_urls should prefer explicit links over social navigation items" do
+    blog = blogs(:saul)
+    blog.rel_me_links = "https://micro.blog/saul"
+
+    assert_equal [ "https://micro.blog/saul" ], blog.rel_me_urls
+  end
+
+  test "rel_me_urls should parse explicit links one per line" do
+    @blog.rel_me_links = "  https://github.com/joel \n\nhttps://mastodon.social/@joel\nhttps://github.com/joel\n"
+
+    assert_equal [ "https://github.com/joel", "https://mastodon.social/@joel" ], @blog.rel_me_urls
+  end
+
+  test "rel_me_urls should filter out invalid schemes" do
+    @blog.rel_me_links = "javascript:alert(1)\nhttps://github.com/joel"
+
+    assert_equal [ "https://github.com/joel" ], @blog.rel_me_urls
+  end
+
+  test "should validate rel_me_links format" do
+    @blog.rel_me_links = "https://github.com/joel\nmailto:joel@pagecord.com"
+    assert @blog.valid?
+
+    @blog.rel_me_links = "not a url"
+    assert_not @blog.valid?
+
+    @blog.rel_me_links = "javascript:alert(1)"
+    assert_not @blog.valid?
+
+    @blog.rel_me_links = "mailto:foo"
+    assert_not @blog.valid?
+  end
+
+  test "should limit rel_me_links to 10" do
+    @blog.rel_me_links = (1..11).map { |i| "https://example.com/#{i}" }.join("\n")
+
+    assert_not @blog.valid?
+  end
 end

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -281,7 +281,7 @@ class BlogTest < ActiveSupport::TestCase
   end
 
   test "rel_me_urls should infer from social navigation items" do
-    assert_equal [ "https://mas.to/@saul", "https://github.com/saul", "mailto:saul@example.com", "https://example.com", "https://x.com/saul" ],
+    assert_equal [ "https://mas.to/@saul", "https://github.com/saul", "mailto:saul@example.com", "https://x.com/saul" ],
       blogs(:saul).rel_me_urls
   end
 
@@ -289,14 +289,14 @@ class BlogTest < ActiveSupport::TestCase
     blog = blogs(:saul)
     blog.rel_me_links = "https://micro.blog/saul"
 
-    assert_equal [ "https://micro.blog/saul", "https://mas.to/@saul", "https://github.com/saul", "mailto:saul@example.com", "https://example.com", "https://x.com/saul" ], blog.rel_me_urls
+    assert_equal [ "https://micro.blog/saul", "https://mas.to/@saul", "https://github.com/saul", "mailto:saul@example.com", "https://x.com/saul" ], blog.rel_me_urls
   end
 
   test "rel_me_urls should not duplicate links that are both explicit and inferred" do
     blog = blogs(:saul)
     blog.rel_me_links = "https://github.com/saul"
 
-    assert_equal [ "https://github.com/saul", "https://mas.to/@saul", "mailto:saul@example.com", "https://example.com", "https://x.com/saul" ], blog.rel_me_urls
+    assert_equal [ "https://github.com/saul", "https://mas.to/@saul", "mailto:saul@example.com", "https://x.com/saul" ], blog.rel_me_urls
   end
 
   test "rel_me_urls should parse explicit links one per line" do


### PR DESCRIPTION
## What

rel=me is how a blog says "that profile over there is also me" – the basis of Mastodon's green tick, Threads link verification, and IndieAuth sign-in. Until now Pagecord only emitted a single `<link rel="me">` for the first Mastodon social navigation item.

This adds an **Identity Links (rel=me)** setting (Blog Settings → Advanced): a textarea of profile URLs, one per line, each emitted as `<link rel="me">` in the blog `<head>`.

## How

- `Blog::RelMe` concern: `rel_me_urls` combines the explicit list with links inferred from social navigation items (deduped, explicit first). Existing Mastodon behaviour is preserved for anyone who never touches the setting.
- Inference covers every social platform except RSS (the blog's own feed) and generic "Web" links, which may point at a site that isn't the author's. Personal sites can be declared explicitly in the box.
- Validation: `http`/`https`/`mailto` URIs only (rescues `URI::Error`), max 10 links. Render path re-filters schemes as defence in depth.
- `_fediverse_identity` partial renamed to `_identity_links` since it now covers any service.

## Test plan

- Model: parsing, scheme validation, 10-link cap, inference (RSS/Web excluded), explicit + inferred combined and deduped, `javascript:` filtering, malformed `mailto:` edge cases.
- Controllers: blog `<head>` output for combined/fallback/none cases; settings round-trip and 422 on invalid input.
- Full suite green; brakeman and rubocop clean.
