### PR TITLE
Record churn and snapshot daily subscriber metrics

### DIFF
--- a/app/controllers/admin/churns_controller.rb
+++ b/app/controllers/admin/churns_controller.rb
@@ -1,11 +1,11 @@
 class Admin::ChurnsController < AdminController
   include Pagy::Method
 
-  MONTHS = 12
+  HISTORY_MONTHS = 12
 
   def index
-    @recent = Churn.where(occurred_at: 30.days.ago..)
-    @by_month = Churn.where(occurred_at: MONTHS.months.ago.beginning_of_month..)
+    @recent = Churn.where(occurred_at: 30.days.ago..).to_a
+    @by_month = Churn.where(occurred_at: HISTORY_MONTHS.months.ago.beginning_of_month..)
                      .group_by { |churn| churn.occurred_at.to_date.beginning_of_month }
     @paid_subscribers_at_month_end = paid_subscribers_at_month_end
     @pagy, @churns = pagy(Churn.order(occurred_at: :desc), limit: 30)
@@ -16,7 +16,7 @@ class Admin::ChurnsController < AdminController
     # Ordered ascending so the last row written for a month wins, which is the closest
     # thing to a month-end count. Blank for any month before the snapshot job started.
     def paid_subscribers_at_month_end
-      Rollup.where(name: "paid_subscribers", interval: "day", time: MONTHS.months.ago.beginning_of_month..)
+      Rollup.where(name: "paid_subscribers", interval: "day", time: HISTORY_MONTHS.months.ago.beginning_of_month..)
             .order(:time)
             .each_with_object({}) { |rollup, counts| counts[rollup.time.to_date.beginning_of_month] = rollup.value.to_i }
     end

--- a/app/controllers/admin/churns_controller.rb
+++ b/app/controllers/admin/churns_controller.rb
@@ -1,0 +1,23 @@
+class Admin::ChurnsController < AdminController
+  include Pagy::Method
+
+  MONTHS = 12
+
+  def index
+    @recent = Churn.where(occurred_at: 30.days.ago..)
+    @by_month = Churn.where(occurred_at: MONTHS.months.ago.beginning_of_month..)
+                     .group_by { |churn| churn.occurred_at.to_date.beginning_of_month }
+    @paid_subscribers_at_month_end = paid_subscribers_at_month_end
+    @pagy, @churns = pagy(Churn.order(occurred_at: :desc), limit: 30)
+  end
+
+  private
+
+    # Ordered ascending so the last row written for a month wins, which is the closest
+    # thing to a month-end count. Blank for any month before the snapshot job started.
+    def paid_subscribers_at_month_end
+      Rollup.where(name: "paid_subscribers", interval: "day", time: MONTHS.months.ago.beginning_of_month..)
+            .order(:time)
+            .each_with_object({}) { |rollup, counts| counts[rollup.time.to_date.beginning_of_month] = rollup.value.to_i }
+    end
+end

--- a/app/jobs/record_daily_metrics_job.rb
+++ b/app/jobs/record_daily_metrics_job.rb
@@ -2,12 +2,15 @@
 # answer "how many paid subscribers did I have in March" after the fact. Rollup rows are
 # written directly rather than through the gem's relation API, which aggregates historic
 # rows by a time column and is the wrong shape for a point-in-time count.
+#
+# Today only, deliberately. These are all live counts, so running this for a past date
+# would stamp today's numbers on a day they didn't describe.
 class RecordDailyMetricsJob < ApplicationJob
   queue_as :default
 
-  def perform(date = Date.current)
+  def perform
     metrics.each do |name, value|
-      Rollup.find_or_initialize_by(name: name, interval: "day", time: date, dimensions: {}).update!(value: value)
+      Rollup.find_or_initialize_by(name: name, interval: "day", time: Date.current, dimensions: {}).update!(value: value)
     end
   end
 
