### PR TITLE
Serve the app on the apex only, redirecting www

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.action_controller.default_url_options = { host: "www.example.com", protocol: "http" }
+  config.action_controller.default_url_options = { host: "example.com", protocol: "http" }
   config.cache_store = :null_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,10 +11,9 @@ end
 module DomainConstraints
   def self.default_domain?(request)
     if Rails.env.test?
-      [ "www.example.com", "localhost", "lvh.me", "example.com" ].include?(request.host)
+      [ "localhost", "lvh.me", "example.com" ].include?(request.host)
     else
-      default_host = Rails.application.config.x.domain
-      request.host == default_host || request.host == "www.#{default_host}"
+      request.host == Rails.application.config.x.domain
     end
   end
 
@@ -67,6 +66,14 @@ Rails.application.routes.draw do
   namespace :billing do
     resources :paddle_events, only: [ :create ]
     post "/paddle/create_update_payment_method_transaction", to: "paddle#create_update_payment_method_transaction"
+  end
+
+  # The apex is the only host this app serves. www used to serve a full second
+  # copy, which meant uploads failed silently there: only the apex is in the R2
+  # CORS allowlist, and that policy lives in the Cloudflare dashboard rather
+  # than in git, so the drift was invisible. Redirect rather than widen CORS.
+  constraints(->(request) { request.host == "www.#{Rails.application.config.x.domain}" }) do
+    match "(*path)", to: redirect(host: Rails.application.config.x.domain), via: :all
   end
 
   constraints(DomainConstraints.method(:default_domain?)) do

--- a/test/controllers/api/embeds_controller_test.rb
+++ b/test/controllers/api/embeds_controller_test.rb
@@ -79,7 +79,7 @@ class Api::EmbedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should work on the app domain, where drafts are previewed" do
-    host! "www.example.com"
+    host! "example.com"
 
     mock_html = <<~HTML
       <html>

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -359,14 +359,14 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     host_subdomain! "nope"
 
     get blog_posts_path
-    assert_redirected_to "http://www.example.com/"
+    assert_redirected_to "http://example.com/"
   end
 
   test "should redirect to root if blog is discarded" do
     @blog.discard!
 
     get blog_posts_path
-    assert_redirected_to "http://www.example.com/"
+    assert_redirected_to "http://example.com/"
   end
 
   test "should redirect to root if user is unverified" do
@@ -374,14 +374,14 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     host_subdomain! @blog.subdomain
 
     get blog_posts_path
-    assert_redirected_to "http://www.example.com/"
+    assert_redirected_to "http://example.com/"
   end
 
   test "should redirect to root if user is discarded" do
     @blog.user.discard!
 
     get blog_posts_path
-    assert_redirected_to "http://www.example.com/"
+    assert_redirected_to "http://example.com/"
   end
 
   ## RSS
@@ -632,7 +632,7 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
 
     get "/#{post.slug}", headers: { "HOST" => "gadzooks.com" }
 
-    assert_redirected_to "http://www.example.com/"
+    assert_redirected_to "http://example.com/"
   end
 
   test "should redirect from default domain index to custom domain" do

--- a/test/integration/www_redirect_test.rb
+++ b/test/integration/www_redirect_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class WwwRedirectTest < ActionDispatch::IntegrationTest
+  test "redirects www to the apex domain" do
+    host! "www.example.com"
+    get "/"
+
+    assert_redirected_to "http://example.com/"
+    assert_equal 301, response.status
+  end
+
+  test "preserves the path and query string" do
+    host! "www.example.com"
+    get "/login?return_to=%2Fapp"
+
+    assert_redirected_to "http://example.com/login?return_to=%2Fapp"
+  end
+
+  test "leaves the apex domain alone" do
+    host! "example.com"
+    get "/login"
+
+    assert_response :success
+  end
+
+  test "redirects non-GET requests too" do
+    host! "www.example.com"
+    post "/sessions"
+
+    assert_redirected_to "http://example.com/sessions"
+  end
+
+  # Customer blogs are reachable on www too, and blogs/base_controller already
+  # canonicalises them to the customer's own apex. The constraint above matches
+  # the app domain exactly, so those are not swept into it.
+  test "sends customer www domains to their own apex, not ours" do
+    blog = blogs(:annie)
+    host! "www.#{blog.custom_domain}"
+    get "/"
+
+    assert_redirected_to "http://#{blog.custom_domain}/"
+  end
+
+  # www is no longer a default domain, so nothing reaches an app controller on
+  # it even if the redirect above is ever bypassed.
+  test "www is not treated as the app host" do
+    request = ActionDispatch::Request.new("HTTP_HOST" => "www.example.com")
+
+    assert_not DomainConstraints.default_domain?(request)
+  end
+end

--- a/test/support/host_helpers.rb
+++ b/test/support/host_helpers.rb
@@ -1,4 +1,9 @@
 class ActionDispatch::IntegrationTest
+  # Rails defaults to www.example.com, but the app serves only the apex and
+  # permanently redirects www, so every request would otherwise bounce through
+  # a 301. Tests that need another host still call host! themselves.
+  setup { host! Rails.application.config.x.domain }
+
   def host_subdomain!(name)
     host! "#{name}.#{Rails.application.config.x.domain}"
   end


### PR DESCRIPTION
## Why

www.pagecord.com served a full second copy of the app, but only the apex is in the R2 CORS allowlist. Anyone who landed on www got direct uploads that failed silently in the browser, with nothing in the server logs. The CORS policy lives in the Cloudflare dashboard rather than in git, which is why the drift went unnoticed.

## What changed

- Permanently redirect www to the apex, all methods
- Drop www from `DomainConstraints.default_domain?`, so nothing reaches an app controller on it even if the redirect is bypassed
- Point the test environment at the apex: tests defaulted to `www.example.com`, Rails' default integration host, and `default_url_options` pointed at www while production uses the apex

## Behaviour changes

- Requests to www.pagecord.com now 301 to pagecord.com, preserving path and query
- Customer blogs on www are unaffected. The constraint matches the app domain exactly, and `blogs/base_controller` already canonicalises those to the customer's own apex