### PR TITLE
Remove the comments feature flag

### DIFF
--- a/app/controllers/app/posts_controller.rb
+++ b/app/controllers/app/posts_controller.rb
@@ -87,7 +87,7 @@ class App::PostsController < AppController
       status = params[:button] == "save_draft" ? :draft : :published
       permitted = [ :title, :content, :slug, :published_at, :canonical_url, :tags_string, :hidden, :locale ]
       permitted += [ :open_graph_image, :open_graph_image_suppressed ] if Current.user.has_premium_access?
-      permitted << :comments_closed if current_features.enabled?(:comments) && @blog.accepts_comments?
+      permitted << :comments_closed if @blog.accepts_comments?
       params.require(:post).permit(*permitted).merge(status: status)
     end
 

--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -42,8 +42,7 @@ class App::Settings::BlogsController < AppController
       end
 
       if @blog.user.has_premium_access?
-        permitted_params << :reply_by_email
-        permitted_params << :comments_enabled if current_features.enabled?(:comments)
+        permitted_params += [ :reply_by_email, :comments_enabled ]
       end
 
       params.require(:blog).permit(permitted_params)

--- a/app/controllers/concerns/comment_moderation.rb
+++ b/app/controllers/concerns/comment_moderation.rb
@@ -4,7 +4,7 @@ module CommentModeration
   include Pagy::Method
 
   included do
-    before_action :require_comments_feature, :ensure_comments_enabled
+    before_action :ensure_comments_enabled
     helper_method :return_path
   end
 
@@ -42,10 +42,6 @@ module CommentModeration
 
     def origin_post
       @comment.post if @comment && params[:post] == @comment.post.token
-    end
-
-    def require_comments_feature
-      render_app_not_found unless current_features.enabled?(:comments)
     end
 
     def ensure_comments_enabled

--- a/app/controllers/posts/comments_controller.rb
+++ b/app/controllers/posts/comments_controller.rb
@@ -1,8 +1,6 @@
 class Posts::CommentsController < Blogs::BaseController
   include Pagy::Method
 
-  before_action :require_comments_feature
-
   include SpamPrevention
 
   layout false # Responses are Turbo Frames, so the surrounding page is dead weight
@@ -30,10 +28,6 @@ class Posts::CommentsController < Blogs::BaseController
   end
 
   private
-
-    def require_comments_feature
-      head :not_found unless current_features.enabled?(:comments)
-    end
 
     def ensure_comments_visible
       head :not_found unless @blog.accepts_comments? && @post.comments_visible?

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,8 +1,4 @@
 module CommentsHelper
-  def comments_enabled?(blog)
-    current_features.enabled?(:comments) && blog.accepts_comments?
-  end
-
   def comments_frame_id(post, page = 1)
     page > 1 ? "comments_#{post.token}_page_#{page}" : "comments_#{post.token}"
   end

--- a/app/jobs/comment_digest_job.rb
+++ b/app/jobs/comment_digest_job.rb
@@ -7,9 +7,6 @@ class CommentDigestJob < ApplicationJob
 
   def perform
     blogs_with_new_comments.find_each do |blog|
-      # comments_enabled outlives the beta flag, so revoking access would
-      # otherwise keep mailing a queue the blogger can no longer open.
-      next unless Rails.features.for(blog: blog).enabled?(:comments)
       next unless blog.accepts_comments?
       next unless claim_digest_window_for(blog)
 

--- a/app/views/app/posts/_form.html.erb
+++ b/app/views/app/posts/_form.html.erb
@@ -77,7 +77,7 @@
       </div>
     </div>
 
-    <% if comments_enabled?(@blog) %>
+    <% if @blog.accepts_comments? %>
       <div class="<%= 'hidden' unless @post.comments_closed %> mb-8" data-post-attributes-target="section" data-section="comments">
         <div class="mt-4 font-bold">
           Comments

--- a/app/views/app/posts/_post.html.erb
+++ b/app/views/app/posts/_post.html.erb
@@ -1,5 +1,5 @@
 <% show_likes = @blog.show_metrics? && post.upvotes_count.positive? %>
-<% show_comments = comments_enabled?(@blog) && post.comments_count.positive? %>
+<% show_comments = @blog.accepts_comments? && post.comments_count.positive? %>
 
 <div class="flex gap-x-2 mb-2">
   <div class="text-slate-500 dark:text-slate-400 <%= local_assigns[:show_year] ? 'w-26' : 'w-16' %> flex-shrink-0">

