### PR TITLE
Fix quadratic query count when saving rich text with attachments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,7 @@ CSP `frame-src` in `config/initializers/content_security_policy.rb` must be upda
 ## Key Gotchas
 
 - **ActionText before_save**: Read from `content.to_s` directly — ActionText changes aren't persisted until callback completes
+- **Rich text save N²**: `ActiveStorage::Attachment`'s auto-generated presence validator on `:record` calls `RichText#blank?`, which re-renders the whole body and re-resolves every attachment's SGID – one full render per embedded attachment, so N photos cost N² blob queries (~1,161 for a 33-photo post). `config/initializers/active_storage.rb` swaps the validator for a cheap nil check; a query-budget test in `test/models/post_test.rb` guards it. Never add an `EachValidator` to an attribute that returns a `RichText` – `value.blank?` renders.
 - **API Markdown attachments**: Redcarpet wraps standalone raw `<action-text-attachment>` tags in `<p>` tags. `Api::BaseController#enrich_attachments` must unwrap attachment-only paragraphs after Markdown conversion or rendered blog HTML loses the outer `<action-text-attachment>` wrapper.
 - **Safari**: Doesn't support `*.localhost` — use Chrome/Firefox for subdomain testing
 - **Blog views**: No Tailwind, use semantic CSS. Check `lexxy-typography.css`, `components.css`, `themes/*.css`

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,20 @@
+# Saving a rich text record attaches one ActiveStorage::Attachment per embedded
+# blob, and each attachment runs the auto-generated presence validator on its
+# `record` association (from `belongs_to_required_by_default`). When the record
+# is an ActionText::RichText, EachValidator's `value.blank?` check delegates to
+# `to_plain_text`, which re-renders the whole body and re-resolves every
+# attachment's SGID – N blob queries per attachment, N² per save (~450 queries
+# for a 20-photo post). Only `blank?`/`empty?`/`present?` trigger the render,
+# so swap the validator for a nil check to keep saves linear.
+#
+# If a Rails upgrade changes how the validator registers, this silently no-ops;
+# the query-budget test in test/models/post_test.rb is the tripwire.
+ActiveSupport.on_load(:active_storage_attachment) do
+  validator = _validators[:record].find { |v| v.is_a?(ActiveRecord::Validations::PresenceValidator) }
+
+  if validator
+    _validators[:record].delete(validator)
+    skip_callback(:validate, validator)
+    validate { errors.add(:record, :blank) if record.nil? }
+  end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -191,6 +191,30 @@ class PostTest < ActiveSupport::TestCase
     assert_equal "", post.text_summary
   end
 
+  # Each embedded attachment used to trigger a full re-render of the rich text
+  # body via ActiveStorage::Attachment's presence validator on :record, making
+  # saves scale quadratically (~450 queries for 20 attachments).
+  test "creating a post with many attachments stays within a query budget" do
+    blobs = 20.times.map do |i|
+      ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new("image #{i}"),
+        filename: "photo#{i}.jpg",
+        content_type: "image/jpeg"
+      )
+    end
+    content = "<p>Photos</p>" + blobs.map { |blob| %(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>) }.join
+
+    query_count = 0
+    counter = ->(name, started, finished, unique_id, payload) {
+      query_count += 1 unless payload[:name].in?([ "SCHEMA", "TRANSACTION" ]) || payload[:cached]
+    }
+
+    post = blogs(:joel).posts.build(content: content, status: :published)
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { post.save! }
+
+    assert_operator query_count, :<, 100, "Expected bounded query count, got #{query_count}"
+  end
+
   test "first_media returns first image or video attachment" do
     blob = ActiveStorage::Blob.create_and_upload!(
       io: StringIO.new("video"),


### PR DESCRIPTION
## Problem

Saving a post with N embedded attachments runs N² blob queries (~1,161 for a 33-photo post). Each `ActiveStorage::Attachment` runs the auto-generated presence validator on its `record` association, and when the record is an `ActionText::RichText`, the validator's `value.blank?` check re-renders the whole body and re-resolves every attachment's SGID – one full render per attachment.

## Fix

`config/initializers/active_storage.rb` hooks `active_storage_attachment` load and swaps the presence validator for a cheap nil check. Only `blank?`/`empty?`/`present?` trigger the render, so a nil check keeps saves linear.

If a Rails upgrade changes how the validator registers, the hook silently no-ops, so a query-budget test in `test/models/post_test.rb` acts as the tripwire (20 attachments must save in under 100 queries).

## Verification

- New query-budget test passes
- Full `test/models/post_test.rb` suite passes (65 runs, 0 failures)
- Confirmed in production: a 12-image post now saves in 56.6ms of ActiveRecord time (59 queries), linear in the number of attachments
