### PR TITLE
Refresh the FAQ intro and fix broken help guide links

### DIFF
--- a/app/views/public/faq.html.erb
+++ b/app/views/public/faq.html.erb
@@ -18,7 +18,7 @@
       "name": "How does Pagecord work?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Create an account by choosing a subdomain for your blog and supplying your email address. Your blog is live straight away at yourname.pagecord.com, and premium subscribers can connect a domain of their own. Write posts in the editor, or publish from wherever you already write: every account gets a private delivery address, so anything you email to it becomes a post, and you can also publish from Obsidian, iA Writer, the command line, or the API."
+        "text": "Create an account by choosing a subdomain for your blog and supplying your email address. Verify your email, then your blog is live at yourname.pagecord.com. Premium subscribers can connect a domain name of their own. Write posts in the editor, or publish from wherever you already write: every account gets a private delivery address, so anything you email to it becomes a post, and you can also publish from Obsidian, iA Writer, the command line, or the API."
       }
     },
     {
@@ -111,8 +111,7 @@
 
   <h3 id="how-does-pagecord-work" class="source-serif font-semibold text-2xl">How does Pagecord work?</h3>
   <p>
-    <%= link_to "Create an account", new_signup_path, class: "home-link" %> by choosing a subdomain for your blog and supplying your email address. Your blog is live
-    straight away at <span class="font-mono">yourname.pagecord.com</span>, and premium subscribers can connect a domain of their own.
+    <%= link_to "Create an account", new_signup_path, class: "home-link" %> by choosing a subdomain for your blog and supplying your email address. Verify your email, then your blog is live at <span class="font-mono">yourname.pagecord.com</span>. Premium subscribers can connect a domain name of their own.
   </p>
   <p>
     Write posts in the editor, or publish from wherever you already write. Every account gets a private delivery address, so anything you email to it becomes a post.

--- a/app/views/public/faq.html.erb
+++ b/app/views/public/faq.html.erb
@@ -18,7 +18,7 @@
       "name": "How does Pagecord work?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Create an account by choosing a subdomain for your blog and supplying your email address. Once you verify your email, you'll receive a secret email address. Emails sent to this secret address from the email address you give us will appear as posts on your Pagecord page. If you prefer, you can log in to your account and create posts directly in the app."
+        "text": "Create an account by choosing a subdomain for your blog and supplying your email address. Your blog is live straight away at yourname.pagecord.com, and premium subscribers can connect a domain of their own. Write posts in the editor, or publish from wherever you already write: every account gets a private delivery address, so anything you email to it becomes a post, and you can also publish from Obsidian, iA Writer, the command line, or the API."
       }
     },
     {
@@ -111,12 +111,12 @@
 
   <h3 id="how-does-pagecord-work" class="source-serif font-semibold text-2xl">How does Pagecord work?</h3>
   <p>
-    <%= link_to "Create an account", new_signup_path, class: "home-link" %> by choosing a subdomain for your blog and supplying your email address. Once you verify
-    your email, you'll receive a secret email address. Emails sent to this secret address from the email address you give us will
-    appear as posts on your Pagecord page. If you prefer, you can log in to your account and create posts directly in the app.
+    <%= link_to "Create an account", new_signup_path, class: "home-link" %> by choosing a subdomain for your blog and supplying your email address. Your blog is live
+    straight away at <span class="font-mono">yourname.pagecord.com</span>, and premium subscribers can connect a domain of their own.
   </p>
   <p>
-    Your Pagecord page is a public profile that anyone can view. It looks like <a href="https://pagecord.com/blog" class="home-link">https://pagecord.com/blog</a>.
+    Write posts in the editor, or publish from wherever you already write. Every account gets a private delivery address, so anything you email to it becomes a post.
+    You can also publish from <a href="https://help.pagecord.com/obsidian" class="home-link">Obsidian</a>, iA Writer, the <a href="https://help.pagecord.com/pagecord-cli" class="home-link">command line</a>, or the <a href="https://help.pagecord.com/api" class="home-link">API</a>.
   </p>
   <p>
     <a href="https://help.pagecord.com/getting-started-with-pagecord" class="home-link">Read the Getting Started guide</a>
@@ -132,7 +132,7 @@
     Yes. Just append <span class="font-mono">/feed.xml</span> to any blog's domain, e.g. <a href="https://blog.pagecord.com/feed.xml" class="home-link">https://blog.pagecord.com/feed.xml</a>
   </p>
   <p>
-    <a href="https://help.pagecord.com/rss" class="home-link">Learn more about RSS feeds</a>
+    <a href="https://help.pagecord.com/rss-feeds" class="home-link">Learn more about RSS feeds</a>
   </p>
 
   <h3 id="importing-blog" class="source-serif text-2xl font-semibold">Can I import my blog from another platform?</h3>
@@ -140,7 +140,7 @@
     Yes, but it's not self-serve. <a href="mailto:hello@pagecord.com?subject=Blog%20Import%20Request" class="home-link">Contact support</a> and we'll look into it for you. We've already done this from WordPress, Ghost, static sites and others. A premium subscription is required to proceed with an import.
   </p>
   <p>
-    <a href="https://help.pagecord.com/importing-your-blog" class="home-link">Learn more about importing</a>
+    <a href="https://help.pagecord.com/importing-an-existing-blog" class="home-link">Learn more about importing</a>
   </p>
 
   <h3 id="refund-policy" class="source-serif text-2xl font-semibold">What is your refund policy?</h3>

--- a/docs/help-guide/index.md
+++ b/docs/help-guide/index.md
@@ -47,7 +47,7 @@ Make your blog your own. Choose a theme, tweak colours, change layouts, add cust
 
 ## Email
 
-Pagecord was built around email. Premium subscribers can enable people to subscribe to their blog via email, and enable the Reply by Email and Contact Form features.
+Email is at the heart of Pagecord. Premium subscribers can let readers subscribe to their blog, reply privately to a post, and get in touch through a contact form.
 
 - [Email subscriptions](email-subscriptions.md)
 - [Reply by email](reply-by-email.md)


### PR DESCRIPTION
The "How does Pagecord work?" answer was written when posting was email-only: it walked through the secret email address first and offered the editor as an afterthought, then described your blog as a "public profile". Neither matches the product or the home page's positioning any more.

## What changed

- Rewrote the intro to lead with the editor, with email as one of several ways in alongside Obsidian, the CLI and the API. Removed the "public profile" line and its `pagecord.com/blog` link.
- Fixed two 404s where help guide slugs had drifted from the doc filenames: `/rss` to `/rss-feeds`, `/importing-your-blog` to `/importing-an-existing-blog`.
- Kept the `FAQPage` JSON-LD in sync, since it duplicates every answer.
- Reworded the help guide index Email section, which used "Pagecord was built around email" to introduce three reader-facing features that have nothing to do with posting by email.

No behaviour changes, copy and links only. All 14 external links on the FAQ now return 200.