### PR TITLE
Add rel=me links for all social navigation items

### DIFF
--- a/app/models/social_navigation_item.rb
+++ b/app/models/social_navigation_item.rb
@@ -8,7 +8,9 @@ class SocialNavigationItem < NavigationItem
 
   before_validation :set_label_from_platform, if: -> { platform.present? && label.blank? }
 
-  scope :mastodon, -> { where(platform: "Mastodon") }
+  # Platforms whose links are identity claims: profiles of the blog's author,
+  # not the blog's own feed (RSS) or an arbitrary site (Web)
+  scope :rel_me, -> { where.not(platform: %w[RSS Web]) }
 
   def link_url
     email? ? "mailto:#{url}" : url

--- a/app/views/layouts/_fediverse_identity.html.erb
+++ b/app/views/layouts/_fediverse_identity.html.erb
@@ -1,4 +1,0 @@
-<% mastodon_link = @blog.social_navigation_items.mastodon.first %>
-<% if mastodon_link.present? %>
-  <link href="<%= mastodon_link.url %>" rel="me">
-<% end %>

--- a/app/views/layouts/_identity_links.html.erb
+++ b/app/views/layouts/_identity_links.html.erb
@@ -1,0 +1,3 @@
+<% @blog.social_navigation_items.rel_me.ordered.each do |link| %>
+  <link href="<%= link.link_url %>" rel="me">
+<% end %>

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -33,7 +33,7 @@
 
     <%= render "layouts/structured_data" %>
 
-    <%= render "layouts/fediverse_identity" %>
+    <%= render "layouts/identity_links" %>
     <%= yield :fediverse %>
 
     <link rel="canonical" href="<%= canonical_url %>" />

--- a/docs/help-guide/index.md
+++ b/docs/help-guide/index.md
@@ -70,6 +70,12 @@ Let readers subscribe to your blog using an RSS reader.
 
 - [RSS feeds](rss-feeds.md)
 
+## IndieWeb
+
+Pagecord blogs are marked up with microformats so that IndieWeb tools can understand your content.
+
+- [Microformats](microformats.md)
+
 ## API & Integrations
 
 Use the Pagecord API to manage your blog programmatically, publish from the command line, or publish directly from tools like Obsidian.