--- a/app/views/app/settings/audience/index.html.erb
+++ b/app/views/app/settings/audience/index.html.erb
@@ -85,15 +85,13 @@
         </div>
       <% end %>
 
-      <% if current_features.enabled?(:comments) %>
-        <%= settings_row "Comments", stacked: true do %>
-          <div class="flex gap-3 <%= 'opacity-50' if features_disabled %>">
-            <div class="flex h-6 shrink-0 items-center">
-              <%= styled_check_box form, :comments_enabled, checked: @blog.comments_enabled, disabled: features_disabled %>
-            </div>
-            <%= form.label :comments_enabled, "Let readers comment on your posts, with your approval before anything appears", class: "text-slate-800 dark:text-slate-100" %>
+      <%= settings_row "Comments", stacked: true do %>
+        <div class="flex gap-3 <%= 'opacity-50' if features_disabled %>">
+          <div class="flex h-6 shrink-0 items-center">
+            <%= styled_check_box form, :comments_enabled, checked: @blog.comments_enabled, disabled: features_disabled %>
           </div>
-        <% end %>
+          <%= form.label :comments_enabled, "Let readers comment on your posts, with your approval before anything appears", class: "text-slate-800 dark:text-slate-100" %>
+        </div>
       <% end %>
 
       <%= settings_row "Post Likes", stacked: true do %>

--- a/app/views/app/shared/_nav.html.erb
+++ b/app/views/app/shared/_nav.html.erb
@@ -1,4 +1,4 @@
-<% comments_enabled = comments_enabled?(@blog) %>
+<% comments_enabled = @blog.accepts_comments? %>
 <% overflow_on_mobile = comments_enabled && @blog.show_metrics? %>
 <% secondary_class = overflow_on_mobile ? "hidden sm:block" : "" %>
 

--- a/app/views/blogs/posts/_post.html.erb
+++ b/app/views/blogs/posts/_post.html.erb
@@ -1,4 +1,4 @@
-<% cache_if(post.post?, [post, @blog.updated_at, local_assigns[:excerpt], comments_enabled?(@blog)]) do %>
+<% cache_if(post.post?, [post, @blog.updated_at, local_assigns[:excerpt], @blog.accepts_comments?]) do %>
   <article class="<%= post.page? ? 'page' : 'post' %> h-entry">
     <%= render "post_title", post: post %>
 
@@ -7,7 +7,7 @@
     <%= render "post_footer", post: post if post.post? %>
   </article>
 
-  <% if post.post? && comments_enabled?(@blog) && post.comments_visible? %>
+  <% if post.post? && @blog.accepts_comments? && post.comments_visible? %>
     <%= turbo_frame_tag comments_frame_id(post) %>
   <% end %>
 <% end %>

--- a/app/views/blogs/posts/_post_footer.html.erb
+++ b/app/views/blogs/posts/_post_footer.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <% reply_enabled = @blog.accepts_replies? %>
-  <% comments_enabled = comments_enabled?(@blog) && post.comments_visible? %>
+  <% comments_enabled = @blog.accepts_comments? && post.comments_visible? %>
   <% if @blog.show_upvotes? || reply_enabled || comments_enabled %>
     <div class="post-actions">
       <% if comments_enabled %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -50,7 +50,7 @@
 
     <p>Write posts where you like, when you like. Use the editor, post by email, publish from Obsidian, iA Writer, or use the terminal to sync local files.</p>
 
-    <p>All the blog essentials in one tidy package: posts, pages, themes, email subscribers, <%= "comments, " if Rails.features.enabled?(:comments) %>analytics, and a domain of your own.</p>
+    <p>All the blog essentials in one tidy package: posts, pages, themes, email subscribers, comments, analytics, and a domain of your own.</p>
 
     <p>Your own words, written your own way, on your own corner of the web.</p>
 
@@ -125,7 +125,7 @@
         <div class="absolute -left-10 -bottom-10 h-28 w-28 rounded-full bg-[#4fbd9c]/12 blur-2xl"></div>
         <div class="relative">
           <h3 class="source-serif font-semibold text-2xl tracking-tight text-slate-900 dark:text-slate-100">Complete, not complicated</h3>
-          <p class="mt-4 leading-relaxed text-slate-700 dark:text-slate-300">Pagecord includes posts, pages, themes, analytics, email subscribers, <%= "comments, " if Rails.features.enabled?(:comments) %>custom domains, and full export. Everything you could reasonably need, for a most reasonable price.</p>
+          <p class="mt-4 leading-relaxed text-slate-700 dark:text-slate-300">Pagecord includes posts, pages, themes, analytics, email subscribers, comments, custom domains, and full export. Everything you could reasonably need, for a most reasonable price.</p>
         </div>
       </section>
     </div>