@@ -15,8 +18,8 @@ class RecordDailyMetricsJob < ApplicationJob
 
     def metrics
       {
-        "users" => User.kept.count,
-        "trialing" => User.kept.where(trial_ends_at: Date.current..).where.missing(:subscription).count,
+        "total_users" => User.kept.count,
+        "trialing_users" => User.kept.where(trial_ends_at: Date.current..).where.missing(:subscription).count,
         "paid_subscribers" => Subscription.active_paid.count,
         "supporters" => Subscription.active_paid.supporter.count,
         "comped_subscribers" => Subscription.comped.count,

--- a/app/jobs/record_daily_metrics_job.rb
+++ b/app/jobs/record_daily_metrics_job.rb
@@ -1,0 +1,34 @@
+# A daily snapshot of the numbers that only ever existed as live counts, so we can
+# answer "how many paid subscribers did I have in March" after the fact. Rollup rows are
+# written directly rather than through the gem's relation API, which aggregates historic
+# rows by a time column and is the wrong shape for a point-in-time count.
+class RecordDailyMetricsJob < ApplicationJob
+  queue_as :default
+
+  def perform(date = Date.current)
+    metrics.each do |name, value|
+      Rollup.find_or_initialize_by(name: name, interval: "day", time: date, dimensions: {}).update!(value: value)
+    end
+  end
+
+  private
+
+    def metrics
+      {
+        "users" => User.kept.count,
+        "trialing" => User.kept.where(trial_ends_at: Date.current..).where.missing(:subscription).count,
+        "paid_subscribers" => Subscription.active_paid.count,
+        "supporters" => Subscription.active_paid.supporter.count,
+        "comped_subscribers" => Subscription.comped.count,
+        "churning_subscribers" => Subscription.churning.count,
+        "mrr_cents" => mrr_cents
+      }
+    end
+
+    # unit_price is the amount billed per period, in cents. Annual and supporter plans
+    # bill yearly, so a twelfth of each counts towards monthly revenue.
+    def mrr_cents
+      Subscription.active_paid.monthly.sum(:unit_price) +
+        Subscription.active_paid.where.not(plan: :monthly).sum(:unit_price) / 12.0
+    end
+end

--- a/app/models/churn.rb
+++ b/app/models/churn.rb
@@ -1,0 +1,53 @@
+# A departure, kept forever. Deliberately has no inverse association on User and no
+# foreign key, so it survives accounts:purge_cancellations destroying the account it
+# describes. Everything worth knowing is denormalised here at write time.
+#
+# Revenue churn is Churn.subscription_cancelled.sum(:unit_price). The account_deleted
+# rows also carry plan and unit_price as context, so summing across both kinds double
+# counts.
+class Churn < ApplicationRecord
+  belongs_to :user, optional: true
+
+  enum :kind, { subscription_cancelled: "subscription_cancelled", account_deleted: "account_deleted" }
+
+  # Idempotent: an in-app cancellation and the Paddle webhook that follows it describe
+  # one churn, so the second caller finds the row the first one wrote.
+  def self.record(user, kind, occurred_at: Time.current)
+    subscription = user.subscription
+    blog = user.blog
+
+    find_or_create_by(user_id: user.id, kind: kind, paddle_subscription_id: subscription&.paddle_subscription_id) do |churn|
+      churn.occurred_at = occurred_at
+      churn.plan = subscription&.plan
+      churn.unit_price = subscription&.unit_price
+      churn.subscribed_at = subscription&.created_at
+      churn.signed_up_at = user.created_at
+      churn.signup_referrer = user.signup_referrer
+      churn.blog_subdomain = blog&.subdomain
+      churn.posts_count = blog&.posts&.count
+    end
+  end
+
+  # Normalised the way the mrr_cents rollup is, so one annual cancellation doesn't
+  # dwarf ten monthly ones.
+  def monthly_unit_price
+    return 0 if unit_price.blank?
+
+    monthly_plan? ? unit_price : unit_price / 12.0
+  end
+
+  # Paid tenure where we have it, account tenure otherwise. For a free departure the
+  # signup date is the only clock we get.
+  def tenure_in_months
+    started = subscribed_at || signed_up_at
+    return unless started
+
+    ((occurred_at - started) / 1.month).floor
+  end
+
+  private
+
+    def monthly_plan?
+      plan == "monthly"
+    end
+end

--- a/app/models/churn.rb
+++ b/app/models/churn.rb
@@ -1,10 +1,6 @@
 # A departure, kept forever. Deliberately has no inverse association on User and no
 # foreign key, so it survives accounts:purge_cancellations destroying the account it
 # describes. Everything worth knowing is denormalised here at write time.
-#
-# Revenue churn is Churn.subscription_cancelled.sum(:unit_price). The account_deleted
-# rows also carry plan and unit_price as context, so summing across both kinds double
-# counts.
 class Churn < ApplicationRecord
   belongs_to :user, optional: true
 
@@ -26,6 +22,16 @@ class Churn < ApplicationRecord
       churn.blog_subdomain = blog&.subdomain
       churn.posts_count = blog&.posts&.count
     end
+  rescue ActiveRecord::RecordNotUnique
+    # Those two can also land together, in which case the unique index settles which
+    # one wrote the row.
+    find_by(kind: kind, paddle_subscription_id: subscription&.paddle_subscription_id)
+  end
+
+  # Only cancellations carry revenue. Deleted accounts keep their plan as context, so
+  # counting both would double up.
+  def self.mrr_lost(churns)
+    churns.select(&:subscription_cancelled?).sum(&:monthly_unit_price) / 100.0
   end
 
   # Normalised the way the mrr_cents rollup is, so one annual cancellation doesn't
@@ -33,7 +39,7 @@ class Churn < ApplicationRecord
   def monthly_unit_price
     return 0 if unit_price.blank?
 
-    monthly_plan? ? unit_price : unit_price / 12.0
+    plan == "monthly" ? unit_price : unit_price / 12.0
   end
 
   # Paid tenure where we have it, account tenure otherwise. For a free departure the
@@ -42,12 +48,7 @@ class Churn < ApplicationRecord
     started = subscribed_at || signed_up_at
     return unless started
 
-    ((occurred_at - started) / 1.month).floor
+    months = (occurred_at.year - started.year) * 12 + occurred_at.month - started.month
+    occurred_at.day < started.day ? months - 1 : months
   end
-
-  private
-
-    def monthly_plan?
-      plan == "monthly"
-    end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -11,6 +11,13 @@ class Subscription < ApplicationRecord
       .where(cancelled_at: nil)
       .where("next_billed_at > ?", Time.current)
   }
