### PR TITLE
Add a first-class navigation item for your posts

### DIFF
--- a/app/controllers/app/settings/navigation_items_controller.rb
+++ b/app/controllers/app/settings/navigation_items_controller.rb
@@ -8,6 +8,7 @@ class App::Settings::NavigationItemsController < AppController
   def create
     klass = case params[:nav_type]
     when "page" then PageNavigationItem
+    when "posts" then PostsNavigationItem
     when "custom" then CustomNavigationItem
     when "social" then SocialNavigationItem
     when "search" then SearchNavigationItem

--- a/app/javascript/controllers/navigation_form_controller.js
+++ b/app/javascript/controllers/navigation_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["pageFields", "customFields", "socialFields", "searchFields", "pageRadio", "customRadio", "socialRadio", "searchRadio", "platform", "url"]
+  static targets = ["pageFields", "postsFields", "customFields", "socialFields", "searchFields", "pageRadio", "postsRadio", "customRadio", "socialRadio", "searchRadio", "platform", "url"]
   static values = {
     rssFeedUrl: { type: String }
   }
@@ -31,6 +31,8 @@ export default class extends Controller {
   toggleFields() {
     if (this.pageRadioTarget.checked) {
       this.showOnly(this.pageFieldsTarget)
+    } else if (this.hasPostsRadioTarget && this.postsRadioTarget.checked) {
+      this.showOnly(this.postsFieldsTarget)
     } else if (this.customRadioTarget.checked) {
       this.showOnly(this.customFieldsTarget)
     } else if (this.hasSearchRadioTarget && this.searchRadioTarget.checked) {
@@ -41,7 +43,7 @@ export default class extends Controller {
   }
 
   showOnly(activeTarget) {
-    [this.pageFieldsTarget, this.customFieldsTarget, this.socialFieldsTarget, this.searchFieldsTarget].forEach(target => {
+    [this.pageFieldsTarget, this.postsFieldsTarget, this.customFieldsTarget, this.socialFieldsTarget, this.searchFieldsTarget].forEach(target => {
       if (target === activeTarget) {
         target.classList.remove("hidden")
         this.enableFields(target)

--- a/app/models/posts_navigation_item.rb
+++ b/app/models/posts_navigation_item.rb
@@ -1,0 +1,7 @@
+class PostsNavigationItem < NavigationItem
+  validates :type, uniqueness: { scope: :blog_id }
+
+  def link_url
+    Rails.application.routes.url_helpers.blog_posts_list_path
+  end
+end

--- a/app/views/app/settings/navigation_items/_posts_navigation_item.html.erb
+++ b/app/views/app/settings/navigation_items/_posts_navigation_item.html.erb
@@ -1,0 +1,5 @@
+<%= render layout: "navigation_item", locals: { navigation_item: posts_navigation_item } do %>
+  <% content_for :details do %>
+    <%= posts_navigation_item.link_url %>
+  <% end %>
+<% end %>

--- a/app/views/app/settings/navigation_items/index.html.erb
+++ b/app/views/app/settings/navigation_items/index.html.erb
@@ -32,6 +32,8 @@
           <div class="space-y-3">
             <% selected_type = if @navigation_item.nil? || @navigation_item.is_a?(PageNavigationItem)
                  "page"
+               elsif @navigation_item.is_a?(PostsNavigationItem)
+                 "posts"
                elsif @navigation_item.is_a?(SocialNavigationItem)
                  "social"
                elsif @navigation_item.is_a?(SearchNavigationItem)
@@ -45,6 +47,14 @@
                   data: { navigation_form_target: "pageRadio", action: "change->navigation-form#toggleFields" } %>
               <span class="ml-2">Link to a page</span>
             </label>
+            <% if @navigation_item.is_a?(PostsNavigationItem) || !@blog.navigation_items.exists?(type: "PostsNavigationItem") %>
+              <label class="flex items-center">
+                <%= radio_button_tag :nav_type, "posts", selected_type == "posts",
+                    class: "rounded-full border-slate-300 dark:border-slate-600 text-[#4fbd9c] focus:ring-[#4fbd9c]",
+                    data: { navigation_form_target: "postsRadio", action: "change->navigation-form#toggleFields" } %>
+                <span class="ml-2">Your posts</span>
+              </label>
+            <% end %>
             <label class="flex items-center">
               <%= radio_button_tag :nav_type, "custom", selected_type == "custom",
                   class: "rounded-full border-slate-300 dark:border-slate-600 text-[#4fbd9c] focus:ring-[#4fbd9c]",
@@ -76,11 +86,23 @@
               class: "w-full rounded-lg border-slate-300 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200" %>
         </div>
 
+        <div data-navigation-form-target="postsFields" class="<%= 'hidden' if selected_type != 'posts' %>">
+          <%= form.label :label, "Label", class: "block font-medium mb-2", for: "navigation_item_posts_label" %>
+          <%= form.text_field :label,
+              id: "navigation_item_posts_label",
+              value: @navigation_item&.label || "Blog",
+              class: "w-full rounded-lg border-slate-300 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200" %>
+          <div class="field-error"><%= @navigation_item.errors[:label].to_sentence if @navigation_item&.errors&.[](:label)&.any? %></div>
+          <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Links to all your posts. Rename it to suit your blog.
+          </p>
+        </div>
+
         <div data-navigation-form-target="customFields" class="space-y-4 <%= 'hidden' if selected_type != 'custom' %>">
           <fieldset>
             <%= form.label :label, "Label", class: "block font-medium mb-2" %>
             <%= form.text_field :label,
-                placeholder: "e.g., Posts, Archive, Blog",
+                placeholder: "e.g., Archive, Newsletter, Shop",
                 class: "w-full rounded-lg border-slate-300 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200" %>
             <div class="field-error"><%= @navigation_item.errors[:label].to_sentence if @navigation_item&.errors&.[](:label)&.any? %></div>
           </fieldset>
@@ -88,11 +110,11 @@
           <fieldset>
             <%= form.label :url, "URL", class: "block font-medium mb-2" %>
             <%= form.text_field :url,
-                placeholder: "e.g., /posts, /archive, https://example.com",
+                placeholder: "e.g., /archive, https://example.com",
                 class: "w-full rounded-lg border-slate-300 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200" %>
             <div class="field-error"><%= @navigation_item.errors[:url].to_sentence if @navigation_item&.errors&.[](:url)&.any? %></div>
             <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
-              Use relative paths (e.g., /posts) or full URLs (https://...)
+              Use relative paths (e.g., /archive) or full URLs (https://...)
             </p>
           </fieldset>
         </div>

--- a/app/views/app/shared/help/_navigation_content.html.erb
+++ b/app/views/app/shared/help/_navigation_content.html.erb
@@ -12,9 +12,16 @@
 </div>
 
 <div>
+  <h3 class="font-medium text-slate-900 dark:text-slate-100">Your posts</h3>
+  <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+    Adds a link to the list of all your posts. It's labelled "Blog" by default, but you can call it whatever suits your blog.
+  </p>
+</div>
+
+<div>
   <h3 class="font-medium text-slate-900 dark:text-slate-100">Custom link</h3>
   <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
-    Use this for a link to <code class="rounded bg-slate-100 px-1 py-0.5 text-slate-800 dark:bg-slate-800 dark:text-slate-200">/posts</code> to show all your posts in your header, or for any external URL you want in your header.
+    Use this for any other URL you want in your header, whether it's elsewhere on your blog or on another site.
   </p>
 </div>
 

--- a/docs/help-guide/setting-up-navigation.md
+++ b/docs/help-guide/setting-up-navigation.md
@@ -19,15 +19,20 @@ Add links to your blog's header so readers can find their way around.
 
 Links to one of your published pages. The label is automatically set to the page title.
 
+### Your posts
+
+Links to the list of all your posts. It's labelled "Blog" by default, but you can change that to whatever suits your blog. You can only add one.
+
+This is useful when you've set a page as your home page, since your posts then live at `/posts` rather than at the root of your blog.
+
 ### Custom link
 
 A manual link with your own label and URL. Use this for:
 
-- A link to `/posts` (all your posts)
 - External links (e.g., your portfolio or shop)
 - Any URL you want
 
-You can use relative paths (like `/posts`) or full URLs (like `https://example.com`).
+You can use relative paths (like `/archive`) or full URLs (like `https://example.com`).
 
 ### Social link
 

--- a/test/controllers/app/settings/navigation_items_controller_test.rb
+++ b/test/controllers/app/settings/navigation_items_controller_test.rb
@@ -79,6 +79,54 @@ class App::Settings::NavigationItemsControllerTest < ActionDispatch::Integration
     assert_equal "Pixelfed", item.label
   end
 
+  test "create posts navigation item" do
+    assert_difference -> { PostsNavigationItem.count }, 1 do
+      post app_settings_navigation_items_path, params: {
+        nav_type: "posts",
+        navigation_item: { label: "Blog" }
+      }
+    end
+
+    assert_redirected_to app_settings_navigation_items_path
+
+    item = PostsNavigationItem.last
+    assert_equal @blog, item.blog
+    assert_equal "Blog", item.label
+    assert_equal "/posts", item.link_url
+  end
+
+  test "posts navigation item keeps the label the blog chose" do
+    post app_settings_navigation_items_path, params: {
+      nav_type: "posts",
+      navigation_item: { label: "Artículos" }
+    }
+
+    assert_equal "Artículos", PostsNavigationItem.last.label
+  end
+
+  test "only one posts navigation item allowed per blog" do
+    @blog.navigation_items.create!(type: "PostsNavigationItem", label: "Blog")
+
+    assert_no_difference -> { PostsNavigationItem.count } do
+      post app_settings_navigation_items_path, params: {
+        nav_type: "posts",
+        navigation_item: { label: "Posts" }
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "posts radio hidden once a posts item exists" do
+    get app_settings_navigation_items_path
+    assert_select "input[name='nav_type'][value='posts']", count: 1
+
+    @blog.navigation_items.create!(type: "PostsNavigationItem", label: "Blog")
+
+    get app_settings_navigation_items_path
+    assert_select "input[name='nav_type'][value='posts']", count: 0
+  end
+
   test "create search navigation item" do
     assert_difference -> { SearchNavigationItem.count }, 1 do
       post app_settings_navigation_items_path, params: {

--- a/test/models/navigation_item_test.rb
+++ b/test/models/navigation_item_test.rb
@@ -132,6 +132,41 @@ class CustomNavigationItemTest < ActiveSupport::TestCase
   end
 end
 
+class PostsNavigationItemTest < ActiveSupport::TestCase
+  setup do
+    @blog = blogs(:joel)
+  end
+
+  test "valid with label" do
+    item = PostsNavigationItem.new(blog: @blog, label: "Blog")
+    assert item.valid?
+  end
+
+  test "invalid without label" do
+    item = PostsNavigationItem.new(blog: @blog)
+    assert_not item.valid?
+    assert_includes item.errors[:label], "can't be blank"
+  end
+
+  test "label can be translated" do
+    item = PostsNavigationItem.create!(blog: @blog, label: "Artículos")
+    assert_equal "Artículos", item.reload.label
+  end
+
+  test "only one allowed per blog" do
+    PostsNavigationItem.create!(blog: @blog, label: "Blog")
+
+    item = PostsNavigationItem.new(blog: @blog, label: "Posts")
+    assert_not item.valid?
+    assert_includes item.errors[:type], "has already been taken"
+  end
+
+  test "link_url returns the posts list path" do
+    item = PostsNavigationItem.new(blog: @blog, label: "Blog")
+    assert_equal Rails.application.routes.url_helpers.blog_posts_list_path, item.link_url
+  end
+end
+
 class SocialNavigationItemTest < ActiveSupport::TestCase
   setup do
     @blog = blogs(:joel)

--- a/test/system/navigation_items_test.rb
+++ b/test/system/navigation_items_test.rb
@@ -27,6 +27,35 @@ class NavigationItemsTest < ApplicationSystemTestCase
     assert_instance_of CustomNavigationItem, item
   end
 
+  test "can add posts navigation item with the default label" do
+    visit app_settings_navigation_items_path
+
+    assert_difference -> { PostsNavigationItem.count }, 1 do
+      choose "Your posts"
+      assert_equal "Blog", find_field("Label").value
+
+      click_on "Add to Navigation"
+      sleep 1
+    end
+
+    assert_equal "Blog", @blog.navigation_items.find_by(type: "PostsNavigationItem").label
+    assert_no_selector "input[name='nav_type'][value='posts']", visible: :all
+  end
+
+  test "can rename the posts navigation item label" do
+    visit app_settings_navigation_items_path
+
+    assert_difference -> { PostsNavigationItem.count }, 1 do
+      choose "Your posts"
+      fill_in "Label", with: "Artículos"
+
+      click_on "Add to Navigation"
+      sleep 1
+    end
+
+    assert_equal "Artículos", @blog.navigation_items.find_by(type: "PostsNavigationItem").label
+  end
+
   test "can add social navigation item with RSS prepopulation" do
     visit app_settings_navigation_items_path
 


### PR DESCRIPTION
Adding a header link to the posts index was the most common navigation need but the least discoverable option: you had to pick "Custom link", invent a label, and hand-type `/posts` into a free-text URL box.

## What changed

- `PostsNavigationItem`, a fifth STI subclass following `SearchNavigationItem`. One per blog, URL derived from `blog_posts_list_path` rather than stored as a string.
- A "Your posts" radio in the Add a link form, hidden once one exists. The label is a normal required field pre-filled with "Blog", not auto-set, so blogs in other languages can name it appropriately.
- Custom-link placeholders and help copy no longer point at `/posts`, since it's no longer the recommended route.
- Help guide updated (`help:sync` after merge).

## Behaviour changes

Existing `CustomNavigationItem` rows with url `/posts` are untouched and keep working. No migration.