### PR TITLE
Add Supporter subscription plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,46 @@ folder and create posts for the first user account in the seed data (`joel@pagec
 DIR=tmp/emails rake email:load
 ```
 
+## Testing billing locally
+
+Billing runs on Paddle Billing. When a subscription is created or changed, Paddle
+sends webhooks to `/billing/paddle_events`, and those webhook handlers are what
+actually set the plan, price, billing dates and send emails. The `paddle:simulate`
+rake tasks replay those webhooks against your running dev server with a valid
+signature, so you can exercise the whole subscription lifecycle without driving the
+Paddle sandbox by hand.
+
+This covers everything **after** Paddle. The outbound side (the `change_plan`
+controller calling Paddle to switch a plan) is a real API call, so verifying Paddle's
+own proration still needs the sandbox.
+
+The dev server must be running (`bin/dev`). Then:
+
+```bash
+# List the ready-made scenarios and the raw fixtures
+bin/rails "paddle:scenarios"
+
+# Run a named scenario against a user (blog subdomain, id, or email)
+bin/rails "paddle:flow[signup_supporter,joel]"
+bin/rails "paddle:flow[upgrade_to_supporter,joel]"
+bin/rails "paddle:flow[downgrade_from_supporter,joel]"
+bin/rails "paddle:flow[cancel,joel]"
+
+# Replay a single webhook fixture, optionally overriding the plan in custom_data
+bin/rails "paddle:simulate[subscription.created,joel,supporter]"
+bin/rails "paddle:simulate[transaction.completed.plan_change.supporter,joel]"
+```
+
+Each run prints the subscription state before and after, so watch that rather than the
+HTTP status (the endpoint always returns `200`). Fixtures live in
+`test/fixtures/billing/`; target a non-default host with `PADDLE_SIMULATE_URL`.
+
+Signature verification needs a shared `webhook_secret_key`. In development this falls
+back to a fixed value (`config/paddle.yml`) when `PADDLE_SANDBOX_WEBHOOK_SECRET_KEY`
+is unset, so both the server and the simulator sign with the same key. Restart the dev
+server after changing that config. Supporter welcome emails are sent with
+`deliver_later`, so to see one you need your local mail catcher and job worker running.
+
 ## Open Graph Images
 
 Pagecord can optionally generate dynamic Open Graph images for blog posts using a separate Cloudflare Worker service. This worker is currently **closed source** and not required to run Pagecord locally.

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,6 +23,9 @@ class Admin::UsersController < AdminController
       when "paid"
         users = users.merge(Subscription.active_paid)
                      .reorder(Subscription.arel_table[:created_at].desc)
+      when "supporter"
+        users = users.merge(Subscription.active_paid.where(plan: :supporter))
+                     .reorder(Subscription.arel_table[:created_at].desc)
       when "comped"
         users = users.where("subscriptions.plan = ?", "complimentary")
       when "churning"

--- a/app/controllers/app/settings/subscriptions_controller.rb
+++ b/app/controllers/app/settings/subscriptions_controller.rb
@@ -48,6 +48,7 @@ class App::Settings::SubscriptionsController < AppController
       @subscription.update!(plan: new_plan, paddle_price_id: SubscriptionsHelper.price_id(new_plan))
       redirect_to app_settings_path, notice: "Your plan has been updated to #{new_plan}!"
     else
+      Rails.logger.error "change_plan failed for user #{Current.user.id} (#{@subscription.paddle_subscription_id} -> #{new_plan}): HTTP #{response.code} #{response.body}"
       redirect_to app_settings_subscriptions_path, alert: "Unable to change plan. Please try again."
     end
   end

--- a/app/controllers/app/settings/subscriptions_controller.rb
+++ b/app/controllers/app/settings/subscriptions_controller.rb
@@ -49,7 +49,12 @@ class App::Settings::SubscriptionsController < AppController
       redirect_to app_settings_path, notice: "Your plan has been updated to #{new_plan}!"
     else
       Rails.logger.error "change_plan failed for user #{Current.user.id} (#{@subscription.paddle_subscription_id} -> #{new_plan}): HTTP #{response.code} #{response.body}"
-      redirect_to app_settings_subscriptions_path, alert: "Unable to change plan. Please try again."
+      alert = if response.body.to_s.include?("subscription_payment_declined")
+        "Your payment was declined. Please update your card details below, then try again."
+      else
+        "Unable to change plan. Please try again."
+      end
+      redirect_to app_settings_subscriptions_path, alert: alert
     end
   end
 

--- a/app/controllers/app/settings/subscriptions_controller.rb
+++ b/app/controllers/app/settings/subscriptions_controller.rb
@@ -17,7 +17,7 @@ class App::Settings::SubscriptionsController < AppController
       SendCancellationEmailJob.set(wait: 4.hours).perform_later(Current.user.id, subscriber: true)
     end
 
-    redirect_to app_settings_path
+    redirect_to app_settings_path, notice: "Your subscription has been cancelled. You'll keep access until the end of your current billing period."
   end
 
   def cancel_confirm
@@ -26,11 +26,26 @@ class App::Settings::SubscriptionsController < AppController
 
   def change_plan
     new_plan = params[:plan]
-    return redirect_to app_settings_subscriptions_path, alert: "Invalid plan" unless %w[monthly annual].include?(new_plan)
+    return redirect_to app_settings_subscriptions_path, alert: "Invalid plan" unless %w[monthly annual supporter].include?(new_plan)
 
-    response = PaddleApi.new.update_subscription_items(@subscription.paddle_subscription_id, SubscriptionsHelper.price_id(new_plan))
+    # Moving from a yearly plan to monthly changes the billing interval, which Paddle reschedules
+    # immediately (billing next month) rather than at the current term's end — it would forfeit
+    # already-paid time. Not offered; monthly is only chosen at signup.
+    if new_plan == "monthly" && !@subscription.monthly?
+      return redirect_to app_settings_subscriptions_path, alert: "Switching to monthly billing isn't available from a yearly plan."
+    end
+
+    # Downgrades take effect at the next billing cycle and never refund; upgrades bill the difference today.
+    downgrade = Subscription.price(new_plan).to_i < Subscription.price(@subscription.plan).to_i
+    proration_billing_mode = downgrade ? "do_not_bill" : "prorated_immediately"
+
+    response = PaddleApi.new.update_subscription_items(@subscription.paddle_subscription_id, SubscriptionsHelper.price_id(new_plan), proration_billing_mode: proration_billing_mode)
 
     if response.success?
+      # Optimistically reflect the switch now so the UI is correct even if the
+      # subscription.updated webhook is delayed or missed. The webhook still
+      # confirms unit_price and the next billing date.
+      @subscription.update!(plan: new_plan, paddle_price_id: SubscriptionsHelper.price_id(new_plan))
       redirect_to app_settings_path, notice: "Your plan has been updated to #{new_plan}!"
     else
       redirect_to app_settings_subscriptions_path, alert: "Unable to change plan. Please try again."

--- a/app/controllers/billing/paddle_events_controller.rb
+++ b/app/controllers/billing/paddle_events_controller.rb
@@ -83,6 +83,8 @@ module Billing
           next_billed_at: Time.parse(data.next_billed_at),
           plan: plan
         )
+
+        Subscription::SupporterWelcomeMailer.welcome(@subscription).deliver_later if @subscription.supporter?
       end
 
       def subscription_canceled
@@ -106,9 +108,12 @@ module Billing
         Rails.logger.info "Subscription next billed at updated to #{next_billed_at}, plan: #{new_plan}"
         @subscription.update!(
           paddle_price_id: new_price_id,
+          unit_price: base_unit_price,
           next_billed_at: next_billed_at,
           plan: new_plan
         )
+
+        notify_supporter_upgrade
 
         # this webhook is also called when a subscription is cancelled, with the
         # scheduled_change action set to cancel.
@@ -163,6 +168,8 @@ module Billing
 
           @subscription.update!(updates)
 
+          notify_supporter_upgrade
+
           Rails.logger.info "Subscription #{@subscription.id} next billed on #{next_billed_at}, unit_price: #{actual_unit_price}"
         else
           raise "Subscription not found for transaction_completed event for #{@user.id} (#{@user.blog.subdomain})"
@@ -171,6 +178,14 @@ module Billing
 
       def transaction_payment_failed
         Rails.logger.warn "Payment failed for user #{@user.id} (#{@user.blog.subdomain}) - Paddle Retain will retry automatically"
+      end
+
+      # Fires only on the save that actually flips the plan to supporter, so the
+      # two webhooks Paddle sends for a single plan change do not double-send.
+      def notify_supporter_upgrade
+        return unless @subscription.saved_change_to_plan? && @subscription.supporter?
+
+        Subscription::SupporterWelcomeMailer.welcome(@subscription).deliver_later
       end
 
       def base_unit_price

--- a/app/controllers/billing/paddle_events_controller.rb
+++ b/app/controllers/billing/paddle_events_controller.rb
@@ -148,11 +148,10 @@ module Billing
 
         if @subscription.present?
           next_billed_at = Time.parse(billing_period_ends_at)
