### PR TITLE
Fix the Aurelia masthead when the blog name is long

### DIFF
--- a/test/fixtures/theme_templates.yml
+++ b/test/fixtures/theme_templates.yml
@@ -1041,13 +1041,24 @@ aurelia:
     header > .email-subscriber-form { order: 4; }
     header hr { display: none; }
 
-    /* Group the avatar and title together, aligned right */
+    /* Avatar pinned to the right margin. The title sits beside it, and drops
+       below it when the column is too narrow to take both. */
     .titlebar { justify-content: flex-end; margin-bottom: 0.75rem; }
-    .avatar-container { width: auto; align-items: center; }
+    .avatar-container {
+      width: 100%;
+      flex-direction: row-reverse;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+      align-items: flex-start;
+      gap: 1rem;
+    }
     .avatar, .avatar img { width: 3rem; height: 3rem; }
     .blog-title {
       font-size: 2em;
       text-align: right;
+      flex: 1 1 19rem;
+      min-width: 0;
+      overflow-wrap: anywhere;
     }
     nav { gap: 1rem; }
 


### PR DESCRIPTION
The avatar in the Aurelia header has no fixed position. The theme sets `.avatar-container { width: auto }` but leaves the base `justify-content: space-between` in place, so the cluster shrink-wraps for short names and expands to full width for long ones. The avatar lands on the left margin while `text-align: right` pulls the title away from it, opening a void.

Everything else in Aurelia is welded to the right margin, so the avatar is the one element that wanders, which is what reads as broken.

## Measured, mobile at 393px

| blog name | avatar offset from left margin |
| --- | --- |
| Aurelia | 187px |
| Run exploration journal | 0px |
| @anthonymagnoni | 11px |
| Le journal de course et d'exploration | 0px |
| unbroken 33-char name | -297px, outside the container |

## What changed

Reversed the row so the avatar pins to the right margin alongside the nav. This turns `text-align: right` from the cause into the fix: right-aligned text now falls against the avatar rather than away from it, so no void is possible at any name length.

The container also wraps, so the title drops below the avatar when the column is too narrow to take both. That is driven by the content column rather than a viewport media query, which matters because blogs can be set to narrow, standard or wide (28/36/48rem).

`min-width: 0` with `overflow-wrap` is load-bearing rather than defensive: without it the unbroken-name case pushes the avatar outside the container.

After, across all five names at 393px and 608px: title overflow past the right margin 0px everywhere, avatar offset from the right margin 0px everywhere.

Cost: the stacked mode is taller. The mobile masthead goes from 48px to 103px for short names and 117px to 142px for the longest. Desktop is unchanged at 48/78px since it stays inline.

## Scope

This updates the seed fixture only. `ThemeTemplate#appearance_attributes` copies `custom_css` onto the blog when a template is applied, so existing Aurelia blogs hold their own snapshot and are unaffected. The production template and any backfill are handled separately.