### PR TITLE
Add image alt text separate from captions

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -119,6 +119,7 @@ class Api::BaseController < ActionController::API
     def attachment_preview_attributes_from(node)
       {}.tap do |attributes|
         attributes[:caption] = node["caption"] if node["caption"].present?
+        attributes[:alt] = node["alt"] if node["alt"].present?
         attributes[:presentation] = node["presentation"] if node["presentation"].present?
       end
     end

--- a/app/controllers/api/micropub_controller.rb
+++ b/app/controllers/api/micropub_controller.rb
@@ -194,6 +194,9 @@ class Api::MicropubController < Api::BaseController
     # Micropub clients reference uploaded images by blob URL returned from the
     # media endpoint. Convert those <img> tags to Action Text attachments so the
     # blob remains associated with the saved post.
+    #
+    # Markdown gives an image two descriptions: ![alt](url "title"). The alt
+    # becomes the accessible description, the title the visible caption.
     def resolve_blob_images(html)
       return html unless html&.match?(BLOB_URL_PATTERN)
 
@@ -202,7 +205,7 @@ class Api::MicropubController < Api::BaseController
         next unless blob = blob_from_url(img["src"])
 
         node = img.parent&.name == "figure" ? img.parent : img
-        node.replace attachment_preview_node(blob, img["src"], attributes: { caption: img["alt"] })
+        node.replace attachment_preview_node(blob, img["src"], attributes: { caption: img["title"], alt: img["alt"] })
       end
       doc.to_html
     end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -4,7 +4,7 @@
   <% elsif blob.audio? %>
     <%= audio_tag rails_public_blob_url(blob), preload: "auto", controls: "controls", class: "attachment__audio w-full" %>
   <% elsif blob.image? %>
-    <% image_alt = blob.try(:caption).presence || "Uploaded image" %>
+    <% image_alt = blob.try(:full_attributes)&.dig("alt").presence || blob.try(:caption).presence || "Uploaded image" %>
     <% if blob.content_type == "image/gif" %>
       <%= image_tag rails_public_blob_url(blob), alt: image_alt %>
     <% else %>

--- a/config/initializers/action_text.rb
+++ b/config/initializers/action_text.rb
@@ -16,4 +16,13 @@ end
 
 ActiveSupport.on_load(:action_text_content) do
   ActionText::ContentHelper.prepend(ActionTextCustomTags)
+
+  # Action Text describes an image only by its caption, which is always visible,
+  # and has no hook for extra attachment attributes. Extending ATTRIBUTES is the
+  # documented workaround (rails/rails discussion #54179) and is needed because
+  # rendering rebuilds each attachment node, dropping anything off the list.
+  # Read it back with attachment.full_attributes["alt"].
+  attributes = (ActionText::Attachment::ATTRIBUTES + %w[alt]).freeze
+  ActionText::Attachment.send(:remove_const, :ATTRIBUTES)
+  ActionText::Attachment.const_set(:ATTRIBUTES, attributes)
 end

--- a/docs/help-guide/micropub.md
+++ b/docs/help-guide/micropub.md
@@ -58,7 +58,7 @@ Pagecord supports creating and updating posts with:
 - Slug
 - Published date
 - Image uploads through the media endpoint
-- Image descriptions from apps, stored as captions
+- Image alt text and captions
 
 Pagecord does not currently support cross-posting targets through Micropub. The `syndicate-to` response is intentionally empty.
 