-          actual_unit_price = transaction_unit_price
 
           updates = {
             next_billed_at: next_billed_at,
-            unit_price: actual_unit_price
+            unit_price: transaction_unit_price
           }
 
           # Plan change: find the new plan item (quantity > 0)
@@ -162,6 +161,10 @@ module Billing
               new_price_id = new_item.price.id
               updates[:paddle_price_id] = new_price_id
               updates[:plan] = Subscription.plan_from_price_id(new_price_id)
+              # On a plan switch, the transaction's line-item total is the prorated
+              # top-up charged today, not the ongoing recurring price. Store the new
+              # price's list price instead, so it matches what the next full renewal bills.
+              updates[:unit_price] = new_item.price.unit_price.amount.to_i
               Rails.logger.info "Plan changed to #{updates[:plan]} (price_id: #{new_price_id})"
             end
           end
@@ -170,7 +173,7 @@ module Billing
 
           notify_supporter_upgrade
 
-          Rails.logger.info "Subscription #{@subscription.id} next billed on #{next_billed_at}, unit_price: #{actual_unit_price}"
+          Rails.logger.info "Subscription #{@subscription.id} next billed on #{next_billed_at}, unit_price: #{updates[:unit_price]}"
         else
           raise "Subscription not found for transaction_completed event for #{@user.id} (#{@user.blog.subdomain})"
         end

--- a/app/helpers/pricing_helper.rb
+++ b/app/helpers/pricing_helper.rb
@@ -1,7 +1,7 @@
 module PricingHelper
   # India, Brazil, China, Indonesia, Mexico, Philippines, Vietnam
   DISCOUNTED_COUNTRIES = %w[IN BR CN ID MX PH VN].freeze
-  DISCOUNTED_PRICES = { monthly: "2.50", annual: "25" }.freeze
+  DISCOUNTED_PRICES = { monthly: "2.50", annual: "25", supporter: "50" }.freeze
 
   def localised_price(plan = :annual)
     if DISCOUNTED_COUNTRIES.include?(request.headers["CF-IPCountry"])

--- a/app/helpers/subscriptions_helper.rb
+++ b/app/helpers/subscriptions_helper.rb
@@ -9,6 +9,11 @@ module SubscriptionsHelper
       production: "pri_01kj7dvn8xc1yee6ppwzda5ykk",
       development: "pri_01jxfe5399nzanxj57bbqk28t4",
       test: "pri_01jxfe5399nzanxj57bbqk28t4"
+    },
+    supporter: {
+      production: "pri_01ky75g6xy1tyddwrax0r3wge4",
+      development: "pri_01ky7775szgjfcrvsaf4pxtnyf",
+      test: "pri_01ky7775szgjfcrvsaf4pxtnyf"
     }
   }.freeze
 
@@ -34,6 +39,10 @@ module SubscriptionsHelper
     paddle_checkout_data(:monthly)
   end
 
+  def paddle_supporter_data
+    paddle_checkout_data(:supporter)
+  end
+
   def paddle_data
     paddle_annual_data
   end
@@ -48,7 +57,7 @@ module SubscriptionsHelper
       {
         items: [ { priceId: price_id(plan), quantity: 1 } ].to_json,
         allow_logout: false,
-        success_url: thanks_app_settings_subscriptions_url,
+        success_url: thanks_app_settings_subscriptions_url(plan: plan),
         custom_data: { user_id: Current.user.id, blog_subdomain: Current.blog.subdomain, plan: plan }.to_json
       }
     end

--- a/app/mailers/subscription/supporter_welcome_mailer.rb
+++ b/app/mailers/subscription/supporter_welcome_mailer.rb
@@ -1,0 +1,14 @@
+class Subscription::SupporterWelcomeMailer < CloudflareMailer
+  helper :routing
+
+  def welcome(subscription)
+    @subscription = subscription
+    @user = subscription.user
+    @blog = @user.blog
+
+    mail(
+      to: @user.email,
+      subject: "Thank you for becoming a Pagecord Supporter 💛"
+    )
+  end
+end

--- a/app/models/paddle_api.rb
+++ b/app/models/paddle_api.rb
@@ -9,10 +9,10 @@ class PaddleApi
     post "subscriptions/#{id}/cancel", { effective_from: "next_billing_period" }.to_json
   end
 
-  def update_subscription_items(subscription_id, price_id)
+  def update_subscription_items(subscription_id, price_id, proration_billing_mode: "prorated_immediately")
     patch "subscriptions/#{subscription_id}", {
       items: [ { price_id: price_id, quantity: 1 } ],
-      proration_billing_mode: "prorated_immediately"
+      proration_billing_mode: proration_billing_mode
     }.to_json
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,21 +3,25 @@ class Subscription < ApplicationRecord
 
   has_many :renewal_reminders, class_name: "Subscription::RenewalReminder", dependent: :destroy
 
-  enum :plan, { monthly: "monthly", annual: "annual", complimentary: "complimentary" }
+  enum :plan, { monthly: "monthly", annual: "annual", supporter: "supporter", complimentary: "complimentary" }
 
   scope :comped, -> { where(plan: :complimentary) }
   scope :active_paid, -> {
-    where(plan: [ :annual, :monthly ])
+    where(plan: [ :annual, :monthly, :supporter ])
       .where(cancelled_at: nil)
       .where("next_billed_at > ?", Time.current)
   }
 
   def self.price(plan = :annual)
-    plan.to_sym == :monthly ? "4" : "39"
+    case plan.to_sym
+    when :monthly then "4"
+    when :supporter then "75"
+    else "39"
+    end
   end
 
   def self.plan_from_price_id(price_id)
-    SubscriptionsHelper::PRICE_IDS[:monthly].values.include?(price_id) ? "monthly" : "annual"
+    SubscriptionsHelper::PRICE_IDS.find { |_, ids| ids.values.include?(price_id) }&.first&.to_s || "annual"
   end
 
   def extend_to(date)

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -15,6 +15,10 @@
         <span class="text-2xl font-bold text-slate-900 dark:text-slate-50 group-hover:underline"><%= number_with_delimiter(Subscription.active_paid.count) %></span>
         <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">Paid</span>
       <% end %>
+      <%= link_to admin_users_path(status: "supporter"), class: "group" do %>
+        <span class="text-2xl font-bold text-slate-900 dark:text-slate-50 group-hover:underline"><%= number_with_delimiter(Subscription.active_paid.where(plan: :supporter).count) %></span>
+        <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">Supporter</span>
+      <% end %>
       <%= link_to admin_users_path(status: "comped"), class: "group" do %>
         <span class="text-2xl font-bold text-slate-900 dark:text-slate-50 group-hover:underline"><%= number_with_delimiter(Subscription.comped.count) %></span>
         <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">Comped</span>
@@ -46,9 +50,8 @@
       <span class="text-lg font-bold text-slate-900 dark:text-slate-50"><%= @pagy.count %></span>
       <span class="text-sm text-slate-500 dark:text-slate-400"><%= "result".pluralize(@pagy.count) %> for</span>
       <% if params[:status].present? %>
-        <% status_label = case params[:status] when "paid" then "Paid" when "comped" then "Comped" when "churning" then "Churning" end %>
         <%= link_to admin_users_path, class: "inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-500 transition-colors" do %>
-          <%= status_label %>
+          <%= params[:status].capitalize %>
           <%= inline_svg_tag "icons/close.svg", class: "w-3.5 h-3.5 text-slate-400" %>
         <% end %>
       <% end %>
@@ -69,7 +72,7 @@
           <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Verified</th>
           <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Status</th>
           <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Marketing</th>
-          <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"><%= params[:status] == "paid" ? "Subscribed" : "Created" %></th>
+          <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"><%= %w[paid supporter].include?(params[:status]) ? "Subscribed" : "Created" %></th>
         </tr>
       </thead>
       <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
@@ -118,7 +121,7 @@
           <td class="whitespace-nowrap py-4 px-6 text-sm text-slate-500 dark:text-slate-400 text-center align-top">
             <%= user.marketing_consent? ? "Yes" : "" %>
           </td>
-          <td class="whitespace-nowrap py-4 px-6 text-sm text-slate-500 dark:text-slate-400 text-end align-top"><%= (params[:status] == "paid" ? user.subscription.created_at : user.created_at).to_formatted_s :long %></td>
+          <td class="whitespace-nowrap py-4 px-6 text-sm text-slate-500 dark:text-slate-400 text-end align-top"><%= (%w[paid supporter].include?(params[:status]) ? user.subscription.created_at : user.created_at).to_formatted_s :long %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -103,6 +103,8 @@
                 <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">Comped</span>
               <% elsif user.subscription.cancelled? %>
                 <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">Churning</span>
+              <% elsif user.subscription.supporter? %>
+                <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">Supporter</span>
               <% else %>
                 <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">Premium</span>
               <% end %>

--- a/app/views/app/settings/subscriptions/_plan_cards.html.erb
+++ b/app/views/app/settings/subscriptions/_plan_cards.html.erb
@@ -6,7 +6,7 @@
       <p class="text-sm text-slate-500 mt-1">Billed monthly</p>
     <% end %>
     <div class="mt-4">