@@ -202,26 +202,24 @@
 </div>
 
 <!-- Comments Section -->
-<% if Rails.features.enabled?(:comments) %>
-  <div id="comments" class="mt-16 mb-4 md:mb-8 mx-auto max-w-4xl px-4 text-slate-800 dark:text-slate-200">
-    <h2 class="source-serif text-center font-semibold my-8 text-3xl md:text-4xl tracking-tight">Host a conversation with comments</h2>
+<div id="comments" class="mt-16 mb-4 md:mb-8 mx-auto max-w-4xl px-4 text-slate-800 dark:text-slate-200">
+  <h2 class="source-serif text-center font-semibold my-8 text-3xl md:text-4xl tracking-tight">Host a conversation with comments</h2>
 
-    <p class="md:text-xl leading-relaxed my-5">
-      With Pagecord Premium you can enable comments on your posts. Readers leave a name and a message: no account needed, no email address revealed. You can post a reply to any of them.
-    </p>
+  <p class="md:text-xl leading-relaxed my-5">
+    With Pagecord Premium you can enable comments on your posts. Readers leave a name and a message: no account needed, no email address revealed. You can post a reply to any of them.
+  </p>
 
-    <p class="md:text-xl leading-relaxed my-5">
-      Comments won't appear until you approve them, and spam is filtered out before it reaches you.
-    </p>
+  <p class="md:text-xl leading-relaxed my-5">
+    Comments won't appear until you approve them, and spam is filtered out before it reaches you.
+  </p>
 
-    <%= image_tag home_image_path("home/comments.webp", width: 1600, quality: 90),
-      srcset: home_image_srcset("home/comments.webp", widths: [ 800, 1600 ], quality: 88),
-      sizes: "(min-width: 56rem) 54rem, 100vw",
-      alt: "A screenshot of comments on a Pagecord blog post",
-      width: "1600",
-      height: "922" %>
-  </div>
-<% end %>
+  <%= image_tag home_image_path("home/comments.webp", width: 1600, quality: 90),
+    srcset: home_image_srcset("home/comments.webp", widths: [ 800, 1600 ], quality: 88),
+    sizes: "(min-width: 56rem) 54rem, 100vw",
+    alt: "A screenshot of comments on a Pagecord blog post",
+    width: "1600",
+    height: "922" %>
+</div>
 
 <!-- Analytics Section -->
 <div id="analytics" class="mt-16 mb-4 md:mb-8 mx-auto max-w-4xl px-4 text-slate-800 dark:text-slate-200">
@@ -368,12 +366,10 @@
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
           Email newsletter (250 subscribers)
         </li>
-        <% if Rails.features.enabled?(:comments) %>
-          <li class="flex items-center text-slate-700 dark:text-slate-300">
-            <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
-            Comments
-          </li>
-        <% end %>
+        <li class="flex items-center text-slate-700 dark:text-slate-300">
+          <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
+          Comments
+        </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
           Reply by email
@@ -407,7 +403,7 @@
   <h2 class="source-serif font-semibold text-center my-8 text-3xl md:text-4xl tracking-tight">Pagecord has everything you need</h2>
 
   <p class="md:text-xl leading-relaxed my-5">
-     Pagecord gives you everything a personal website actually needs: blog posts, pages, RSS, email subscriptions, <%= "comments, " if Rails.features.enabled?(:comments) %>simple analytics, a custom domain, full site export, and integrations with popular writing tools like Obsidian and iA Writer.
+     Pagecord gives you everything a personal website actually needs: blog posts, pages, RSS, email subscriptions, comments, simple analytics, a custom domain, full site export, and integrations with popular writing tools like Obsidian and iA Writer.
   </p>
 
   <div class="mt-8 bg-slate-50 dark:bg-slate-800 px-6 py-4 rounded-xl">
@@ -608,16 +604,14 @@
           </td>
         </tr>
 