@@ -143,6 +143,24 @@ file=@photo.jpg
 ```
 
 On success, Pagecord returns `201 Created` with a `Location` header. Use that URL in your Markdown content or as a Micropub `photo` property.
+
+### Alt text and captions
+
+A Markdown image carries two descriptions, and Pagecord uses both:
+
+```text
+![A fishing boat at sunset](image-url "Sunset on the Mekong")
+```
+
+The text in the square brackets becomes the image's alt text. It describes the image for screen readers and is not shown on the page. The quoted title after the URL becomes the visible caption underneath the image.
+
+Give an image alt text alone and it stays undescribed on screen but readable to assistive technology:
+
+```text
+![A fishing boat at sunset](image-url)
+```
+
+The `alt` value on a Micropub `photo` property is treated the same way.
 
 ## Source Queries
 

--- a/test/controllers/api/micropub_controller_test.rb
+++ b/test/controllers/api/micropub_controller_test.rb
@@ -179,7 +179,55 @@ class Api::MicropubControllerTest < ActionDispatch::IntegrationTest
     created_post = @blog.posts.find_by(slug: "photo-post")
     stored_html = created_post.content.body.to_html
     assert_includes stored_html, "action-text-attachment"
-    assert_includes stored_html, 'caption="Stars"'
+    assert_includes stored_html, 'alt="Stars"'
+  end
+
+  test "markdown image alt describes the image and title captions it" do
+    file = fixture_file_upload("space.jpg", "image/jpeg")
+    post "/micropub/media", params: { file: file }, headers: auth_header
+    media_url = response.headers["Location"]
+
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "Boat Post" ],
+          content: [ %(![A boat at sunset](#{media_url} "Sunset on the Mekong")) ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    created_post = @blog.posts.find_by(slug: "boat-post")
+    stored_html = created_post.content.body.to_html
+    assert_includes stored_html, 'alt="A boat at sunset"'
+    assert_includes stored_html, 'caption="Sunset on the Mekong"'
+
+    # Rendering rebuilds the attachment node, so assert the alt survives it
+    rendered = created_post.content.body.to_s
+    assert_includes rendered, 'alt="A boat at sunset"'
+    assert_includes rendered, "Sunset on the Mekong"
+  end
+
+  test "markdown image without a title has no caption" do
+    file = fixture_file_upload("space.jpg", "image/jpeg")
+    post "/micropub/media", params: { file: file }, headers: auth_header
+    media_url = response.headers["Location"]
+
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "Quiet Post" ],
+          content: [ %(![A boat at sunset](#{media_url})) ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    stored_html = @blog.posts.find_by(slug: "quiet-post").content.body.to_html
+    assert_includes stored_html, 'alt="A boat at sunset"'
+    assert_not_includes stored_html, "caption="
   end
 
   test "updates a post with replace and returns created when url changes" do

--- a/test/controllers/api/posts_controller_test.rb
+++ b/test/controllers/api/posts_controller_test.rb
@@ -380,6 +380,22 @@ class Api::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes json["content"], "<figure"
   end
 
+  test "update with attachment preserves a client supplied alt" do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("space.jpg").open,
+      filename: "space.jpg",
+      content_type: "image/jpeg"
+    )
+
+    patch "/posts/#{@post.token}", params: {
+      content: %(Hello\n\n<action-text-attachment sgid="#{blob.attachable_sgid}" alt="A boat at sunset"></action-text-attachment>),
+      content_format: "markdown"
+    }, headers: auth_header
+
+    assert_response :success
+    assert_includes JSON.parse(response.body)["content"], 'alt="A boat at sunset"'
+  end
+
   test "update with identical content skips attachment churn" do
     blob = ActiveStorage::Blob.create_and_upload!(
       io: file_fixture("space.jpg").open,


### PR DESCRIPTION
Action Text describes an image only by its caption, which is always visible. An image could not be described for screen readers without that description also appearing on the page, and images with no caption fell back to `alt="Uploaded image"`.

## What changed

Markdown images carry two descriptions, so Micropub maps them to different things:

```
![A boat at sunset](image-url "Sunset on the Mekong")
```

- alt text (invisible, for screen readers): `A boat at sunset`
- visible caption: `Sunset on the Mekong`

The API accepts an `alt` attribute on `<action-text-attachment>` tags for the same purpose.

Action Text has no hook for extra attachment attributes, so `alt` joins `ATTRIBUTES` in an initializer. This is unavoidable rather than preferred: rendering rebuilds every attachment node via `with_full_attributes`, discarding anything off that list, so setting the attribute on the node alone survives storage but vanishes on render. See rails/rails discussion 54179, still open.

## Behaviour changes

- Micropub markdown alt no longer produces a visible caption. Use the title for that. Stored posts are unaffected.
- mf2 `photo` alt now maps to alt text rather than caption, matching what the spec means by it.
- Lexxy captions still supply the alt via a fallback, so editor behaviour is unchanged.

## Before merging

The help guide documents the title syntax, but the Obsidian plugin mishandles it: `IMAGE_EXTENSIONS` is anchored, so a quoted title makes the plugin skip the image and publish raw markdown pointing at a vault path. The plugin also drops alt entirely. Either fix the plugin first or cut that doc section.

Mastodon link previews still will not show the alt, as `og:image:alt` is not emitted yet.