-      <%= link_to monthly_label, "#", class: "paddle_button btn-secondary w-full text-center", data: paddle_monthly_data %>
+      <%= link_to monthly_label, "#", class: "paddle_button btn-secondary w-full justify-center", data: paddle_monthly_data %>
     </div>
   </div>
   <div class="border-2 border-[#4fbd9c] rounded-lg p-4 relative">
@@ -17,7 +17,10 @@
       <p class="text-sm text-slate-500 mt-1">Save vs monthly</p>
     <% end %>
     <div class="mt-4">
-      <%= link_to annual_label, "#", class: "paddle_button btn-primary w-full text-center", data: paddle_annual_data %>
+      <%= link_to annual_label, "#", class: "paddle_button btn-primary w-full justify-center", data: paddle_annual_data %>
     </div>
   </div>
 </div>
+<p class="mt-4 text-center text-sm text-slate-500">
+  Or <%= link_to "become a Supporter for $#{Subscription.price(:supporter)}/year", "#", class: "paddle_button underline font-medium", data: paddle_supporter_data %> and back Pagecord's independent development: no extra features, just buckets of thanks and a spot for your blog on the upcoming supporters page 🙏💖
+</p>

--- a/app/views/app/settings/subscriptions/_plan_cards.html.erb
+++ b/app/views/app/settings/subscriptions/_plan_cards.html.erb
@@ -22,5 +22,5 @@
   </div>
 </div>
 <p class="mt-4 text-center text-sm text-slate-500">
-  Or <%= link_to "become a Supporter for $#{Subscription.price(:supporter)}/year", "#", class: "paddle_button underline font-medium", data: paddle_supporter_data %> and back Pagecord's independent development: no extra features, just buckets of thanks and a spot for your blog on the upcoming supporters page 🙏💖
+  Or <%= link_to "become a Supporter for $#{localised_price(:supporter)}/year", "#", class: "paddle_button underline font-medium", data: paddle_supporter_data %> and back Pagecord's independent development: no extra features, just buckets of thanks and a spot for your blog on the upcoming supporters page 🙏💖
 </p>

--- a/app/views/app/settings/subscriptions/index.html.erb
+++ b/app/views/app/settings/subscriptions/index.html.erb
@@ -17,20 +17,30 @@
   <% if @subscription.complimentary? %>
     <p>You have a free Pagecord Premium subscription! 🎉</p>
 
-    <div class="mt-4">
-      <%= link_to "← Back", app_settings_path, class: "btn-primary" %>
+    <div class="mt-6">
+      <%= link_to "Back", app_settings_path, class: "btn-secondary" %>
     </div>
   <% elsif @subscription.cancelled? %>
     <p>
       Your Pagecord Premium subscription has been scheduled for cancellation on
       <strong><%= @subscription.next_billed_at.to_date.to_formatted_s(:long) %></strong>.
-      <% if @subscription.paddle_customer_id.present? %>
-        <%= link_to "View past invoices", app_settings_paddle_invoices_path, target: "_blank", rel: "noopener", class: "underline font-medium" %>.
-      <% end %>
     </p>
     <p class="mt-2">Changed your mind?</p>
     <div class="mt-4">
       <%= button_to "Resume Subscription", resume_app_settings_subscriptions_path, class: "btn-primary" %>
+    </div>
+
+    <% if @subscription.paddle_customer_id.present? %>
+      <div class="mt-6 pt-2 border-t border-slate-200 dark:border-slate-700">
+        <%= link_to app_settings_paddle_invoices_path, target: "_blank", rel: "noopener", class: "flex items-center justify-between py-3 text-slate-700 dark:text-slate-200 hover:text-slate-950 dark:hover:text-white" do %>
+          <span>View past invoices</span>
+          <span aria-hidden="true" class="text-slate-400">&rsaquo;</span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="mt-6">
+      <%= link_to "Back", app_settings_path, class: "btn-secondary" %>
     </div>
   <% elsif @subscription.lapsed? %>
     <p>
@@ -43,47 +53,91 @@
 
     <%= render "plan_cards", monthly_label: "Restart Monthly", annual_label: "Restart Annually" %>
   <% else %>
-    <p>
-      💳 You are currently subscribed to Pagecord Premium. Thank you! 💖
-    </p>
+    <% if @subscription.supporter? %>
+      <p>You're a <strong>Pagecord Supporter</strong> 💛 Thank you for helping keep Pagecord independent and affordable for everyone.</p>
+    <% else %>
+      <p>💳 You're subscribed to <strong>Pagecord Premium</strong>. Thank you! 💖</p>
+    <% end %>
 
-    <% if @subscription.monthly? %>
+    <% unless @subscription.monthly? %>
+      <dl class="mt-3 sm:max-w-sm overflow-hidden rounded-lg text-sm">
+        <div class="grid grid-cols-[6rem_1fr] gap-x-4 px-4 py-2 bg-slate-50 dark:bg-slate-800/60">
+          <dt class="text-slate-500 dark:text-slate-400">Plan</dt>
+          <dd class="font-medium text-slate-900 dark:text-slate-100"><%= @subscription.plan.titleize %></dd>
+        </div>
+        <div class="grid grid-cols-[6rem_1fr] gap-x-4 px-4 py-2">
+          <dt class="text-slate-500 dark:text-slate-400">Price</dt>
+          <dd class="font-medium text-slate-900 dark:text-slate-100">$<%= @subscription.unit_price / 100 %>/year</dd>
+        </div>
+        <div class="grid grid-cols-[6rem_1fr] gap-x-4 px-4 py-2 bg-slate-50 dark:bg-slate-800/60">
+          <dt class="text-slate-500 dark:text-slate-400">Renews</dt>
+          <dd class="font-medium text-slate-900 dark:text-slate-100"><%= @subscription.next_billed_at.to_date.to_formatted_s(:long) %></dd>
+        </div>
+      </dl>
+    <% end %>
+
+    <% if @subscription.supporter? %>
+      <h3 class="font-semibold text-lg mt-6">Change your plan</h3>
+      <p class="mt-2">
+        Switching takes effect at your next renewal, with no charge or refund now.
+      </p>
+      <div class="mt-4 border border-slate-200 dark:border-slate-600 rounded-lg p-4 sm:max-w-xs">
+        <h3 class="font-semibold text-lg">Annual</h3>
+        <p class="text-2xl font-bold mt-2">$<%= localised_price %><span class="text-sm font-normal text-slate-500">/year</span></p>
+        <div class="mt-4">
+          <%= button_to "Switch to Annual", change_plan_app_settings_subscriptions_path(plan: "annual"), class: "btn-optional w-full justify-center", data: { turbo_confirm: "Switch to the standard annual plan? You won't be charged or refunded now: it takes effect at your next renewal." } %>
+        </div>
+      </div>
+    <% elsif @subscription.monthly? %>
+      <h3 class="font-semibold text-lg mt-6">Change your plan</h3>
       <div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
         <div class="border-2 border-[#4fbd9c] rounded-lg p-4 relative">
           <span class="absolute -top-3 left-4 bg-[#4fbd9c] text-white text-xs font-semibold px-2 py-1 rounded">Current Plan</span>
           <h3 class="font-semibold text-lg">Monthly</h3>
           <p class="text-2xl font-bold mt-2">$<%= @subscription.unit_price / 100 %><span class="text-sm font-normal text-slate-500">/month</span></p>
-          <p class="text-sm text-slate-500 mt-1">Next payment <%= @subscription.next_billed_at.to_date.to_formatted_s(:long) %></p>
+          <p class="text-sm text-slate-500 mt-1">Renews <%= @subscription.next_billed_at.to_date.to_formatted_s(:long) %></p>
         </div>
         <div class="border border-slate-200 dark:border-slate-600 rounded-lg p-4">
           <h3 class="font-semibold text-lg">Annual</h3>
           <p class="text-2xl font-bold mt-2">$<%= localised_price %><span class="text-sm font-normal text-slate-500">/year</span></p>
           <p class="text-sm text-slate-500 mt-1">Save vs monthly</p>
           <div class="mt-4">
-            <%= button_to "Switch to Annual", change_plan_app_settings_subscriptions_path(plan: "annual"), class: "btn-primary w-full text-center", data: { turbo_confirm: "Switch to annual billing? You'll be charged a prorated amount today and your next billing date will be adjusted." } %>
+            <%= button_to "Switch to Annual", change_plan_app_settings_subscriptions_path(plan: "annual"), class: "btn-primary w-full justify-center", data: { turbo_confirm: "Switch to annual billing? You'll be charged a prorated amount today and your next billing date will be adjusted." } %>
           </div>
         </div>
       </div>
-    <% else %>
-      <p class="mt-2">
-        Your next payment of
-        <strong>$<%= @subscription.unit_price / 100 %></strong> will be taken on
-        <strong><%= @subscription.next_billed_at.to_date.to_formatted_s(:long) %></strong>.
-      </p>
     <% end %>
 