+  scope :churning, -> { where.not(cancelled_at: nil).where("next_billed_at > ?", Time.current) }
+
+  # A callback rather than call sites: cancelled_at is set from the in-app cancel, the
+  # subscription.canceled webhook, the subscription.updated webhook with a scheduled
+  # cancel, and cancellations made in Paddle's own portal. Resuming nils it, so the
+  # presence guard keeps that quiet.
+  after_update_commit :record_churn, if: -> { saved_change_to_cancelled_at? && cancelled_at.present? }
 
   def self.price(plan = :annual)
     case plan.to_sym
@@ -52,4 +59,13 @@ class Subscription < ApplicationRecord
 
     next_billed_at && next_billed_at < Time.current
   end
+
+  private
+
+    # Time.current, not cancelled_at: a scheduled cancel sets cancelled_at to the end of
+    # the paid period, which would file the churn in the future. The day they told us is
+    # the churn date; the day the money stops shows up in the mrr_cents series.
+    def record_churn
+      Churn.record(user, :subscription_cancelled)
+    end
 end

--- a/app/views/admin/churns/index.html.erb
+++ b/app/views/admin/churns/index.html.erb
@@ -1,0 +1,86 @@
+<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-hidden mb-6">
+  <div class="bg-slate-50 dark:bg-slate-700/50 border-b border-slate-200 dark:border-slate-700 px-6 py-3">
+    <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Last 30 days</h3>
+  </div>
+  <div class="px-6 py-5">
+    <div class="grid grid-cols-2 sm:flex sm:items-center sm:gap-8 gap-4">
+      <div>
+        <span class="text-2xl font-bold text-slate-900 dark:text-slate-50"><%= @recent.count %></span>
+        <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">Left</span>
+      </div>
+      <div>
+        <span class="text-2xl font-bold text-slate-900 dark:text-slate-50"><%= number_to_currency(-@recent.select(&:subscription_cancelled?).sum(&:monthly_unit_price) / 100.0) %></span>
+        <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">MRR</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-x-auto mb-6">
+  <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+    <thead>
+      <tr class="bg-slate-50 dark:bg-slate-700/50">
+        <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Month</th>
+        <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Cancelled</th>
+        <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Deleted</th>
+        <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">MRR lost</th>
+        <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Paid at month end</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+      <% @by_month.sort.reverse.each do |month, churns| %>
+        <tr>
+          <td class="whitespace-nowrap py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-50"><%= l(month, format: "%B %Y") %></td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churns.count(&:subscription_cancelled?) %></td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churns.count(&:account_deleted?) %></td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= number_to_currency(churns.select(&:subscription_cancelled?).sum(&:monthly_unit_price) / 100.0) %></td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= @paid_subscribers_at_month_end[month] || "-" %></td>
+        </tr>
+      <% end %>
+      <% if @by_month.empty? %>
+        <tr>
+          <td colspan="5" class="py-6 px-6 text-sm text-slate-500 dark:text-slate-400 text-center">Nothing recorded yet.</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<%= turbo_frame_tag "stats-content" do %>
+  <div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-x-auto">
+    <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+      <thead>
+        <tr class="bg-slate-50 dark:bg-slate-700/50">
+          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Left</th>
+          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Blog</th>
+          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Plan</th>
+          <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Tenure</th>
+          <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Posts</th>
+          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Referrer</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+        <% @churns.each do |churn| %>
+          <tr>
+            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400">
+              <%= l(churn.occurred_at.to_date, format: :long) %>
+              <span class="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-slate-700 dark:text-slate-300"><%= churn.subscription_cancelled? ? "cancelled" : "deleted" %></span>
+            </td>
+            <td class="whitespace-nowrap py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-50"><%= churn.blog_subdomain || "-" %></td>
+            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400"><%= churn.plan || "free" %></td>
+            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churn.tenure_in_months ? "#{churn.tenure_in_months}mo" : "-" %></td>
+            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churn.posts_count || "-" %></td>
+            <td class="py-3 px-6 text-sm text-slate-500 dark:text-slate-400 max-w-xs truncate" title="<%= churn.signup_referrer %>"><%= churn.signup_referrer %></td>
+          </tr>
+        <% end %>
+        <% if @churns.empty? %>
+          <tr>
+            <td colspan="6" class="py-6 px-6 text-sm text-slate-500 dark:text-slate-400 text-center">Nothing recorded yet.</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <%= render "app/shared/pagy_nav" %>
+<% end %>