-        <% if Rails.features.enabled?(:comments) %>
-          <tr>
-            <td class="py-3 align-middle">
-              <div class="text-base md:font-bold text-slate-800 dark:text-slate-200">Comments</div>
-              <div class="hidden sm:block">Readers comment without signing up for anything. Every comment waits for your approval, and spam is filtered out before it reaches you 💬</div>
-            </td>
-            <td></td>
-            <td class="text-center align-middle text-xl">✅</td>
-          </tr>
-        <% end %>
+        <tr>
+          <td class="py-3 align-middle">
+            <div class="text-base md:font-bold text-slate-800 dark:text-slate-200">Comments</div>
+            <div class="hidden sm:block">Readers comment without signing up for anything. Every comment waits for your approval, and spam is filtered out before it reaches you 💬</div>
+          </td>
+          <td></td>
+          <td class="text-center align-middle text-xl">✅</td>
+        </tr>
 
         <tr>
           <td class="py-3 align-middle">

--- a/app/views/public/llms/show.text.erb
+++ b/app/views/public/llms/show.text.erb
@@ -2,7 +2,7 @@
 
 > A blog you'll actually keep updated.
 
-Pagecord is an independent blogging platform for people who want to keep a personal blog alive. Publish wherever you like, from email, Obsidian, the editor, API, CLI, or your own scripts. Readers can follow by RSS or email. The free Classic plan includes unlimited posts and pages, themes, search, tags, RSS, full export and 50 hosted uploads (images and audio). Premium adds a much bigger upload allowance including video, custom domains, email subscribers, <%= "comments, " if Rails.features.enabled?(:comments) %>analytics, Obsidian, API, CLI, and more. Nothing you make is ever taken away if you stop paying.
+Pagecord is an independent blogging platform for people who want to keep a personal blog alive. Publish wherever you like, from email, Obsidian, the editor, API, CLI, or your own scripts. Readers can follow by RSS or email. The free Classic plan includes unlimited posts and pages, themes, search, tags, RSS, full export and 50 hosted uploads (images and audio). Premium adds a much bigger upload allowance including video, custom domains, email subscribers, comments, analytics, Obsidian, API, CLI, and more. Nothing you make is ever taken away if you stop paying.
 
 ## Features
 - Post by email (forward or compose to your blog)
@@ -14,9 +14,7 @@ Pagecord is an independent blogging platform for people who want to keep a perso
 - Email newsletter (weekly digest or per-post delivery to subscribers)
 - Privacy-respecting analytics
 - Custom domains
-<% if Rails.features.enabled?(:comments) %>
 - Comments (no reader account needed, held for approval, spam filtered)
-<% end %>
 - Reply by email (readers can respond to posts)
 - Full site HTML export
 - Dynamic open graph images

--- a/app/views/public/pagecord_vs_about_me.html.erb
+++ b/app/views/public/pagecord_vs_about_me.html.erb
@@ -130,13 +130,11 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
         </tr>
-        <% if Rails.features.enabled?(:comments) %>
-          <tr>
-            <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">Moderated, with spam filtering</span></td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
-          </tr>
-        <% end %>
+        <tr>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">Moderated, with spam filtering</span></td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
+        </tr>
         <!-- about.me unique features -->
         <tr>
           <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Privacy-respecting analytics</td>

--- a/app/views/public/pagecord_vs_hey_world.html.erb
+++ b/app/views/public/pagecord_vs_hey_world.html.erb
@@ -122,13 +122,11 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
         </tr>
-        <% if Rails.features.enabled?(:comments) %>
-          <tr>
-            <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">Moderated, with spam filtering</span></td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
-          </tr>
-        <% end %>
+        <tr>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">Moderated, with spam filtering</span></td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
+        </tr>
         <tr>
           <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Post likes</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>

--- a/app/views/public/pagecord_vs_medium.html.erb
+++ b/app/views/public/pagecord_vs_medium.html.erb
@@ -132,13 +132,11 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
         </tr>
-        <% if Rails.features.enabled?(:comments) %>
-          <tr>
-            <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">No reader account needed</span></td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">(Medium account required)</span></td>
-          </tr>
-        <% end %>
+        <tr>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">No reader account needed</span></td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">(Medium account required)</span></td>
+        </tr>
         <tr>
           <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Reply by email</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>

--- a/app/views/public/pagecord_vs_substack.html.erb
+++ b/app/views/public/pagecord_vs_substack.html.erb
@@ -71,13 +71,11 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
         </tr>
-        <% if Rails.features.enabled?(:comments) %>
-          <tr>
-            <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">No reader account needed</span></td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">(Substack account required)</span></td>
-          </tr>
-        <% end %>
+        <tr>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">No reader account needed</span></td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">(Substack account required)</span></td>
+        </tr>
         <tr>
           <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Reply by email</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>