-    <% if @subscription.paddle_customer_id.present? %>
-      <p class="mt-2">
-        <%= link_to "View past invoices", app_settings_paddle_invoices_path, target: "_blank", rel: "noopener", class: "underline font-medium" %>
-      </p>
+    <% unless @subscription.supporter? %>
+      <div class="mt-6 rounded-lg p-4 bg-[#4fbd9c]/5 border border-[#4fbd9c]/40">
+        <h3 class="font-semibold text-lg">Become a Supporter</h3>
+        <p class="text-sm text-slate-500 mt-1">
+          Love Pagecord? Back its independent development for <strong>$<%= Subscription.price(:supporter) %>/year</strong>. No extra features, just buckets of thanks and a spot for your blog on the upcoming supporters page 🙏💖
+        </p>
+        <div class="mt-4">
+          <%= button_to "Support Pagecord", change_plan_app_settings_subscriptions_path(plan: "supporter"), class: "btn-primary", data: { turbo_confirm: "Become a Pagecord Supporter for $#{Subscription.price(:supporter)}/year? You'll be charged a prorated amount today and your next billing date will be adjusted." } %>
+        </div>
+      </div>
     <% end %>
 
-    <div class="mt-6 flex justify-between" data-controller="paddle">
-      <%= link_to "Update Card Details", "#", data: { paddle_target: "link", id: @subscription.paddle_subscription_id }, class: "btn-primary" %>
-      <%= link_to "Cancel Subscription", cancel_confirm_app_settings_subscriptions_path, class: "btn-danger" %>
+    <div class="mt-6 pt-2 border-t border-slate-200 dark:border-slate-700" data-controller="paddle">
+      <%= link_to "#", data: { paddle_target: "link", id: @subscription.paddle_subscription_id }, class: "flex items-center justify-between py-3 text-slate-700 dark:text-slate-200 hover:text-slate-950 dark:hover:text-white" do %>
+        <span>Update card details</span>
+        <span aria-hidden="true" class="text-slate-400">&rsaquo;</span>
+      <% end %>
+      <% if @subscription.paddle_customer_id.present? %>
+        <%= link_to app_settings_paddle_invoices_path, target: "_blank", rel: "noopener", class: "flex items-center justify-between py-3 text-slate-700 dark:text-slate-200 hover:text-slate-950 dark:hover:text-white" do %>
+          <span>View past invoices</span>
+          <span aria-hidden="true" class="text-slate-400">&rsaquo;</span>
+        <% end %>
+      <% end %>
+      <%= link_to cancel_confirm_app_settings_subscriptions_path, class: "flex items-center justify-between py-3 text-slate-700 dark:text-slate-200 hover:text-slate-950 dark:hover:text-white" do %>
+        <span>Cancel subscription</span>
+        <span aria-hidden="true" class="text-slate-400">&rsaquo;</span>
+      <% end %>
     </div>
 
-    <div class="flex items-center gap-x-2 pt-4 border-t border-t-slate-200 dark:border-slate-600">
+    <div class="mt-6">
       <%= link_to "Back", app_settings_path, class: "btn-secondary" %>
     </div>
   <% end %>

--- a/app/views/app/settings/subscriptions/index.html.erb
+++ b/app/views/app/settings/subscriptions/index.html.erb
@@ -112,10 +112,10 @@
       <div class="mt-6 rounded-lg p-4 bg-[#4fbd9c]/5 border border-[#4fbd9c]/40">
         <h3 class="font-semibold text-lg">Become a Supporter</h3>
         <p class="text-sm text-slate-500 mt-1">
-          Love Pagecord? Back its independent development for <strong>$<%= Subscription.price(:supporter) %>/year</strong>. No extra features, just buckets of thanks and a spot for your blog on the upcoming supporters page 🙏💖
+          Love Pagecord? Back its independent development for <strong>$<%= localised_price(:supporter) %>/year</strong>. No extra features, just buckets of thanks and a spot for your blog on the upcoming supporters page 🙏💖
         </p>
         <div class="mt-4">
-          <%= button_to "Support Pagecord", change_plan_app_settings_subscriptions_path(plan: "supporter"), class: "btn-primary", data: { turbo_confirm: "Become a Pagecord Supporter for $#{Subscription.price(:supporter)}/year? You'll be charged a prorated amount today and your next billing date will be adjusted." } %>
+          <%= button_to "Support Pagecord", change_plan_app_settings_subscriptions_path(plan: "supporter"), class: "btn-primary", data: { turbo_confirm: "Become a Pagecord Supporter for $#{localised_price(:supporter)}/year? You'll be charged a prorated amount today and your next billing date will be adjusted." } %>
         </div>
       </div>
     <% end %>

--- a/app/views/app/settings/subscriptions/thanks.html.erb
+++ b/app/views/app/settings/subscriptions/thanks.html.erb
@@ -1,11 +1,19 @@
 <div class="space-y-8">
   <%= settings_section "Billing" do %>
     <div class="px-6 py-5 space-y-4">
-      <p class="text-lg font-bold">Thank you for subscribing! ✨</p>
+      <% if params[:plan] == "supporter" %>
+        <p class="text-lg font-bold">Thank you for becoming a Supporter! 💛</p>
 
-      <p>
-        Your Pagecord Premium subscription is now active 🎉
-      </p>
+        <p>
+          You're now a <strong>Pagecord Supporter</strong>. Thank you for backing Pagecord's independent development 🙏
+        </p>
+      <% else %>
+        <p class="text-lg font-bold">Thank you for subscribing! ✨</p>
+
+        <p>
+          Your Pagecord Premium subscription is now active 🎉
+        </p>
+      <% end %>
 
       <p>
         You can manage your subscription from your

--- a/app/views/subscription/supporter_welcome_mailer/welcome.html.erb
+++ b/app/views/subscription/supporter_welcome_mailer/welcome.html.erb
@@ -1,14 +1,10 @@
 <p>Hi there 👋</p>
 
-<p>Thank you for becoming a <strong>Pagecord Supporter</strong>. It genuinely means a lot.</p>
+<p>Thanks so much for becoming a <strong>Pagecord Supporter</strong>! That's very generous of you and it genuinely means a lot.</p>
 
-<p>Here's the honest part: you don't get any extra features, and that's the point. Pagecord stays deliberately affordable for everyone, and supporters like you are what keep it independent and sustainable. You're backing the thing because you believe in it, and I don't take that for granted.</p>
+<p>I plan to add a supporters page on the website where I'll list everyone who wants to be featured, with a link back to their blog. If you'd like to feature on this page, let me know.</p>
 
-<p>Nothing else changes for your blog, <strong><%= link_to @blog.display_name, blog_home_url(@blog) %></strong>. You'll simply be billed as a supporter from now on, and you can switch back to the standard plan at any time from your <%= link_to "Billing page", app_settings_subscriptions_url %>.</p>
-
-<p>A supporters page is coming soon where I'll list everyone who wants to be featured, with a link back to their blog. I'll also be running the occasional customer interview on the Pagecord blog, and supporters get first dibs. I'll be in touch about both.</p>
-
-<p>Thank you again for helping keep Pagecord going.</p>
+<p>Thanks again for supporting Pagecord!</p>
 
 <%= image_tag "signature.jpg", style: "margin-top: 8px; text-align: left; width:120px;" %>
 

--- a/app/views/subscription/supporter_welcome_mailer/welcome.html.erb
+++ b/app/views/subscription/supporter_welcome_mailer/welcome.html.erb
@@ -1,0 +1,15 @@
+<p>Hi there 👋</p>
+
+<p>Thank you for becoming a <strong>Pagecord Supporter</strong>. It genuinely means a lot.</p>
+
+<p>Here's the honest part: you don't get any extra features, and that's the point. Pagecord stays deliberately affordable for everyone, and supporters like you are what keep it independent and sustainable. You're backing the thing because you believe in it, and I don't take that for granted.</p>
+
+<p>Nothing else changes for your blog, <strong><%= link_to @blog.display_name, blog_home_url(@blog) %></strong>. You'll simply be billed as a supporter from now on, and you can switch back to the standard plan at any time from your <%= link_to "Billing page", app_settings_subscriptions_url %>.</p>
+
+<p>A supporters page is coming soon where I'll list everyone who wants to be featured, with a link back to their blog. I'll also be running the occasional customer interview on the Pagecord blog, and supporters get first dibs. I'll be in touch about both.</p>
+
+<p>Thank you again for helping keep Pagecord going.</p>
+
+<%= image_tag "signature.jpg", style: "margin-top: 8px; text-align: left; width:120px;" %>
+
+<p>Olly – creator of Pagecord</p>

--- a/app/views/subscription/supporter_welcome_mailer/welcome.text.erb
+++ b/app/views/subscription/supporter_welcome_mailer/welcome.text.erb
@@ -1,0 +1,18 @@
+Hi there 👋
+
+Thank you for becoming a Pagecord Supporter. It genuinely means a lot.
+
+Here's the honest part: you don't get any extra features, and that's the point. Pagecord stays deliberately affordable for everyone, and supporters like you are what keep it independent and sustainable. You're backing the thing because you believe in it, and I don't take that for granted.
+
+Nothing else changes for your blog, <%= @blog.display_name %> (<%= blog_home_url(@blog) %>). You'll simply be billed as a supporter from now on, and you can switch back to the standard plan at any time from your Billing page:
+
+<%= app_settings_subscriptions_url %>
+
+A supporters page is coming soon where I'll list everyone who wants to be featured, with a link back to their blog. I'll also be running the occasional customer interview on the Pagecord blog, and supporters get first dibs. I'll be in touch about both.
+
+Thank you again for helping keep Pagecord going.
+
+Olly
+
+--
+Creator, Pagecord