--- a/app/views/admin/churns/index.html.erb
+++ b/app/views/admin/churns/index.html.erb
@@ -6,11 +6,11 @@
     <div class="grid grid-cols-2 sm:flex sm:items-center sm:gap-8 gap-4">
       <div>
         <span class="text-2xl font-bold text-slate-900 dark:text-slate-50"><%= @recent.count %></span>
-        <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">Left</span>
+        <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">Churned</span>
       </div>
       <div>
-        <span class="text-2xl font-bold text-slate-900 dark:text-slate-50"><%= number_to_currency(-@recent.select(&:subscription_cancelled?).sum(&:monthly_unit_price) / 100.0) %></span>
-        <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">MRR</span>
+        <span class="text-2xl font-bold text-slate-900 dark:text-slate-50"><%= number_to_currency(Churn.mrr_lost(@recent)) %></span>
+        <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">MRR lost</span>
       </div>
     </div>
   </div>
@@ -33,7 +33,7 @@
           <td class="whitespace-nowrap py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-50"><%= l(month, format: "%B %Y") %></td>
           <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churns.count(&:subscription_cancelled?) %></td>
           <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churns.count(&:account_deleted?) %></td>
-          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= number_to_currency(churns.select(&:subscription_cancelled?).sum(&:monthly_unit_price) / 100.0) %></td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= number_to_currency(Churn.mrr_lost(churns)) %></td>
           <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= @paid_subscribers_at_month_end[month] || "-" %></td>
         </tr>
       <% end %>
@@ -46,41 +46,39 @@
   </table>
 </div>
 
-<%= turbo_frame_tag "stats-content" do %>
-  <div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-x-auto">
-    <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
-      <thead>
-        <tr class="bg-slate-50 dark:bg-slate-700/50">
-          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Left</th>
-          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Blog</th>
-          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Plan</th>
-          <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Tenure</th>
-          <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Posts</th>
-          <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Referrer</th>
+<div class="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-x-auto">
+  <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+    <thead>
+      <tr class="bg-slate-50 dark:bg-slate-700/50">
+        <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Left</th>
+        <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Blog</th>
+        <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Plan</th>
+        <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Tenure (months)</th>
+        <th class="py-3 px-6 text-end text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Posts</th>
+        <th class="py-3 px-6 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Referrer</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
+      <% @churns.each do |churn| %>
+        <tr>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400">
+            <%= l(churn.occurred_at.to_date, format: :long) %>
+            <span class="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-slate-700 dark:text-slate-300"><%= churn.subscription_cancelled? ? "cancelled" : "deleted" %></span>
+          </td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-50"><%= churn.blog_subdomain || "-" %></td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400"><%= churn.plan || "free" %></td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churn.tenure_in_months || "-" %></td>
+          <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churn.posts_count || "-" %></td>
+          <td class="py-3 px-6 text-sm text-slate-500 dark:text-slate-400 max-w-xs truncate" title="<%= churn.signup_referrer %>"><%= churn.signup_referrer %></td>
         </tr>
-      </thead>
-      <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
-        <% @churns.each do |churn| %>
-          <tr>
-            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400">
-              <%= l(churn.occurred_at.to_date, format: :long) %>
-              <span class="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-slate-700 dark:text-slate-300"><%= churn.subscription_cancelled? ? "cancelled" : "deleted" %></span>
-            </td>
-            <td class="whitespace-nowrap py-3 px-6 text-sm font-medium text-slate-900 dark:text-slate-50"><%= churn.blog_subdomain || "-" %></td>
-            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400"><%= churn.plan || "free" %></td>
-            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churn.tenure_in_months ? "#{churn.tenure_in_months}mo" : "-" %></td>
-            <td class="whitespace-nowrap py-3 px-6 text-sm text-slate-500 dark:text-slate-400 text-end"><%= churn.posts_count || "-" %></td>
-            <td class="py-3 px-6 text-sm text-slate-500 dark:text-slate-400 max-w-xs truncate" title="<%= churn.signup_referrer %>"><%= churn.signup_referrer %></td>
-          </tr>
-        <% end %>
-        <% if @churns.empty? %>
-          <tr>
-            <td colspan="6" class="py-6 px-6 text-sm text-slate-500 dark:text-slate-400 text-center">Nothing recorded yet.</td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+      <% end %>
+      <% if @churns.empty? %>
+        <tr>
+          <td colspan="6" class="py-6 px-6 text-sm text-slate-500 dark:text-slate-400 text-center">Nothing recorded yet.</td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
 