--- a/app/views/public/pagecord_vs_wordpress.html.erb
+++ b/app/views/public/pagecord_vs_wordpress.html.erb
@@ -142,13 +142,11 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
         </tr>
-        <% if Rails.features.enabled?(:comments) %>
-          <tr>
-            <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">Moderation and spam filtering built in</span></td>
-            <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">(spam filtering needs a plugin)</span></td>
-          </tr>
-        <% end %>
+        <tr>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Comments</td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">Moderation and spam filtering built in</span></td>
+          <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">(spam filtering needs a plugin)</span></td>
+        </tr>
         <tr>
           <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Reply by email</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -5,10 +5,6 @@
       "note": "Admin-only template author URL \u2014 entered by admin, not user input"
     },
     {
-      "fingerprint": "0dfbc3bb7da613a4ed55ba90c2b83268e8cb2f4a9cc7885ec66d19738d49c2b2",
-      "note": "SQL values are hardcoded in AdminHelper#blogs_date_column, not user input"
-    },
-    {
       "fingerprint": "4d27bc375baf7b5892ac53a25bf63c138272cd3aaa5435e762839612f0b07f93",
       "note": "Paddle customer portal URL host is validated against ALLOWED_HOSTS before redirecting"
     },

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,5 +1,1 @@
 env "FEATURE"
-
-feature :comments do |user: nil, blog: nil|
-  (blog&.user || user)&.features&.include?("comments")
-end

--- a/docs/help-guide/comments.md
+++ b/docs/help-guide/comments.md
@@ -4,8 +4,6 @@ published: true
 published_at: 2026-07-31T12:00:00+00:00
 ---
 
-> **Beta:** Comments are in beta and enabled by invitation only. If you'd like to take part in the beta, please email [hello@pagecord.com](mailto:hello@pagecord.com).
-
 Let readers comment on your posts. Nothing appears on your blog until you approve it, so you decide what shows up. Readers don't need a Pagecord account to comment, and they aren't asked for an email address – just a name and a message, with an optional link to their own site.
 
 This is a premium feature.

--- a/docs/help-guide/comments.md
+++ b/docs/help-guide/comments.md
@@ -13,7 +13,7 @@ This is a premium feature.
 1. Go to **Settings** → **Audience**
 2. Toggle on **Comments**
 
-A comment form then appears at the bottom of each post, along with a comment count.
+A comment icon then appears at the bottom of each post, with a count once there are approved comments. Readers click it to see the comments and leave their own.
 
 ## Approving comments
 
@@ -32,12 +32,15 @@ You can post one reply to each comment, and it appears indented beneath the orig
 
 To disable new comments on a specific post:
 
-1. Open the post's **⋯** menu
+1. Edit the post and open the **⋯** menu
 2. Choose **Comments**
+3. Tick **Close comments on this post** and save
 
-Existing approved comments stay visible, and the form is replaced with "Comments are closed." Use this on an old post that's attracting nothing useful, or on something you'd rather not discuss.
+Untick it to reopen them.
 
-Turning comments off for the whole blog in **Settings** → **Audience** hides the form on every post.
+If the post already has approved comments, they stay visible and the form is replaced with "Comments are closed." If you close a post before anyone has commented, the comments section doesn't appear on it at all. Use this on an old post that's attracting nothing useful, or on something you'd rather not discuss.
+
+Turning comments off for the whole blog in **Settings** → **Audience** hides the whole comments section on every post, including comments you've already published.
 
 ## Spam
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -236,14 +236,13 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
 
   test "show renders feature fields as an array" do
     user = users(:vivian)
+    user.update!(features: [ "custom_feature" ])
 
     get admin_user_url(user)
 
     assert_response :success
     assert_select "input[type='hidden'][name='user[features][]'][value='']"
-    assert_select "input[type='checkbox'][name='user[features][]'][value='comments']", count: 1 do |fields|
-      assert_nil fields.first["checked"]
-    end
+    assert_select "input[type='checkbox'][name='user[features][]'][value='custom_feature']", count: 1
   end
 
   test "should add a feature to user" do

--- a/test/controllers/app/comments/approvals_controller_test.rb
+++ b/test/controllers/app/comments/approvals_controller_test.rb
@@ -84,7 +84,6 @@ class App::Comments::ApprovalsControllerTest < ActionDispatch::IntegrationTest
 
   test "can't touch another blog's comments" do
     blogs(:annie).update!(comments_enabled: true)