--- a/app/views/subscription/supporter_welcome_mailer/welcome.text.erb
+++ b/app/views/subscription/supporter_welcome_mailer/welcome.text.erb
@@ -1,16 +1,10 @@
 Hi there 👋
 
-Thank you for becoming a Pagecord Supporter. It genuinely means a lot.
+Thanks so much for becoming a Pagecord Supporter! That's very generous of you and it genuinely means a lot.
 
-Here's the honest part: you don't get any extra features, and that's the point. Pagecord stays deliberately affordable for everyone, and supporters like you are what keep it independent and sustainable. You're backing the thing because you believe in it, and I don't take that for granted.
+I plan to add a supporters page on the website where I'll list everyone who wants to be featured, with a link back to their blog. If you'd like to feature on this page, let me know.
 
-Nothing else changes for your blog, <%= @blog.display_name %> (<%= blog_home_url(@blog) %>). You'll simply be billed as a supporter from now on, and you can switch back to the standard plan at any time from your Billing page:
-
-<%= app_settings_subscriptions_url %>
-
-A supporters page is coming soon where I'll list everyone who wants to be featured, with a link back to their blog. I'll also be running the occasional customer interview on the Pagecord blog, and supporters get first dibs. I'll be in touch about both.
-
-Thank you again for helping keep Pagecord going.
+Thanks again for supporting Pagecord!
 
 Olly
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
 
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :async
 
 
   # Raises error for missing translations.

--- a/config/paddle.yml
+++ b/config/paddle.yml
@@ -5,6 +5,7 @@ default: &default
 
 development:
   <<: *default
+  webhook_secret_key: <%= ENV.fetch("PADDLE_SANDBOX_WEBHOOK_SECRET_KEY", "local_development_webhook_secret") %>
 
 test:
   <<: *default