-  <%= render "app/shared/pagy_nav" %>
-<% end %>
+<%= render "app/shared/pagy_nav" %>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -13,8 +13,11 @@
         <%= link_to "Analytics", admin_analytics_path, class: "text-sm font-semibold hover:underline text-slate-900 dark:text-slate-100 #{'home-link' if controller_name == 'analytics'}" %>
 
         <details class="relative">
-          <summary class="text-sm font-semibold cursor-pointer list-none text-slate-900 dark:text-slate-100 hover:underline select-none #{'home-link' if controller_name == 'suppressions'}">More ▾</summary>
+          <summary class="text-sm font-semibold cursor-pointer list-none text-slate-900 dark:text-slate-100 hover:underline select-none #{'home-link' if controller_name.in?(%w[suppressions churns])}">More ▾</summary>
           <div class="absolute right-0 top-full mt-1 w-44 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-10">
+            <%= link_to "Churn", admin_churns_path,
+                class: "block px-4 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 #{'font-semibold' if controller_name == 'churns'}",
+                onclick: "this.closest('details').removeAttribute('open')" %>
             <%= link_to "Suppressions", admin_suppressions_path,
                 class: "block px-4 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 #{'font-semibold' if controller_name == 'suppressions'}",
                 onclick: "this.closest('details').removeAttribute('open')" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -24,7 +24,7 @@
         <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">Comped</span>
       <% end %>
       <%= link_to admin_users_path(status: "churning"), class: "group" do %>
-        <span class="text-2xl font-bold text-slate-900 dark:text-slate-50 group-hover:underline"><%= number_with_delimiter(Subscription.where.not(cancelled_at: nil).where("next_billed_at > ?", Time.current).count) %></span>
+        <span class="text-2xl font-bold text-slate-900 dark:text-slate-50 group-hover:underline"><%= number_with_delimiter(Subscription.churning.count) %></span>
         <span class="text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wide ml-1">Churning</span>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,7 @@ Rails.application.routes.draw do
         get :fixtures, on: :collection
       end
       resources :analytics, only: [ :index ]
+      resources :churns, only: [ :index ]
       resources :posts, only: [ :index ]
       resources :suppressions, only: [ :index ] do
         collection do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -55,6 +55,12 @@ every :day, at: "5:15 am" do
   runner "SendTrialEndedEmailsJob.perform_later"
 end
 
+# Well clear of accounts:purge_cancellations at 4:30, so the counts are taken after the
+# day's departures have been recorded.
+every :day, at: "5:20 am" do
+  runner "RecordDailyMetricsJob.perform_later"
+end
+
 # Spam blogs earn their keep from indexed backlinks, so the sooner they are
 # flagged the less they get out of us. Cheap to run: blogs with a detection drop
 # out, and empty ones are skipped before the model is called.

--- a/db/migrate/20260807120000_create_churns.rb
+++ b/db/migrate/20260807120000_create_churns.rb
@@ -1,0 +1,25 @@
+class CreateChurns < ActiveRecord::Migration[8.2]
+  def change
+    create_table :churns do |t|
+      # Deliberately no foreign key and no inverse association on User: this row
+      # must outlive the account it describes, including the nightly purge.
+      t.bigint :user_id
+      t.string :kind, null: false
+      t.datetime :occurred_at, null: false
+      t.string :plan
+      t.integer :unit_price
+      t.string :paddle_subscription_id
+      t.string :blog_subdomain
+      t.string :signup_referrer
+      t.datetime :signed_up_at
+      t.datetime :subscribed_at
+      t.integer :posts_count
+
+      t.timestamps
+    end
+
+    add_index :churns, :occurred_at
+    add_index :churns, :user_id
+    add_index :churns, [ :kind, :paddle_subscription_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_08_02_090000) do
+ActiveRecord::Schema[8.2].define(version: 2026_08_07_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -141,6 +141,25 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_02_090000) do
     t.index ["home_page_id"], name: "index_blogs_on_home_page_id"
     t.index ["subdomain"], name: "index_blogs_on_subdomain", unique: true
     t.index ["user_id"], name: "index_blogs_on_user_id"
+  end
+
+  create_table "churns", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "kind", null: false
+    t.datetime "occurred_at", null: false
+    t.string "plan"
+    t.integer "unit_price"
+    t.string "paddle_subscription_id"
+    t.string "blog_subdomain"
+    t.string "signup_referrer"
+    t.datetime "signed_up_at"
+    t.datetime "subscribed_at"
+    t.integer "posts_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["kind", "paddle_subscription_id"], name: "index_churns_on_kind_and_paddle_subscription_id", unique: true
+    t.index ["occurred_at"], name: "index_churns_on_occurred_at"
+    t.index ["user_id"], name: "index_churns_on_user_id"
   end
 
   create_table "contact_messages", force: :cascade do |t|

