### PR TITLE
Make post likes free on all plans

### DIFF
--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -33,7 +33,8 @@ class App::Settings::BlogsController < AppController
         :seo_title,
         :locale,
         :show_metrics,
-        :external_links_in_new_tab
+        :external_links_in_new_tab,
+        :show_upvotes
       ]
 
       if @blog.user.subscribed?
@@ -41,7 +42,7 @@ class App::Settings::BlogsController < AppController
       end
 
       if @blog.user.has_premium_access?
-        permitted_params += [ :reply_by_email, :show_upvotes ]
+        permitted_params += [ :reply_by_email ]
       end
 
       params.require(:blog).permit(permitted_params)

--- a/app/views/app/posts/_post.html.erb
+++ b/app/views/app/posts/_post.html.erb
@@ -18,7 +18,7 @@
       <% if post.hidden? %>
         <%= inline_svg_tag "icons/eye-slash.svg", class: "w-4 h-4", title: "Private post", aria: { label: "Private post" }, role: "img" %>
       <% end %>
-      <% if @user.has_premium_access? && @blog.show_metrics? && post.upvotes_count > 0 %>
+      <% if @blog.show_metrics? && post.upvotes_count > 0 %>
         <span class="flex gap-x-0.5">
           <span class="text-xs"><%= post.upvotes_count %></span>
           <%= inline_svg_tag "icons/heart.svg", class: "w-4 h-4" %>

--- a/app/views/app/settings/audience/index.html.erb
+++ b/app/views/app/settings/audience/index.html.erb
@@ -4,7 +4,7 @@
 <% if Current.user.on_free_plan? %>
   <div class="mb-6">
     <%= callout(:info) do %>
-      <%= link_to "Subscribe", app_settings_subscriptions_path, class: "underline font-medium" %> to enable audience features for your blog.
+      <%= link_to "Subscribe", app_settings_subscriptions_path, class: "underline font-medium" %> to enable email subscriptions and reply by email for your blog.
     <% end %>
   </div>
 <% elsif Current.user.on_trial? %>
@@ -86,9 +86,9 @@
       <% end %>
 
       <%= settings_row "Post Likes", stacked: true do %>
-        <div class="flex gap-3 <%= 'opacity-50' if features_disabled %>">
+        <div class="flex gap-3">
           <div class="flex h-6 shrink-0 items-center">
-            <%= styled_check_box form, :show_upvotes, checked: @blog.show_upvotes, disabled: features_disabled %>
+            <%= styled_check_box form, :show_upvotes, checked: @blog.show_upvotes %>
           </div>
           <%= form.label :show_upvotes, "Show a ❤️ button next to each post to receive appreciation", class: "text-slate-800 dark:text-slate-100" %>
         </div>

--- a/app/views/blogs/posts/_post_footer.html.erb
+++ b/app/views/blogs/posts/_post_footer.html.erb
@@ -7,9 +7,10 @@
     <%= local_time post.published_at, format: published_at_date_format, class: "dt-published" %>
   <% end %>
 
-  <% if @user.has_premium_access? %>
+  <% reply_enabled = @user.has_premium_access? && @blog.reply_by_email %>
+  <% if @blog.show_upvotes? || reply_enabled %>
     <div class="post-actions">
-      <% if @blog.reply_by_email %>
+      <% if reply_enabled %>
         <%= link_to new_post_reply_path(post),
                   title: "Reply to this post via email",
                   aria: { label: "Reply to this post via email" },

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -282,6 +282,10 @@
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
           Dynamic open graph images
         </li>
+        <li class="flex items-center text-slate-700 dark:text-slate-300">
+          <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
+          Post likes
+        </li>
       </ul>
     </div>
 
@@ -324,7 +328,7 @@
         </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
-          Reply by email & post likes
+          Reply by email
         </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
@@ -487,6 +491,14 @@
           <td class="text-center align-middle text-xl">✅</td>
           <td class="text-center align-middle text-xl">✅</td>
         </tr>
+        <tr>
+          <td class="py-3 align-middle">
+            <div class="text-base md:font-bold text-slate-800 dark:text-slate-200">Post Likes</div>
+            <div class="hidden sm:block">Visitors can 'like' your posts. You track the stats in the app ❤️</div>
+          </td>
+          <td class="text-center align-middle text-xl">✅</td>
+          <td class="text-center align-middle text-xl">✅</td>
+        </tr>
 
         <tr>
           <td class="py-3 align-middle">
@@ -534,15 +546,6 @@
           <td class="py-3 align-middle">
             <div class="text-base md:font-bold text-slate-800 dark:text-slate-200">Embeddable Contact Form</div>
             <div class="hidden sm:block">Add a contact form to any page. Messages go straight to your inbox 📨</div>
-          </td>
-          <td></td>
-          <td class="text-center align-middle text-xl">✅</td>
-        </tr>
-
-        <tr>
-          <td class="py-3 align-middle">
-            <div class="text-base md:font-bold text-slate-800 dark:text-slate-200">Post Likes</div>
-            <div class="hidden sm:block">Visitors can 'like' your posts. You track the stats in the app ❤️</div>
           </td>
           <td></td>
           <td class="text-center align-middle text-xl">✅</td>

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -884,14 +884,14 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href*='/upvotes']", false
   end
 
-  test "should not render upvotes for a non-subscriber" do
+  test "should render upvotes for a non-subscriber" do
     @blog = blogs(:vivian)
     host_subdomain! "vivian"
 
     get blog_posts_path
 
     assert_response :success
-    assert_select "a.upvote", count: 0
+    assert_select "button.upvote"
   end
 
   test "should not render upvotes if show_upvotes is false" do
@@ -900,7 +900,7 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     get blog_posts_path
 
     assert_response :success
-    assert_select "a.upvote", count: 0
+    assert_select "button.upvote", count: 0
   end
 
   test "post published_at is stored and rendered correctly in UTC" do


### PR DESCRIPTION
## Why

Post likes (upvotes) were gated behind premium access. But free-plan blogs are eligible for Spotlight, whose trending tab is ranked largely by upvotes. Gating likes meant the free posts Spotlight is meant to surface couldn't collect the signal that helps surface them.

## What changed

- Like button renders whenever a blog has `show_upvotes` enabled, regardless of plan (`_post_footer.html.erb`). Reply by email stays premium.
- `show_upvotes` moved to the always-permitted params; free users can now toggle it (`blogs_controller.rb`, `audience/index.html.erb`).
- Free users see their own like counts in the post list (`_post.html.erb`).
- Home page pricing/features updated: Post Likes shown as a Classic (free) feature.

## Behaviour change

`show_upvotes` defaults to `true`, so existing free blogs that never touched the setting will start showing the like button on deploy. This is intended.