--- a/docs/help-guide/microformats.md
+++ b/docs/help-guide/microformats.md
@@ -1,0 +1,25 @@
+---
+title: "Microformats"
+published: false
+---
+Every Pagecord blog is marked up with [microformats](https://microformats.org) – small HTML conventions that let machines understand your content, not just humans. You don't need to do anything; it's built into every blog, free or premium.
+
+## What Pagecord marks up
+
+- **Posts** use `h-entry`, identifying the title (`p-name`), permalink (`u-url`), publication date (`dt-published`) and content (`e-content`).
+- **Your post stream** uses `h-feed`, so tools can treat your home page as a feed of entries.
+- **Your blog itself** uses `h-card` – the online equivalent of a business card – with your blog's name, URL and avatar.
+- **Identity links** use `rel="me"` to declare that profiles elsewhere on the web belong to you. See [SEO & Discovery](seo-and-discovery.md).
+
+## What's it good for?
+
+Microformats are a cornerstone of the IndieWeb. Tools that understand them can do useful things with your blog without any screen-scraping:
+
+- IndieWeb feed readers can present your posts properly – title, author, date and content – because your stream is a parseable `h-feed`.
+- Mastodon, Threads and other services use `rel="me"` to verify that your blog and your profiles belong to the same person.
+- Services like [IndieLogin](https://indielogin.com) can sign you in with your own domain.
+- Publishing tools that speak [Micropub](micropub.md) build on the same ideas.
+
+## See what a machine sees
+
+Paste your blog's URL into the [microformats parser at pin13.net](https://pin13.net/mf2/) to see exactly what IndieWeb tools can read from it.

--- a/docs/help-guide/seo-and-discovery.md
+++ b/docs/help-guide/seo-and-discovery.md
@@ -20,6 +20,14 @@ Just paste the verification code (or the full meta tag – Pagecord will extract
 
 If you're on Mastodon or another Fediverse platform, you can enter your Fediverse username (e.g. `@you@mastodon.social`) so that your posts are attributed to you when shared on those platforms.
 
+## Identity Links (rel=me)
+
+Pagecord adds a `rel="me"` link to your blog's HTML for each social link in your navigation, except your RSS feed and generic "Web" links (which might point at a site that isn't yours). These tell other services that those profiles belong to the same person as your blog – it's what gets you the green verified tick on a Mastodon profile.
+
+Verification is reciprocal: your profile on the other service must also link back to your blog. On Mastodon, add your blog's URL to your profile metadata and re-save it.
+
+rel=me is one of several [microformats](microformats.md) built into every Pagecord blog.
+
 ## Discoverability
 
 By default, your blog can be found through search engines and may be featured in the Pagecord Spotlight and Shuffle. If you'd prefer to keep things low-key, untick the "Make my blog discoverable" box – Pagecord will serve a `robots.txt` that discourages search engines, and exclude your blog from Spotlight and Shuffle.

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -824,19 +824,29 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select 'meta[name="fediverse:creator"][content="@joel@pagecord.com"]'
   end
 
-  test "should include rel='me' link if Mastodon social navigation item is present" do
-    mastodon_link = SocialNavigationItem.create!(
-      blog: @blog,
-      platform: "Mastodon",
-      url: "https://mas.to/@joel_on_pagecord"
-    )
+  test "should include rel='me' links for social navigation items" do
+    blog = blogs(:saul)
+    host_subdomain! blog.subdomain
 
     get blog_posts_path
 
-    assert_select "link[rel=\"me\"][href=\"#{mastodon_link.url}\"]"
+    assert_select "link[rel=\"me\"]", count: 4
+    assert_select "link[rel=\"me\"][href=\"https://mas.to/@saul\"]"
+    assert_select "link[rel=\"me\"][href=\"https://github.com/saul\"]"
+    assert_select "link[rel=\"me\"][href=\"mailto:saul@example.com\"]"
+    assert_select "link[rel=\"me\"][href=\"https://x.com/saul\"]"
   end
 
-  test "should not include rel='me' link if Mastodon social navigation item is not present" do
+  test "should include rel='me' link for any social profile platform" do
+    # joel's only social navigation item is Bluesky
+    get blog_posts_path
+
+    assert_select "link[rel=\"me\"][href=\"https://bsky.app/profile/joel.example.com\"]"
+  end
+
+  test "should not include rel='me' link if no social navigation items are present" do
+    @blog.social_navigation_items.destroy_all
+
     get blog_posts_path
 
     assert_select "link[rel=\"me\"]", count: 0

--- a/test/fixtures/navigation_items.yml
+++ b/test/fixtures/navigation_items.yml
@@ -26,3 +26,51 @@ joel_hidden:
   post: contact
   label: "Contact"
   position: 4
+
+saul_social_mastodon:
+  type: SocialNavigationItem
+  blog: saul
+  label: "Mastodon"
+  platform: "Mastodon"
+  url: "https://mas.to/@saul"
+  position: 1
+
+saul_social_github:
+  type: SocialNavigationItem
+  blog: saul
+  label: "GitHub"
+  platform: "GitHub"
+  url: "https://github.com/saul"
+  position: 2
+
+saul_social_email:
+  type: SocialNavigationItem
+  blog: saul
+  label: "Email"
+  platform: "Email"
+  url: "saul@example.com"
+  position: 3
+
+saul_social_rss:
+  type: SocialNavigationItem
+  blog: saul
+  label: "RSS"
+  platform: "RSS"
+  url: "https://saul.pagecord.com/feed.xml"
+  position: 4
+
+saul_social_web:
+  type: SocialNavigationItem
+  blog: saul
+  label: "Web"
+  platform: "Web"
+  url: "https://example.com"
+  position: 5
+
+saul_social_x:
+  type: SocialNavigationItem
+  blog: saul
+  label: "X"
+  platform: "X"
+  url: "https://x.com/saul"
+  position: 6


### PR DESCRIPTION
## Why

Pagecord already emits a single rel=me link for a Mastodon navigation link, but rel=me is an IndieWeb convention that applies to any profile you own, and services like Pixelfed, GitHub and Threads participate in the same verification mechanism.

## What changed

- Every social navigation link now emits `<link rel="me">` in the blog head, not just Mastodon. RSS and generic Web links are excluded: a feed isn't an identity, and a Web link may point at a site that isn't the author's.
- Email links are emitted as `mailto:`.
- The `_fediverse_identity` partial is renamed `_identity_links`, and the unused `mastodon` scope is replaced by a `rel_me` scope.
- New help guide page documenting Pagecord's microformats support (h-entry, h-feed, h-card, rel=me), linked from the help index and SEO & Discovery.

## Behaviour changes

Blogs with non-Mastodon social links (Bluesky, GitHub, Pixelfed, etc.) gain rel=me identity links automatically. Mastodon verification behaviour is unchanged.