--- a/lib/tasks/accounts.rake
+++ b/lib/tasks/accounts.rake
@@ -5,6 +5,11 @@ namespace :accounts do
     users = User.purgeable_discarded(before: discard_date)
 
     Rails.logger.info "Purging #{users.count} accounts cancelled prior to #{discard_date.to_formatted_s(:short)}"
+
+    # Last moment this data exists, so record the departure before it goes. Restored
+    # accounts never reach here, and a failed DestroyUserJob doesn't lose the record.
+    users.find_each { |user| Churn.record(user, :account_deleted, occurred_at: user.discarded_at) }
+
     users.destroy_all
   end
 end

--- a/test/controllers/admin/churns_controller_test.rb
+++ b/test/controllers/admin/churns_controller_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class Admin::ChurnsControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  test "should get index" do
+    login_as users(:joel)
+
+    get admin_churns_path
+
+    assert_response :success
+    assert_select "td", text: /joel/
+    assert_select "td", text: /gone/
+  end
+
+  test "groups every churn into a month" do
+    login_as users(:joel)
+
+    get admin_churns_path
+
+    assert_equal Churn.count, assigns(:by_month).values.sum(&:size)
+  end
+
+  test "should not be accessible to non-admins" do
+    login_as users(:vivian)
+
+    get admin_churns_path
+
+    assert_redirected_to root_path
+  end
+end

--- a/test/fixtures/churns.yml
+++ b/test/fixtures/churns.yml
@@ -1,0 +1,19 @@
+cancelled_annual:
+  user: joel
+  kind: subscription_cancelled
+  occurred_at: <%= 10.days.ago %>
+  plan: annual
+  unit_price: 3900
+  paddle_subscription_id: sub_cancelled_01
+  blog_subdomain: joel
+  signed_up_at: <%= 2.years.ago %>
+  subscribed_at: <%= 14.months.ago %>
+  posts_count: 63
+
+deleted_free:
+  kind: account_deleted
+  occurred_at: <%= 5.days.ago %>
+  blog_subdomain: gone
+  signup_referrer: https://news.ycombinator.com/
+  signed_up_at: <%= 3.months.ago %>
+  posts_count: 0

--- a/test/jobs/record_daily_metrics_job_test.rb
+++ b/test/jobs/record_daily_metrics_job_test.rb
@@ -2,33 +2,47 @@ require "test_helper"
 
 class RecordDailyMetricsJobTest < ActiveSupport::TestCase
   test "records a snapshot for the day" do
-    RecordDailyMetricsJob.perform_now(Date.current)
+    RecordDailyMetricsJob.perform_now
 
     assert_equal Subscription.active_paid.count, value_for("paid_subscribers")
-    assert_equal User.kept.count, value_for("users")
+    assert_equal User.kept.count, value_for("total_users")
     assert_equal Subscription.comped.count, value_for("comped_subscribers")
   end
 
   test "mrr counts a twelfth of the yearly plans" do
-    RecordDailyMetricsJob.perform_now(Date.current)
+    RecordDailyMetricsJob.perform_now
 
     # Three annual at 2000 plus one monthly at 400: 500 + 400.
     assert_equal 900, value_for("mrr_cents")
   end
 
   test "re-running a day updates the values in place" do
-    RecordDailyMetricsJob.perform_now(Date.current)
+    RecordDailyMetricsJob.perform_now
     subscriptions(:one).update!(cancelled_at: Time.current)
 
     assert_no_difference -> { Rollup.count } do
-      RecordDailyMetricsJob.perform_now(Date.current)
+      RecordDailyMetricsJob.perform_now
     end
 
     assert_equal Subscription.active_paid.count, value_for("paid_subscribers")
     assert_equal 1, value_for("churning_subscribers")
   end
 
+  test "each day gets its own row" do
+    RecordDailyMetricsJob.perform_now
+
+    travel 1.day do
+      assert_difference -> { Rollup.count }, metric_count do
+        RecordDailyMetricsJob.perform_now
+      end
+    end
+  end
+
   private
+
+    def metric_count
+      RecordDailyMetricsJob.new.send(:metrics).size
+    end
 
     def value_for(name)
       Rollup.find_by(name: name, interval: "day", time: Date.current).value