-    users(:annie).update!(features: [ "comments" ])
     login_as users(:annie)
 
     post app_comment_approval_path(post_comments(:pending))

--- a/test/controllers/app/comments_controller_test.rb
+++ b/test/controllers/app/comments_controller_test.rb
@@ -119,12 +119,4 @@ class App::CommentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to app_settings_audience_index_path
   end
-
-  test "is not found when the comments feature is disabled" do
-    @user.update!(features: [])
-
-    get app_comments_path
-
-    assert_response :not_found
-  end
 end

--- a/test/controllers/app/posts_controller_test.rb
+++ b/test/controllers/app/posts_controller_test.rb
@@ -261,7 +261,6 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
   # The moderation screen can only reach posts that already have a comment, so
   # closing a thread pre-emptively has to be possible from the editor.
   test "closes and reopens comments on a post with no comments" do
-    users(:joel).update!(features: [ "comments" ])
     login_as users(:joel)
     target = posts(:two)
     assert_equal 0, target.comments_count
@@ -275,7 +274,6 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "re-closing a thread keeps the original closing time" do
-    users(:joel).update!(features: [ "comments" ])
     login_as users(:joel)
     target = posts(:two)
     target.close_comments!
@@ -287,7 +285,6 @@ class App::PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "ignores comments_closed when the blog has comments off" do
-    users(:joel).update!(features: [ "comments" ])
     login_as users(:joel)
     blogs(:joel).update!(comments_enabled: false)
 

--- a/test/controllers/app/settings/audience_controller_test.rb
+++ b/test/controllers/app/settings/audience_controller_test.rb
@@ -34,16 +34,7 @@ class App::Settings::AudienceControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", app_settings_subscribers_path(format: :csv)
   end
 
-  test "hides comments settings when the feature is disabled" do
-    @user.update!(features: [])
-
-    get app_settings_audience_index_url
-
-    assert_response :success
-    assert_select "input[name='blog[comments_enabled]']", count: 0
-  end
-
-  test "shows comments settings when the feature is enabled" do
+  test "shows comments settings" do
     get app_settings_audience_index_url
 
     assert_response :success

--- a/test/controllers/posts/comments_controller_test.rb
+++ b/test/controllers/posts/comments_controller_test.rb
@@ -28,20 +28,6 @@ class Posts::CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame##{comments_frame_id(@post)}", count: 0
   end
 
-  test "the feature flag hides comments and blocks the comments endpoint" do
-    @post.blog.user.update!(features: [])
-
-    get blog_post_path(@post.slug)
-
-    assert_response :success
-    assert_select "a.comment-link", count: 0
-    assert_select "turbo-frame##{comments_frame_id(@post)}", count: 0
-
-    get post_comments_path(@post)
-
-    assert_response :not_found
-  end
-
   test "loads the comments frame with approved comments and a form" do
     get post_comments_path(@post)
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,6 @@ joel:
   admin: true
   verified: true
   onboarding_state: completed
-  features: [ comments ]
   created_at: <%= 30.days.ago %>
 
 elliot:

--- a/test/jobs/comment_digest_job_test.rb
+++ b/test/jobs/comment_digest_job_test.rb
@@ -57,15 +57,4 @@ class CommentDigestJobTest < ActiveSupport::TestCase
       CommentDigestJob.perform_now
     end
   end
-
-  # Losing the beta flag leaves comments_enabled set, and the moderation queue
-  # 404s, so a digest would point at a page they can't open. When the flag goes,
-  # this test and the guard it covers go with it.
-  test "ignores blogs whose beta access has been revoked" do
-    users(:joel).update!(features: [])
-
-    assert_no_enqueued_emails do
-      CommentDigestJob.perform_now
-    end
-  end
 end


### PR DESCRIPTION
Comments launch next week, so the beta gate goes.

Every place the flag was checked already had a `blog.accepts_comments?` check beside it, so that becomes the only gate. `CommentsHelper#comments_enabled?` was an exact alias for `blog.accepts_comments?` once the flag went, so it is deleted and its six callers call the model directly. The marketing pages, help guide beta notice, and the flag-specific tests go too.

The `users.features` mechanism stays for future flags. Beta users keep a stale `comments` entry, which the admin UI shows as legacy. Also prunes an obsolete brakeman ignore entry.

**Behaviour changes**
- Comments are available to every premium blog, controlled only by the Comments toggle in Audience settings.
- The comments section, pricing row and comparison rows now always render on the marketing pages.