--- a/lib/tasks/paddle.rake
+++ b/lib/tasks/paddle.rake
@@ -1,0 +1,155 @@
+# Replays Paddle webhook fixtures against a running local server so billing flows
+# can be tested end to end without driving the Paddle sandbox by hand.
+#
+# It exercises everything that happens *after* Paddle: the webhook handlers that
+# actually set the plan, price, billing dates and send emails. The outbound side
+# (change_plan -> Paddle PATCH) still needs the sandbox, since that call is real.
+#
+# Usage:
+#   bin/rails "paddle:simulate[subscription.created,olly,supporter]"
+#   bin/rails "paddle:simulate[transaction.completed.plan_change.supporter,olly]"
+#   bin/rails "paddle:scenarios"        # list ready-made billing scenarios
+#   bin/rails "paddle:flow[upgrade_to_supporter,olly]"
+#
+# "user" is a blog subdomain, a user id, or an email. Target a different host with
+# PADDLE_SIMULATE_URL (default http://localhost:3000). The dev server must be running.
+
+module PaddleSimulator
+  module_function
+
+  # Named flows expand to the sequence of webhooks Paddle sends for a scenario.
+  # Each step is [fixture, plan_override_or_nil]. Guard the constant so re-loading
+  # the rake file (which happens under the test runner) doesn't warn.
+  remove_const(:FLOWS) if defined?(FLOWS)
+  FLOWS = {
+    "signup_annual" => [ [ "subscription.created", "annual" ] ],
+    "signup_monthly" => [ [ "subscription.created.monthly", "monthly" ] ],
+    "signup_supporter" => [ [ "subscription.created", "supporter" ] ],
+    # Upgrade bills immediately (prorated_immediately), so Paddle carries the plan change on transaction.completed.
+    "upgrade_to_supporter" => [ [ "transaction.completed.plan_change.supporter", "supporter" ] ],
+    # Downgrade uses do_not_bill, so there's no transaction — the plan change arrives on subscription.updated.
+    "downgrade_from_supporter" => [ [ "subscription.updated.plan_change", "annual" ] ],
+    "renewal" => [ [ "transaction.completed", nil ] ],
+    "cancel" => [ [ "subscription.updated.cancellation", nil ] ],
+    "payment_failed" => [ [ "transaction.payment_failed", nil ] ]
+  }.freeze
+
+  def fixtures_dir
+    Rails.root.join("test", "fixtures", "billing")
+  end
+
+  def available_fixtures
+    Dir.glob(fixtures_dir.join("*.json")).map { |f| File.basename(f, ".json") }.sort
+  end
+
+  def find_user(identifier)
+    abort "Provide a user (blog subdomain, id, or email)" if identifier.blank?
+
+    user =
+      if identifier.match?(/\A\d+\z/)
+        User.find_by(id: identifier)
+      elsif identifier.include?("@")
+        User.find_by(email: identifier)
+      else
+        Blog.find_by(subdomain: identifier)&.user
+      end
+
+    user || abort("No user found for '#{identifier}'")
+  end
+
+  def build_payload(fixture, user, plan)
+    path = fixtures_dir.join("#{fixture}.json")
+    abort "No fixture '#{fixture}'. Available:\n  #{available_fixtures.join("\n  ")}" unless File.exist?(path)
+
+    data = JSON.parse(File.read(path))
+    d = data["data"]
+    d["custom_data"] ||= {}
+    d["custom_data"]["user_id"] = user.id
+    d["custom_data"]["blog_subdomain"] = user.blog.subdomain
+    d["custom_data"]["plan"] = plan if plan.present?
+
+    # Keep the resulting subscription active by pushing billing dates into the future.
+    d["next_billed_at"] = 1.month.from_now.iso8601 if d.key?("next_billed_at")
+    if d["billing_period"].is_a?(Hash) && d["billing_period"].key?("ends_at")
+      d["billing_period"]["ends_at"] = 1.month.from_now.iso8601
+    end
+
+    data.to_json
+  end
+
+  def simulate_url
+    "#{ENV.fetch("PADDLE_SIMULATE_URL", "http://localhost:3000")}/billing/paddle_events"
+  end
+
+  def post(payload)
+    require "httparty"
+
+    secret = Rails.application.config_for(:paddle)[:webhook_secret_key]
+    warn "⚠️  No Paddle webhook_secret_key configured for #{Rails.env} — the server will reject the signature." if secret.blank?
+
+    ts = Time.current.to_i.to_s
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), secret.to_s, "#{ts}:#{payload}")
+
+    HTTParty.post(simulate_url,
+      body: payload,
+      headers: {
+        "Content-Type" => "application/json",
+        "Paddle-Signature" => "ts=#{ts};h1=#{signature}"
+      })
+  rescue Errno::ECONNREFUSED
+    abort "Could not reach #{simulate_url}. Is the dev server running? (bin/dev or bin/rails server)"
+  end
+
+  def subscription_summary(user)
+    s = user.reload.subscription
+    return "no subscription" unless s
+
+    cancelled = s.cancelled_at ? s.cancelled_at.to_date.to_s : "no"
+    "plan=#{s.plan} price=$#{s.unit_price.to_i / 100} next_billed=#{s.next_billed_at&.to_date} cancelled=#{cancelled}"
+  end
+
+  def run(fixture, user, plan)
+    payload = build_payload(fixture, user, plan)
+    event = JSON.parse(payload)["event_type"]
+
+    before = subscription_summary(user)
+    response = post(payload)
+    after = subscription_summary(user)
+
+    puts "  #{event}#{plan ? " (plan=#{plan})" : ""}  → HTTP #{response.code}"
+    puts "    before: #{before}"
+    puts "    after:  #{after}"
+  end
+end
+
+namespace :paddle do
+  desc "Replay a single Paddle webhook fixture. Usage: paddle:simulate[fixture,user,plan]"
+  task :simulate, [ :fixture, :user, :plan ] => :environment do |_t, args|
+    abort "Refusing to run in production" if Rails.env.production?
+
+    user = PaddleSimulator.find_user(args[:user])
+    puts "user ##{user.id} @#{user.blog.subdomain} via #{PaddleSimulator.simulate_url}"
+    puts "(the endpoint always returns HTTP 200; watch the before/after state, not the status)"
+    PaddleSimulator.run(args[:fixture], user, args[:plan].presence)
+  end
+
+  desc "Replay a named billing scenario (see paddle:scenarios). Usage: paddle:flow[name,user]"
+  task :flow, [ :name, :user ] => :environment do |_t, args|
+    abort "Refusing to run in production" if Rails.env.production?
+
+    steps = PaddleSimulator::FLOWS[args[:name]]
+    abort "Unknown flow '#{args[:name]}'. Run paddle:scenarios to list them." unless steps
+
+    user = PaddleSimulator.find_user(args[:user])
+    puts "flow '#{args[:name]}' for user ##{user.id} @#{user.blog.subdomain} via #{PaddleSimulator.simulate_url}"
+    steps.each { |fixture, plan| PaddleSimulator.run(fixture, user, plan) }
+  end
+
+  desc "List available webhook fixtures and named scenarios"
+  task scenarios: :environment do
+    puts "Named flows (paddle:flow[name,user]):"
+    PaddleSimulator::FLOWS.each_key { |name| puts "  #{name}" }
+    puts "\nRaw fixtures (paddle:simulate[fixture,user,plan]):"
+    PaddleSimulator.available_fixtures.each { |f| puts "  #{f}" }
+  end
+end

--- a/test/controllers/app/settings/subscriptions_controller_test.rb
+++ b/test/controllers/app/settings/subscriptions_controller_test.rb
@@ -30,6 +30,7 @@ class App::Settings::SubscriptionsControllerTest < ActionDispatch::IntegrationTe
     end
 
     assert_redirected_to app_settings_path
+    assert_equal "Your subscription has been cancelled. You'll keep access until the end of your current billing period.", flash[:notice]
     assert @user.subscription.reload.cancelled?
   end
 
@@ -44,28 +45,24 @@ class App::Settings::SubscriptionsControllerTest < ActionDispatch::IntegrationTe
     assert_select "body", text: /\$20/
   end
 
-  test "should change plan from annual to monthly" do
-    mock_response = mock
-    mock_response.stubs(:success?).returns(true)
-    mock_api = mock
-    mock_api.expects(:update_subscription_items)
-      .with(@user.subscription.paddle_subscription_id, SubscriptionsHelper.price_id(:monthly))
-      .returns(mock_response)
-    PaddleApi.stubs(:new).returns(mock_api)
+  test "should not allow switching from a yearly plan to monthly" do
+    # @user.subscription is annual; monthly is a different billing interval Paddle can't defer.
+    PaddleApi.expects(:new).never
 
     post change_plan_app_settings_subscriptions_path(plan: "monthly")
 
-    assert_redirected_to app_settings_path
-    assert_equal "Your plan has been updated to monthly!", flash[:notice]
+    assert_redirected_to app_settings_subscriptions_path
+    assert_equal "Switching to monthly billing isn't available from a yearly plan.", flash[:alert]
+    assert @user.subscription.reload.annual?
   end
 
-  test "should change plan from monthly to annual" do
+  test "should change plan from monthly to annual with immediate proration" do
     @user.subscription.update!(plan: :monthly)
     mock_response = mock
     mock_response.stubs(:success?).returns(true)
     mock_api = mock
     mock_api.expects(:update_subscription_items)
-      .with(@user.subscription.paddle_subscription_id, SubscriptionsHelper.price_id(:annual))
+      .with(@user.subscription.paddle_subscription_id, SubscriptionsHelper.price_id(:annual), proration_billing_mode: "prorated_immediately")
       .returns(mock_response)
     PaddleApi.stubs(:new).returns(mock_api)
 
@@ -73,6 +70,55 @@ class App::Settings::SubscriptionsControllerTest < ActionDispatch::IntegrationTe
 
     assert_redirected_to app_settings_path
     assert_equal "Your plan has been updated to annual!", flash[:notice]
+  end
+
+  test "should upgrade from annual to supporter with immediate proration" do
+    mock_response = mock
+    mock_response.stubs(:success?).returns(true)
+    mock_api = mock
+    mock_api.expects(:update_subscription_items)
+      .with(@user.subscription.paddle_subscription_id, SubscriptionsHelper.price_id(:supporter), proration_billing_mode: "prorated_immediately")
+      .returns(mock_response)
+    PaddleApi.stubs(:new).returns(mock_api)
+
+    post change_plan_app_settings_subscriptions_path(plan: "supporter")
+
+    assert_redirected_to app_settings_path
+    assert_equal "Your plan has been updated to supporter!", flash[:notice]
+  end
+
+  test "should upgrade from monthly to supporter with immediate proration" do
+    @user.subscription.update!(plan: :monthly)
+    mock_response = mock
+    mock_response.stubs(:success?).returns(true)
+    mock_api = mock
+    mock_api.expects(:update_subscription_items)
+      .with(@user.subscription.paddle_subscription_id, SubscriptionsHelper.price_id(:supporter), proration_billing_mode: "prorated_immediately")
+      .returns(mock_response)
+    PaddleApi.stubs(:new).returns(mock_api)
+
+    post change_plan_app_settings_subscriptions_path(plan: "supporter")
+
+    assert_redirected_to app_settings_path
+    assert_equal "Your plan has been updated to supporter!", flash[:notice]
+  end
+
+  test "should downgrade from supporter to standard at next cycle without refund" do
+    @user.subscription.update!(plan: :supporter)
+    mock_response = mock
+    mock_response.stubs(:success?).returns(true)
+    mock_api = mock
+    mock_api.expects(:update_subscription_items)
+      .with(@user.subscription.paddle_subscription_id, SubscriptionsHelper.price_id(:annual), proration_billing_mode: "do_not_bill")
+      .returns(mock_response)
+    PaddleApi.stubs(:new).returns(mock_api)
+
+    post change_plan_app_settings_subscriptions_path(plan: "annual")
+
+    assert_redirected_to app_settings_path
+    assert_equal "Your plan has been updated to annual!", flash[:notice]
+    assert @user.subscription.reload.annual?, "expected plan to be optimistically updated to annual"
+    assert_equal SubscriptionsHelper.price_id(:annual), @user.subscription.paddle_price_id
   end
 
   test "should reject invalid plan" do
@@ -89,10 +135,11 @@ class App::Settings::SubscriptionsControllerTest < ActionDispatch::IntegrationTe
     mock_api.expects(:update_subscription_items).returns(mock_response)
     PaddleApi.stubs(:new).returns(mock_api)
 
-    post change_plan_app_settings_subscriptions_path(plan: "monthly")
+    post change_plan_app_settings_subscriptions_path(plan: "supporter")
 
     assert_redirected_to app_settings_subscriptions_path
     assert_equal "Unable to change plan. Please try again.", flash[:alert]
+    assert @user.subscription.reload.annual?, "plan should be unchanged when Paddle rejects the change"
   end
 
   test "should resume cancelled subscription" do

--- a/test/controllers/app/settings/subscriptions_controller_test.rb
+++ b/test/controllers/app/settings/subscriptions_controller_test.rb
@@ -131,6 +131,8 @@ class App::Settings::SubscriptionsControllerTest < ActionDispatch::IntegrationTe
   test "should handle failed plan change" do
     mock_response = mock
     mock_response.stubs(:success?).returns(false)
+    mock_response.stubs(:code).returns(400)
+    mock_response.stubs(:body).returns('{"error":{"detail":"declined"}}')
     mock_api = mock
     mock_api.expects(:update_subscription_items).returns(mock_response)
     PaddleApi.stubs(:new).returns(mock_api)
@@ -140,6 +142,22 @@ class App::Settings::SubscriptionsControllerTest < ActionDispatch::IntegrationTe
     assert_redirected_to app_settings_subscriptions_path
     assert_equal "Unable to change plan. Please try again.", flash[:alert]
     assert @user.subscription.reload.annual?, "plan should be unchanged when Paddle rejects the change"
+  end
+
+  test "should route a declined payment to updating card details" do
+    mock_response = mock
+    mock_response.stubs(:success?).returns(false)
+    mock_response.stubs(:code).returns(400)
+    mock_response.stubs(:body).returns('{"error":{"code":"subscription_payment_declined","detail":"declined"}}')
+    mock_api = mock
+    mock_api.expects(:update_subscription_items).returns(mock_response)
+    PaddleApi.stubs(:new).returns(mock_api)
+
+    post change_plan_app_settings_subscriptions_path(plan: "supporter")
+
+    assert_redirected_to app_settings_subscriptions_path
+    assert_equal "Your payment was declined. Please update your card details below, then try again.", flash[:alert]
+    assert @user.subscription.reload.annual?
   end
 
   test "should resume cancelled subscription" do

--- a/test/controllers/billing/paddle_events_controller_test.rb
+++ b/test/controllers/billing/paddle_events_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Billing::PaddleEventsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   test "should handle subscription.created event" do
     user = users(:vivian)
     payload = payload_for("subscription.created", user)
@@ -216,6 +218,87 @@ class Billing::PaddleEventsControllerTest < ActionDispatch::IntegrationTest
     subscription.reload
     assert subscription.annual?, "Expected subscription to be annual after plan change"
     assert_equal SubscriptionsHelper.price_id(:annual), subscription.paddle_price_id
+  end
+
+  test "should set supporter plan and send welcome email on subscription.created" do
+    user = users(:vivian)
+    payload = payload_for("subscription.created", user)
+    payload["data"]["custom_data"]["plan"] = "supporter"
+    json_payload = payload.to_json
+
+    assert_enqueued_emails 1 do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    assert_response :success
+    assert user.subscription.reload.supporter?
+  end
+
+  test "should send supporter welcome email when upgrading to supporter via transaction.completed" do
+    subscription = subscriptions(:one)
+    assert subscription.annual?
+
+    payload = payload_for("transaction.completed.plan_change.supporter", subscription.user)
+    json_payload = payload.to_json
+
+    assert_enqueued_emails 1 do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    assert_response :success
+    assert subscription.reload.supporter?
+  end
+
+  test "should not resend supporter welcome email when plan is already supporter" do
+    subscription = subscriptions(:one)
+    subscription.update!(plan: :supporter)
+
+    payload = payload_for("transaction.completed.plan_change.supporter", subscription.user)
+    json_payload = payload.to_json
+
+    assert_no_enqueued_emails do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    assert_response :success
+    assert subscription.reload.supporter?
+  end
+
+  test "should reconcile plan and unit_price on a subscription.updated downgrade" do
+    subscription = subscriptions(:one)
+    subscription.update!(plan: :supporter, unit_price: 7500)
+
+    payload = payload_for("subscription.updated.plan_change", subscription.user)
+    json_payload = payload.to_json
+
+    assert_no_enqueued_emails do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    assert_response :success
+    subscription.reload
+    assert subscription.annual?, "plan should reconcile to annual from the webhook price id"
+    assert_equal 3900, subscription.unit_price, "unit_price should reconcile from the webhook, not stay at the supporter price"
   end
 
   private

--- a/test/controllers/billing/paddle_events_controller_test.rb
+++ b/test/controllers/billing/paddle_events_controller_test.rb
@@ -220,6 +220,28 @@ class Billing::PaddleEventsControllerTest < ActionDispatch::IntegrationTest
     assert_equal SubscriptionsHelper.price_id(:annual), subscription.paddle_price_id
   end
 
+  test "should store the new plan's recurring price, not the prorated transaction total, on a small-proration plan change" do
+    subscription = subscriptions(:one)
+    assert subscription.annual?
+
+    payload = payload_for("transaction.completed.plan_change.small_proration", subscription.user)
+    json_payload = payload.to_json
+
+    post billing_paddle_events_url,
+      params: json_payload,
+      headers: {
+        "Content-Type" => "application/json",
+        "Paddle-Signature" => paddle_signature_for(json_payload)
+      }
+
+    assert_response :success
+    subscription.reload
+    assert subscription.supporter?
+    # The transaction's line-item total (758) is the prorated top-up charged today, not
+    # the ongoing recurring price (7500) — the stored unit_price must be the latter.
+    assert_equal 7500, subscription.unit_price
+  end
+
   test "should set supporter plan and send welcome email on subscription.created" do
     user = users(:vivian)
     payload = payload_for("subscription.created", user)

--- a/test/fixtures/billing/subscription.updated.plan_change.json
+++ b/test/fixtures/billing/subscription.updated.plan_change.json
@@ -1,0 +1,61 @@
+{
+  "data": {
+    "id": "sub_01hvrk1481njzb874tn7wyrksv",
+    "items": [
+      {
+        "price": {
+          "id": "pri_01jxfe5399nzanxj57bbqk28t4",
+          "name": "Pagecord Premium Annual",
+          "type": "standard",
+          "status": "active",
+          "quantity": { "maximum": 999999, "minimum": 1 },
+          "tax_mode": "account_setting",
+          "seller_id": "19023",
+          "created_at": "2024-04-17T13:17:52.685854Z",
+          "product_id": "pro_01hvnxr1b68jzv8cc969b09zvf",
+          "unit_price": { "amount": "3900", "currency_code": "USD" },
+          "updated_at": "2024-04-18T11:20:55.503101Z",
+          "custom_data": null,
+          "description": "Pagecord Premium Annual",
+          "import_meta": null,
+          "trial_period": null,
+          "billing_cycle": { "interval": "year", "frequency": 1 },
+          "unit_price_overrides": []
+        },
+        "status": "active",
+        "quantity": 1,
+        "recurring": true,
+        "created_at": "2024-04-18T12:31:47.619Z",
+        "updated_at": "2024-04-18T12:31:47.619Z",
+        "trial_dates": null,
+        "next_billed_at": null,
+        "previously_billed_at": null
+      }
+    ],
+    "status": "active",
+    "discount": null,
+    "paused_at": null,
+    "address_id": "add_01hvrk0nwyzkrkc5dwew3p72j7",
+    "created_at": "2024-04-18T12:31:15.713Z",
+    "started_at": "2024-04-18T12:31:15.024685Z",
+    "updated_at": "2024-04-18T12:32:45.853Z",
+    "business_id": null,
+    "canceled_at": null,
+    "custom_data": { "plan": "annual" },
+    "customer_id": "ctm_01hvp3m53528fz6scv2esx0s9g",
+    "import_meta": null,
+    "billing_cycle": { "interval": "year", "frequency": 1 },
+    "currency_code": "USD",
+    "next_billed_at": "2027-04-18T12:31:15.024685Z",
+    "billing_details": null,
+    "collection_mode": "automatic",
+    "first_billed_at": "2024-04-18T12:31:15.024685Z",
+    "scheduled_change": null,
+    "current_billing_period": { "ends_at": "2027-04-18T12:31:15.024685Z", "starts_at": "2026-04-18T12:31:15.024685Z" }
+  },
+  "event_id": "evt_01hvrk3ws77t3z4694hgr33fy0",
+  "event_type": "subscription.updated",
+  "occurred_at": "2026-07-23T12:32:46.375453Z",
+  "notification_id": "ntf_01hvrk3wvm5925h32jmx5dk285",
+  "paddle_event": {}
+}

--- a/test/fixtures/billing/transaction.completed.plan_change.small_proration.json
+++ b/test/fixtures/billing/transaction.completed.plan_change.small_proration.json
@@ -1,0 +1,113 @@
+{
+  "data": {
+    "id": "txn_01ky7wz80m3g3e68ftayckvbgs",
+    "items": [
+      {
+        "price": {
+          "id": "pri_01ky7775szgjfcrvsaf4pxtnyf",
+          "name": "Pagecord Supporter",
+          "type": "standard",
+          "status": "active",
+          "unit_price": {
+            "amount": "7500",
+            "currency_code": "USD"
+          },
+          "billing_cycle": {
+            "interval": "year",
+            "frequency": 1
+          }
+        },
+        "price_id": "pri_01ky7775szgjfcrvsaf4pxtnyf",
+        "quantity": 1,
+        "proration": {
+          "rate": "0.10101",
+          "billing_period": {
+            "ends_at": "2026-08-29T13:22:06.446110Z",
+            "starts_at": "2026-07-23T16:29:36.327Z"
+          }
+        }
+      },
+      {
+        "price": {
+          "id": "pri_01jxfe5399nzanxj57bbqk28t4",
+          "name": "Pagecord Premium Annual",
+          "type": "standard",
+          "status": "active",
+          "unit_price": {
+            "amount": "3900",
+            "currency_code": "USD"
+          },
+          "billing_cycle": {
+            "interval": "year",
+            "frequency": 1
+          }
+        },
+        "price_id": "pri_01jxfe5399nzanxj57bbqk28t4",
+        "quantity": -1,
+        "proration": {
+          "rate": "0.10101",
+          "billing_period": {
+            "ends_at": "2026-08-29T13:22:06.446110Z",
+            "starts_at": "2026-07-23T16:29:36.321Z"
+          }
+        }
+      }
+    ],
+    "origin": "subscription_update",
+    "status": "completed",
+    "details": {
+      "totals": {
+        "total": "465",
+        "currency_code": "USD"
+      },
+      "line_items": [
+        {
+          "id": "txnitm_01ky7wz80m3g3e68ftayckvbgs1",
+          "totals": {
+            "total": "758"
+          },
+          "price_id": "pri_01ky7775szgjfcrvsaf4pxtnyf",
+          "quantity": 1,
+          "unit_totals": {
+            "total": "758"
+          }
+        },
+        {
+          "id": "txnitm_01ky7wz80m3g3e68ftayckvbgs2",
+          "totals": {
+            "total": "-394"
+          },
+          "price_id": "pri_01jxfe5399nzanxj57bbqk28t4",
+          "quantity": -1,
+          "unit_totals": {
+            "total": "394"
+          }
+        }
+      ]
+    },
+    "payments": [
+      {
+        "amount": "465",
+        "status": "captured"
+      }
+    ],
+    "billed_at": "2026-07-23T16:29:39.316105Z",
+    "created_at": "2026-07-23T16:29:39.316105Z",
+    "updated_at": "2026-07-23T16:29:39.316105Z",
+    "custom_data": {
+      "user_id": 383,
+      "blog_subdomain": "d6y"
+    },
+    "customer_id": "ctm_01k3tzv4b9hhxbfae533tndymw",
+    "currency_code": "USD",
+    "billing_period": {
+      "ends_at": "2026-08-29T13:22:06.446110Z",
+      "starts_at": "2025-08-29T13:22:06.446110Z"
+    },
+    "subscription_id": "sub_01k3tzw5tx9h6axgvb1n2ba0aw"
+  },
+  "event_id": "evt_01ky7wzakm7dxr0ejkfhfyk9h8",
+  "event_type": "transaction.completed",
+  "occurred_at": "2026-07-23T16:29:39.316105Z",
+  "notification_id": "ntf_01ky7wzays76w1fvhrpv6cg599"
+}

--- a/test/fixtures/billing/transaction.completed.plan_change.supporter.json
+++ b/test/fixtures/billing/transaction.completed.plan_change.supporter.json
@@ -1,0 +1,97 @@
+{
+  "data": {
+    "id": "txn_01kgcep4ne4ybc5tqzngpn1y3f",
+    "items": [
+      {
+        "price": {
+          "id": "pri_01ky7775szgjfcrvsaf4pxtnyf",
+          "name": "Pagecord Supporter",
+          "type": "standard",
+          "status": "active",
+          "unit_price": {
+            "amount": "7500",
+            "currency_code": "USD"
+          },
+          "billing_cycle": {
+            "interval": "year",
+            "frequency": 1
+          }
+        },
+        "price_id": "pri_01ky7775szgjfcrvsaf4pxtnyf",
+        "quantity": 1,
+        "proration": null
+      },
+      {
+        "price": {
+          "id": "pri_01jxfe5399nzanxj57bbqk28t4",
+          "name": "Pagecord Premium Annual",
+          "type": "standard",
+          "status": "active",
+          "unit_price": {
+            "amount": "3900",
+            "currency_code": "USD"
+          },
+          "billing_cycle": {
+            "interval": "year",
+            "frequency": 1
+          }
+        },
+        "price_id": "pri_01jxfe5399nzanxj57bbqk28t4",
+        "quantity": -1,
+        "proration": {
+          "rate": "0.99936",
+          "billing_period": {
+            "ends_at": "2027-02-01T10:50:15.843123Z",
+            "starts_at": "2026-02-01T11:16:24.481Z"
+          }
+        }
+      }
+    ],
+    "origin": "subscription_update",
+    "status": "completed",
+    "details": {
+      "totals": {
+        "total": "3600",
+        "currency_code": "USD"
+      },
+      "line_items": [
+        {
+          "id": "txnitm_01kgcep4p6d00d5222mrpmxd72",
+          "totals": {
+            "total": "7500"
+          },
+          "price_id": "pri_01ky7775szgjfcrvsaf4pxtnyf",
+          "quantity": 1,
+          "unit_totals": {
+            "total": "7500"
+          }
+        }
+      ]
+    },
+    "payments": [
+      {
+        "amount": "3600",
+        "status": "captured"
+      }
+    ],
+    "billed_at": "2026-02-01T11:16:24.878177Z",
+    "created_at": "2026-02-01T11:16:24.948301Z",
+    "updated_at": "2026-02-01T11:16:29.901081178Z",
+    "custom_data": {
+      "plan": "supporter",
+      "user_id": 918740832,
+      "blog_subdomain": "olly"
+    },
+    "customer_id": "ctm_01kfftttjknezsfycs2krvv13n",
+    "currency_code": "USD",
+    "billing_period": {
+      "ends_at": "2027-02-01T11:16:24.469Z",
+      "starts_at": "2026-02-01T11:16:24.469Z"
+    },
+    "subscription_id": "sub_01kgcd69d47j1mpe1a1xvkfw5g"
+  },
+  "event_id": "evt_01kgcep9jn0m8s8bvtkeq954mw",
+  "event_type": "transaction.completed",
+  "occurred_at": "2026-02-01T11:16:29.909843Z",
+  "notification_id": "ntf_01kgcepa4ass0bjmxvjdmn0xr8"
+}

--- a/test/mailers/previews/subscription/supporter_welcome_mailer_preview.rb
+++ b/test/mailers/previews/subscription/supporter_welcome_mailer_preview.rb
@@ -1,0 +1,6 @@
+class Subscription::SupporterWelcomeMailerPreview < ActionMailer::Preview
+  def welcome
+    subscription = Subscription.active_paid.first
+    Subscription::SupporterWelcomeMailer.welcome(subscription)
+  end
+end

--- a/test/mailers/subscription/supporter_welcome_mailer_test.rb
+++ b/test/mailers/subscription/supporter_welcome_mailer_test.rb
@@ -13,12 +13,12 @@ class Subscription::SupporterWelcomeMailerTest < ActionMailer::TestCase
     assert_equal "Thank you for becoming a Pagecord Supporter 💛", email.subject
   end
 
-  test "welcome email renders both parts with the blog name" do
+  test "welcome email renders both html and text parts" do
     subscription = subscriptions(:one)
     email = Subscription::SupporterWelcomeMailer.welcome(subscription)
 
-    assert_match subscription.user.blog.display_name, email.html_part.body.to_s
-    assert_match subscription.user.blog.display_name, email.text_part.body.to_s
-    assert_match(/extra features/, email.html_part.body.to_s)
+    assert_match(/Pagecord Supporter/, email.html_part.body.to_s)
+    assert_match(/Pagecord Supporter/, email.text_part.body.to_s)
+    assert_match(/supporters page/, email.text_part.body.to_s)
   end
 end

--- a/test/mailers/subscription/supporter_welcome_mailer_test.rb
+++ b/test/mailers/subscription/supporter_welcome_mailer_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Subscription::SupporterWelcomeMailerTest < ActionMailer::TestCase
+  test "welcome email is sent to the subscriber" do
+    subscription = subscriptions(:one)
+    email = Subscription::SupporterWelcomeMailer.welcome(subscription)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal [ subscription.user.email ], email.to
+    assert_equal "Thank you for becoming a Pagecord Supporter 💛", email.subject
+  end
+
+  test "welcome email renders both parts with the blog name" do
+    subscription = subscriptions(:one)
+    email = Subscription::SupporterWelcomeMailer.welcome(subscription)
+
+    assert_match subscription.user.blog.display_name, email.html_part.body.to_s
+    assert_match subscription.user.blog.display_name, email.text_part.body.to_s
+    assert_match(/extra features/, email.html_part.body.to_s)
+  end
+end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -26,6 +26,20 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert_equal "4", Subscription.price(:monthly)
   end
 
+  test "should be priced at $75 for supporter" do
+    assert_equal "75", Subscription.price(:supporter)
+  end
+
+  test "plan_from_price_id maps each plan's price id back to its plan" do
+    assert_equal "monthly", Subscription.plan_from_price_id(SubscriptionsHelper.price_id(:monthly))
+    assert_equal "annual", Subscription.plan_from_price_id(SubscriptionsHelper.price_id(:annual))
+    assert_equal "supporter", Subscription.plan_from_price_id(SubscriptionsHelper.price_id(:supporter))
+  end
+
+  test "plan_from_price_id falls back to annual for unknown price id" do
+    assert_equal "annual", Subscription.plan_from_price_id("pri_unknown")
+  end
+
   test "active? should return true if not cancelled and not lapsed" do
     assert @subscription.active?
   end
@@ -71,8 +85,8 @@ class SubscriptionTest < ActiveSupport::TestCase
     assert_not @subscription.active?
   end
 
-  test "plan enum should have monthly, annual, and complimentary values" do
-    assert_equal({ "monthly" => "monthly", "annual" => "annual", "complimentary" => "complimentary" }, Subscription.plans)
+  test "plan enum should have monthly, annual, supporter, and complimentary values" do
+    assert_equal({ "monthly" => "monthly", "annual" => "annual", "supporter" => "supporter", "complimentary" => "complimentary" }, Subscription.plans)
   end
 
   test "monthly? should return true for monthly subscription" do


### PR DESCRIPTION
## Why

Several customers have said Pagecord is worth more than they pay and they'd happily give more. Supporter is an optional higher tier ($75/year) for backing the platform's independent development. It unlocks **no extra features** on purpose: keeping Pagecord affordable for everyone is the point.

## What changed

- New `supporter` plan ($75/year) alongside monthly/annual, with self-serve switching and a supporter welcome email (idempotent, sent once when a subscription first becomes supporter).
- Billing screen reworked: plan/price/renews summary, change-plan cards, a consolidated account-actions list, and a supporter callout for non-supporters.
- Direction-aware proration in `change_plan`: upgrades charge immediately (`prorated_immediately`); downgrades take effect at the next renewal and never refund (`do_not_bill`).
- Optimistic plan write on a successful switch so the UI is correct even if the webhook lags; the webhook remains the source of truth and now reconciles `unit_price` on `subscription.updated` too.
- Local webhook simulator (`paddle:simulate` / `paddle:flow`) to exercise billing flows without driving the Paddle sandbox.

## Behaviour changes

- **Yearly to monthly switching is removed and blocked server-side.** Monthly is a different billing interval that Paddle reschedules immediately, forfeiting already-paid time; it can't be deferred to term end.
- Cancelling now shows a confirmation flash.
- Dev queue adapter `:inline` → `:async` so scheduled jobs (the delayed cancellation email) work locally.
- **Paddle config:** the notification destination must subscribe to `subscription.updated` (downgrades rely on it, since `do_not_bill` produces no transaction). Applies to sandbox and production.

CI: brakeman, rubocop, importmap, unit + system tests all green.