--- a/test/jobs/record_daily_metrics_job_test.rb
+++ b/test/jobs/record_daily_metrics_job_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class RecordDailyMetricsJobTest < ActiveSupport::TestCase
+  test "records a snapshot for the day" do
+    RecordDailyMetricsJob.perform_now(Date.current)
+
+    assert_equal Subscription.active_paid.count, value_for("paid_subscribers")
+    assert_equal User.kept.count, value_for("users")
+    assert_equal Subscription.comped.count, value_for("comped_subscribers")
+  end
+
+  test "mrr counts a twelfth of the yearly plans" do
+    RecordDailyMetricsJob.perform_now(Date.current)
+
+    # Three annual at 2000 plus one monthly at 400: 500 + 400.
+    assert_equal 900, value_for("mrr_cents")
+  end
+
+  test "re-running a day updates the values in place" do
+    RecordDailyMetricsJob.perform_now(Date.current)
+    subscriptions(:one).update!(cancelled_at: Time.current)
+
+    assert_no_difference -> { Rollup.count } do
+      RecordDailyMetricsJob.perform_now(Date.current)
+    end
+
+    assert_equal Subscription.active_paid.count, value_for("paid_subscribers")
+    assert_equal 1, value_for("churning_subscribers")
+  end
+
+  private
+
+    def value_for(name)
+      Rollup.find_by(name: name, interval: "day", time: Date.current).value
+    end
+end

--- a/test/lib/tasks/accounts_rake_test.rb
+++ b/test/lib/tasks/accounts_rake_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "rake"
+
+class AccountsRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("accounts:purge_cancellations")
+    Rake::Task["accounts:purge_cancellations"].reenable
+
+    @user = users(:vivian)
+    @user.discard!
+    @user.update!(discarded_at: 10.days.ago)
+  end
+
+  test "records the departure before purging the account" do
+    assert_difference -> { Churn.count } do
+      Rake::Task["accounts:purge_cancellations"].invoke
+    end
+
+    assert_not User.exists?(@user.id)
+
+    churn = Churn.last
+    assert_equal "account_deleted", churn.kind
+    assert_equal @user.id, churn.user_id
+    assert_in_delta 10.days.ago, churn.occurred_at, 1.second
+  end
+
+  test "leaves accounts still inside the grace period alone" do
+    @user.update!(discarded_at: 1.day.ago)
+
+    assert_no_difference -> { Churn.count } do
+      Rake::Task["accounts:purge_cancellations"].invoke
+    end
+
+    assert User.exists?(@user.id)
+  end
+end

--- a/test/models/churn_test.rb
+++ b/test/models/churn_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class ChurnTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:joel)
+    @subscription = subscriptions(:one)
+  end
+
+  test "record denormalises everything worth keeping" do
+    @user.update!(signup_referrer: "https://news.ycombinator.com/")
+
+    churn = Churn.record(@user, :subscription_cancelled)
+
+    assert_equal @user.id, churn.user_id
+    assert_equal "subscription_cancelled", churn.kind
+    assert_equal "annual", churn.plan
+    assert_equal 2000, churn.unit_price
+    assert_equal @subscription.paddle_subscription_id, churn.paddle_subscription_id
+    assert_equal @user.blog.subdomain, churn.blog_subdomain
+    assert_equal "https://news.ycombinator.com/", churn.signup_referrer
+    assert_equal @user.created_at, churn.signed_up_at
+    assert_equal @subscription.created_at, churn.subscribed_at
+    assert_equal @user.blog.posts.count, churn.posts_count
+  end
+
+  test "record is idempotent for the same departure" do
+    Churn.record(@user, :subscription_cancelled)
+
+    assert_no_difference -> { Churn.count } do
+      Churn.record(@user, :subscription_cancelled)
+    end
+  end
+
+  test "record captures a free user with no subscription" do
+    user = users(:vivian)
+
+    churn = Churn.record(user, :account_deleted)
+
+    assert_nil churn.plan
+    assert_nil churn.unit_price
+    assert_nil churn.paddle_subscription_id
+    assert_equal user.created_at, churn.signed_up_at
+  end
+
+  test "record accepts an explicit occurred_at" do
+    churn = Churn.record(@user, :account_deleted, occurred_at: 3.days.ago)
+
+    assert_in_delta 3.days.ago, churn.occurred_at, 1.second
+  end
+
+  test "survives the account it describes being destroyed" do
+    churn = Churn.record(@user, :account_deleted)
+
+    @user.destroy!
+
+    assert_equal @user.id, churn.reload.user_id
+    assert_nil churn.user
+  end
+end

--- a/test/models/churn_test.rb
+++ b/test/models/churn_test.rb
@@ -48,6 +48,30 @@ class ChurnTest < ActiveSupport::TestCase
     assert_in_delta 3.days.ago, churn.occurred_at, 1.second
   end
 
+  test "mrr_lost takes a twelfth of yearly plans and ignores deleted accounts" do
+    churns = [
+      Churn.new(kind: :subscription_cancelled, plan: "annual", unit_price: 3900),
+      Churn.new(kind: :subscription_cancelled, plan: "monthly", unit_price: 400),
+      Churn.new(kind: :account_deleted, plan: "annual", unit_price: 3900)
+    ]
+
+    assert_in_delta 7.25, Churn.mrr_lost(churns), 0.001
+  end
+
+  test "tenure_in_months counts whole calendar months" do
+    churn = Churn.new(subscribed_at: Time.zone.parse("2025-01-15"), occurred_at: Time.zone.parse("2026-03-14"))
+    assert_equal 13, churn.tenure_in_months
+
+    churn.occurred_at = Time.zone.parse("2026-03-15")
+    assert_equal 14, churn.tenure_in_months
+  end
+
+  test "tenure_in_months falls back to the signup date for a free departure" do
+    churn = Churn.new(signed_up_at: 6.months.ago, occurred_at: Time.current)
+
+    assert_equal 6, churn.tenure_in_months
+  end
+
   test "survives the account it describes being destroyed" do
     churn = Churn.record(@user, :account_deleted)
 

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -125,4 +125,38 @@ class SubscriptionTest < ActiveSupport::TestCase
     subscription.update!(plan: :complimentary)
     assert_includes Subscription.comped, subscription
   end
+
+  test "churning scope should return cancelled subscriptions still inside their paid period" do
+    subscription = subscriptions(:one)
+    subscription.update!(cancelled_at: Time.current)
+
+    assert_includes Subscription.churning, subscription
+    assert_not_includes Subscription.churning, subscriptions(:two)
+  end
+
+  test "cancelling should record a churn" do
+    assert_difference -> { Churn.count } do
+      subscriptions(:one).update!(cancelled_at: Time.current)
+    end
+
+    assert_equal "subscription_cancelled", Churn.last.kind
+  end
+
+  test "cancelling twice should record one churn" do
+    subscription = subscriptions(:one)
+    subscription.update!(cancelled_at: Time.current)
+
+    assert_no_difference -> { Churn.count } do
+      subscription.update!(cancelled_at: 1.month.from_now)
+    end
+  end
+
+  test "resuming should not record a churn" do
+    subscription = subscriptions(:one)
+    subscription.update!(cancelled_at: Time.current)
+
+    assert_no_difference -> { Churn.count } do
+      subscription.update!(cancelled_at: nil)
+    end
+  end
 end


### PR DESCRIPTION
Cancelled and deleted accounts currently take their history with them. `DestroyUserJob` only discards; seven days later `accounts:purge_cancellations` hard-destroys the user, and `dependent: :destroy` takes the subscription row and the whole Paddle webhook log with it. Nothing is written anywhere first, so free-user churn is unrecoverable. Separately, the only business metrics in the app are five live `COUNT(*)` calls in the admin users view, so nothing can answer "how many paid subscribers did I have in March".

Two pieces that cover each other's blind spots.

**A `churns` table that outlives the account.** No foreign key, and deliberately no `has_many` on `User`, so nothing can cascade it away. Everything worth keeping is denormalised at write time: plan, price, paid and account tenure, signup referrer, blog subdomain, post count.

Two write sites. An `after_update_commit` on `Subscription` keyed on `cancelled_at`, rather than call sites, because cancellation flows through four paths today (in-app cancel, the `subscription.canceled` webhook, `subscription.updated` with a scheduled cancel, and Paddle's own portal). And one line in `accounts:purge_cancellations`, which is the last moment the data exists. `Churn.record` is idempotent, so the in-app cancel and the webhook that follows it produce one row.

**A daily snapshot into the existing `rollups` table.** `RecordDailyMetricsJob` writes seven counters at 5:20am: users, trialing, paid subscribers, supporters, comped, churning, and MRR in cents. Rollup rows are written directly rather than through the gem's relation API, which aggregates historic rows by a time column and is the wrong shape for a point-in-time count. Re-running a day updates in place.

**`/admin/churns`**, in the More menu: last 30 days, a month-by-month table, and a paginated list of departures. MRR lost is normalised the same way as the `mrr_cents` rollup, so one annual cancellation doesn't dwarf ten monthly ones.

### Behaviour changes

Nothing customer-facing. No change to the cancel flow: `CancellationMailer` already asks people to reply and that stays the feedback channel.

One new cron entry, and one extra query per purged account in the nightly task.

### Notes

Ship in a single deploy. The `Subscription` callback and the purge task both reference `Churn`, so the model must not land ahead of the migration.

Passive lapses (a failed card where Paddle never sends `subscription.canceled`) don't produce a churn row. The `paid_subscribers` and `mrr_cents` series show the drop instead, which is why both halves exist.

Plan downgrades aren't recorded per customer. Annual to monthly is blocked in `change_plan`, so supporter to annual is the only real one, and unlike a deletion that data isn't lost: the subscription row survives and `paddle_events` keeps the payload.

The subscriber and MRR series starts from the first cron run. It isn't backfilled, because past free-user counts can't be reconstructed and a fabricated series is worse than a short one. Historical paid cancellations can be backfilled from Paddle separately.
