### PR TITLE
Support PDF attachments with a first-page preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
             libjemalloc2 \
             libsqlite3-0 \
             libvips \
-            libvips-dev
+            libvips-dev \
+            poppler-utils
 
       - name: Checkout code
         uses: actions/checkout@v7

--- a/app/assets/stylesheets/blogs.css
+++ b/app/assets/stylesheets/blogs.css
@@ -387,6 +387,59 @@ footer.blog-footer #brand svg {
       }
     }
 
+    /* A PDF's rendered first page stands in for the document, sized like an
+       image. Every part carries its own class so a blog can restyle this from
+       custom CSS: a flex row on .attachment--pdf gives the compact chip
+       layout, and either caption element can be hidden on its own. The caption
+       uses gap rather than a separator glyph so hiding one leaves no orphan.
+       Until the preview job has run there is no page, and .attachment__icon
+       renders instead. */
+    .attachment--pdf {
+      .attachment__page {
+        border: 1px solid var(--color-border);
+        inline-size: auto;
+        max-block-size: 600px;
+      }
+
+      /* A little document: portrait card, thick top edge, uppercase extension. */
+      .attachment__icon {
+        aspect-ratio: 4 / 5;
+        block-size: 2.5lh;
+        border: 2px solid var(--color-text-muted);
+        border-block-start-width: 1ch;
+        border-radius: 0.5ch;
+        color: var(--color-text-muted);
+        display: grid;
+        font-size: 0.875em;
+        font-weight: bold;
+        margin-inline: auto;
+        padding-inline: 0.5ch;
+        place-content: center;
+        text-transform: uppercase;
+      }
+
+      .attachment__caption {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75ch;
+        justify-content: center;
+      }
+
+      /* Separators sit on the items either side of the Download link, never on
+         the link itself, where they would be underlined and clickable. Each
+         one disappears with its owner, so an attachment with no caption title
+         starts cleanly and hiding the size from custom CSS takes its dot too. */
+      .attachment__title::after {
+        content: "·";
+        margin-inline-start: 0.75ch;
+      }
+
+      .attachment__size::before {
+        content: "·";
+        margin-inline-end: 0.75ch;
+      }
+    }
+
     code,
     pre {
       background-color: var(--color-bg-subtle);

--- a/app/assets/tailwind/components.css
+++ b/app/assets/tailwind/components.css
@@ -27,7 +27,7 @@
     @apply dark:bg-slate-900 text-slate-800 dark:text-slate-200 rounded-lg focus:outline-none focus:ring-0 focus:border-slate-500 dark:focus:border-slate-400 border-slate-300 dark:border-slate-700;
   }
 
-  /* Native auto-growing textarea (Chrome 123+, Safari 17.4+, Edge 123+) */
+  /* Native auto-growing textarea (Chrome/Edge 123+, Safari 26.2+; not Firefox) */
   .autogrow {
     field-sizing: content;
   }

--- a/app/javascript/controllers/lexxy_controller.js
+++ b/app/javascript/controllers/lexxy_controller.js
@@ -4,7 +4,8 @@ const maxFileSizes = {
   "image/jpeg": 10, "image/jpg": 10, "image/png": 10,
   "image/gif": 10, "image/webp": 10,
   "video/mp4": 50, "video/quicktime": 50,
-  "audio/mpeg": 20, "audio/wav": 20
+  "audio/mpeg": 20, "audio/wav": 20,
+  "application/pdf": 10
 }
 
 const typingAttributes = ["autocapitalize", "autocorrect", "spellcheck"]
@@ -52,8 +53,18 @@ export default class extends Controller {
 
     if (size > limitMB * 1024 * 1024) {
       e.preventDefault()
-      const category = type.startsWith("video/") ? "Videos" : type.startsWith("audio/") ? "Audio files" : "Images"
-      alert(`This file is too large. ${category} are limited to ${limitMB}MB.`)
+      alert(`This file is too large. ${this.#categoryFor(type)} are limited to ${limitMB}MB.`)
+    }
+  }
+
+  // PDF is the only application/* type in maxFileSizes, so the media type is
+  // enough to name the category back to the writer.
+  #categoryFor(type) {
+    switch (type.split("/")[0]) {
+      case "video": return "Videos"
+      case "audio": return "Audio files"
+      case "application": return "PDFs"
+      default: return "Images"
     }
   }
 

--- a/app/javascript/controllers/lightbox_controller.js
+++ b/app/javascript/controllers/lightbox_controller.js
@@ -19,6 +19,9 @@ export default class extends Controller {
 
   lightboxEnabledFor(img) {
     if (img.closest(".posts-gallery")) return false
+    // A PDF's first page is a stand-in for the document, not an image in its
+    // own right. Zooming it would show the same page back at the same size.
+    if (img.closest(".attachment--pdf")) return false
     return !this.isMobile() || img.closest(".attachment-gallery")
   }
 

--- a/app/jobs/generate_pdf_preview_job.rb
+++ b/app/jobs/generate_pdf_preview_job.rb
@@ -1,0 +1,22 @@
+# Renders a PDF's first page once, so the blog page can treat it as an ordinary
+# image and let Cloudflare resize it. Passing no transformations means
+# ActiveStorage::Preview#processed attaches preview_image and skips the variant,
+# which is all we want: a second derivative would be dead weight.
+#
+# The output is a 72dpi PNG, which Rails' PopplerPDFPreviewer hardcodes.
+#
+# Silently does nothing without poppler (pdftoppm) on the box: previewable? is
+# false, and the attachment falls back to a file chip.
+class GeneratePdfPreviewJob < ApplicationJob
+  queue_as :low
+
+  # PreviewError means the file itself is unreadable – a missing pdftoppm is
+  # already caught by the previewable? guard – so retrying can never succeed.
+  discard_on ActiveJob::DeserializationError, ActiveStorage::PreviewError
+
+  def perform(blob)
+    return if blob.preview_image.attached? || !blob.previewable?
+
+    blob.preview({}).processed
+  end
+end

--- a/app/models/blog/export/image_handler.rb
+++ b/app/models/blog/export/image_handler.rb
@@ -8,23 +8,46 @@ class Blog::Export::ImageHandler
   def process_images(html)
     doc = Nokogiri::HTML::DocumentFragment.parse(html)
     doc.css("img").each do |img|
-      process_image(img)
+      process_node(img, "src")
+    end
+    hosted_links(doc).each do |link|
+      process_node(link, "href")
     end
     doc.to_html
   end
 
   private
 
-    def process_image(img)
-      src = img["src"]
+    # A PDF attachment is a link, not an image, so it needs bundling too. Only
+    # our own storage qualifies: Html::Sanitize has already stripped the
+    # classes that would otherwise identify the attachment, and a post's other
+    # links belong to whoever they point at.
+    def hosted_links(doc)
+      doc.css("a[href]").select { |link| own_storage?(link["href"]) }
+    end
+
+    # In production blobs live behind the public asset host; in development
+    # the app serves them itself, so recognise its Active Storage routes.
+    def own_storage?(href)
+      if (host = ENV["ACTIVE_STORAGE_ASSET_HOST"]).present?
+        href.start_with?(host)
+      else
+        href.include?("/rails/active_storage/")
+      end
+    end
+
+    def process_node(node, attribute)
+      src = node[attribute]
       return unless src
 
       FileUtils.mkdir_p(@post_images_dir)
       safe_filename = sanitized_filename(src)
       local_path = File.join(@post_images_dir, safe_filename)
 
-      download_image(src, local_path)
-      update_img_src(img, safe_filename)
+      # The same href can appear twice in one post, and claim() hands both the
+      # same local name, so only the first occurrence downloads.
+      download_image(src, local_path) unless File.exist?(local_path)
+      node[attribute] = "images/#{@post.slug}/#{safe_filename}"
     rescue StandardError => e
       Rails.logger.warn "Blog::Export::ImageHandler. Unable to process image #{src} for post #{@post.slug} on blog #{@post.blog.subdomain}: #{e.class} - #{e.message}"
     end
@@ -93,9 +116,5 @@ class Blog::Export::ImageHandler
       # Extract original URL from Cloudflare CDN image URLs like:
       # https://pagecord.com/cdn-cgi/image/width=1600,height=1200,format=webp,quality=90/https://storage.pagecord.com/78v1ct1yskcl66bzrl5zf8bz2rpw
       src.gsub(%r{https://pagecord\.com/cdn-cgi/image/[^/]+/}, "")
-    end
-
-    def update_img_src(img, safe_filename)
-      img["src"] = "images/#{@post.slug}/#{safe_filename}"
     end
 end

--- a/app/models/upload_limits.rb
+++ b/app/models/upload_limits.rb
@@ -8,6 +8,7 @@ class UploadLimits
     "video/mp4" => 50.megabytes,
     "video/quicktime" => 50.megabytes,
     "audio/mpeg" => 20.megabytes,
-    "audio/wav" => 20.megabytes
+    "audio/wav" => 20.megabytes,
+    "application/pdf" => 10.megabytes
   }.freeze
 end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,4 +1,4 @@
-<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension.downcase %>">
   <% if blob.video? %>
     <%= video_tag rails_public_blob_url(blob), preload: "auto", controls: "controls", class: "attachment__video max-h-[600px] mx-auto" %>
   <% elsif blob.audio? %>
@@ -12,9 +12,23 @@
       <% lightbox_image_url = resized_image_url(blob, width: 1600, height: 1200) %>
       <%= image_tag resized_image_url(blob, width: width, height: height), alt: image_alt, data: { lightbox_full_url: lightbox_image_url } %>
     <% end %>
+  <% elsif blob.content_type == "application/pdf" %>
+    <% if blob.preview_image.attached? %>
+      <%= image_tag resized_image_url(blob.preview_image.blob, width: 1600, height: 1200), alt: "First page of #{blob.filename}", class: "attachment__page" %>
+    <% else %>
+      <span class="attachment__icon">pdf</span>
+    <% end %>
   <% end %>
 
-  <% if caption = blob.try(:caption) %>
+  <% if blob.content_type == "application/pdf" %>
+    <figcaption class="attachment__caption">
+      <% if pdf_caption = blob.try(:caption).presence %>
+        <span class="attachment__title"><%= pdf_caption %></span>
+      <% end %>
+      <%= link_to "Download", rails_public_blob_url(blob), target: "_blank", rel: "noopener", download: blob.filename.to_s, class: "attachment__link" %>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    </figcaption>
+  <% elsif caption = blob.try(:caption) %>
     <figcaption class="attachment__caption">
       <%= caption %>
     </figcaption>

--- a/app/views/app/onboardings/show.html.erb
+++ b/app/views/app/onboardings/show.html.erb
@@ -65,7 +65,7 @@
           autocorrect: "on",
           autocapitalize: "sentences",
           attachments: false,
-          data: { controller: "autogrow", subscribed: false } %>
+          data: { subscribed: false } %>
 
         <div id="bio_error" class="field-error"><%= render "bio_error" if @blog.errors[:bio].any? %></div>
       </fieldset>

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -18,3 +18,11 @@ ActiveSupport.on_load(:active_storage_attachment) do
     validate { errors.add(:record, :blank) if record.nil? }
   end
 end
+
+# Hook the attachment rather than the upload so every route in covers itself:
+# the editor, the API, Micropub and inbound email all end up attaching a blob.
+# This is where Rails runs analyze_blob_later for the same reason.
+ActiveSupport.on_load(:active_storage_attachment) do
+  after_create_commit -> { GeneratePdfPreviewJob.perform_later(blob) },
+    if: -> { blob.content_type == "application/pdf" }
+end

--- a/config/initializers/reverse_markdown.rb
+++ b/config/initializers/reverse_markdown.rb
@@ -10,5 +10,16 @@ module ReverseMarkdown
           language_from_confluence_class(node)
       end
     end
+
+    # The stock converter flattens the caption to plain text, which turns a
+    # PDF attachment's Download link into bare words. Convert each child
+    # properly so links survive, joined with spaces because the whitespace
+    # between the partial's tags is otherwise dropped.
+    class FigCaption < Base
+      def convert(node, state = {})
+        content = node.children.map { |child| treat(child, state).squish }.reject(&:empty?).join(" ")
+        content.empty? ? "" : "\n_#{content}_\n"
+      end
+    end
   end
 end

--- a/docs/help-guide/custom-css.md
+++ b/docs/help-guide/custom-css.md
@@ -480,6 +480,49 @@ By default, image galleries render in 2 or 3 columns depending on how many image
 
 Adjust `600px` to your preferred breakpoint.
 
+### PDF attachments: changing the layout
+
+A PDF attachment renders its first page as a thumbnail, with a download link and the file size below. You can target the following classes:
+
+- `.attachment--pdf` – the container
+- `.attachment__page` – the rendered first page
+- `.attachment__caption` – the line beneath it
+- `.attachment__title` – the caption you typed in the editor, if any
+- `.attachment__link` – the download link
+- `.attachment__size` – the file size
+
+**Show it as a compact row** instead of a full-size page:
+
+```css
+.attachment--pdf {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.attachment--pdf .attachment__page { max-block-size: 6rem; }
+.attachment--pdf .attachment__caption { justify-content: flex-start; }
+```
+
+**Change how large the page appears:**
+
+```css
+.attachment--pdf .attachment__page { max-block-size: 300px; }
+```
+
+**Hide the file size:**
+
+```css
+.attachment--pdf .attachment__size { display: none; }
+```
+
+The separator dots are attached to the items either side of the download link, so hiding an item hides its dot too. The one exception is hiding the download link itself, which needs an extra line:
+
+```css
+.attachment--pdf .attachment__link { display: none; }
+.attachment--pdf .attachment__size::before { content: none; }
+```
+
 ### Posts gallery: customising the layout
 
 The `{{ posts | style: gallery }}` dynamic variable renders posts as a grid of square thumbnails. You can target the following classes:

--- a/test/controllers/active_storage/direct_uploads_controller_test.rb
+++ b/test/controllers/active_storage/direct_uploads_controller_test.rb
@@ -23,6 +23,32 @@ class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTe
     assert_response :success
   end
 
+  test "allows pdf upload within size limit" do
+    post rails_direct_uploads_path, params: {
+      blob: { filename: "report.pdf", content_type: "application/pdf", byte_size: 5.megabytes, checksum: "abc123" }
+    }, as: :json
+
+    assert_response :success
+  end
+
+  test "allows pdf from a free user" do
+    login_as users(:vivian)
+
+    post rails_direct_uploads_path, params: {
+      blob: { filename: "report.pdf", content_type: "application/pdf", byte_size: 1.megabyte, checksum: "abc123" }
+    }, as: :json
+
+    assert_response :success
+  end
+
+  test "rejects pdf over 10MB" do
+    post rails_direct_uploads_path, params: {
+      blob: { filename: "huge.pdf", content_type: "application/pdf", byte_size: 11.megabytes, checksum: "abc123" }
+    }, as: :json
+
+    assert_response :unprocessable_entity
+  end
+
   test "rejects image over 10MB" do
     post rails_direct_uploads_path, params: {
       blob: { filename: "huge.png", content_type: "image/png", byte_size: 11.megabytes, checksum: "abc123" }

--- a/test/fixtures/files/document.pdf
+++ b/test/fixtures/files/document.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 54 >>
+stream
+BT /F1 24 Tf 72 750 Td (Pagecord test document) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000344 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+414
+%%EOF

--- a/test/jobs/generate_pdf_preview_job_test.rb
+++ b/test/jobs/generate_pdf_preview_job_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class GeneratePdfPreviewJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("document.pdf").open,
+      filename: "document.pdf",
+      content_type: "application/pdf"
+    )
+  end
+
+  test "renders the first page to an attached preview image" do
+    GeneratePdfPreviewJob.perform_now(@blob)
+
+    assert @blob.reload.preview_image.attached?
+    assert_equal "image/png", @blob.preview_image.content_type
+  end
+
+  test "does nothing when a preview already exists" do
+    GeneratePdfPreviewJob.perform_now(@blob)
+    existing = @blob.reload.preview_image.blob
+
+    GeneratePdfPreviewJob.perform_now(@blob)
+
+    assert_equal existing, @blob.reload.preview_image.blob
+  end
+
+  test "does nothing without a previewer" do
+    @blob.stubs(:previewable?).returns(false)
+
+    GeneratePdfPreviewJob.perform_now(@blob)
+
+    assert_not @blob.reload.preview_image.attached?
+  end
+
+  test "is enqueued when a pdf is embedded in a post" do
+    assert_enqueued_with job: GeneratePdfPreviewJob do
+      create_post_embedding(@blob)
+    end
+  end
+
+  test "is not enqueued for an image" do
+    image = create_image_blob
+
+    assert_no_enqueued_jobs only: GeneratePdfPreviewJob do
+      create_post_embedding(image)
+    end
+  end
+
+  private
+
+    def create_post_embedding(blob)
+      blogs(:joel).posts.create!(title: "Attached", content: attachment_node_for(blob), status: :published)
+    end
+end

--- a/test/mailers/previews/post_digest_mailer_preview.rb
+++ b/test/mailers/previews/post_digest_mailer_preview.rb
@@ -8,11 +8,21 @@ class PostDigestMailerPreview < ActionMailer::Preview
 
   def individual
     blog = preview_blog
-    digest = blog.post_digests.individual.last || create_individual_digest(blog)
+    digest = digest_for_param(blog) || blog.post_digests.individual.last || create_individual_digest(blog)
     PostDigestMailer.with(digest: digest, subscriber: blog.email_subscribers.first).individual
   end
 
   private
+
+    # ?post=<token> previews a specific post rather than the latest, reusing
+    # its digest if one already exists.
+    def digest_for_param(blog)
+      return unless params[:post]
+
+      post = blog.all_posts.find_by!(token: params[:post])
+      blog.post_digests.individual.joins(:digest_posts).find_by(digest_posts: { post_id: post.id }) ||
+        PostDigest.create!(blog: blog, kind: :individual).tap { |digest| digest.digest_posts.create!(post: post) }
+    end
 
     def preview_blog
       Blog.find_by(subdomain: "joel").tap do |blog|

--- a/test/models/blog/export/image_handler_test.rb
+++ b/test/models/blog/export/image_handler_test.rb
@@ -128,7 +128,73 @@ class Blog::Export::ImageHandlerTest < ActiveSupport::TestCase
     assert_equal expected, result
   end
 
+  test "bundles a PDF linked from the storage host" do
+    blob = create_pdf_blob
+    handler = isolated_handler
+    handler.stubs(:download_image)
+
+    processed_html = with_asset_host do
+      handler.process_images(%(<a href="https://storage.pagecord.com/#{blob.key}">Download</a>))
+    end
+
+    assert_match %r{href="images/[^/]+/document\.pdf"}, processed_html
+  end
+
+  test "bundles a PDF served by the app when no asset host is set" do
+    handler = isolated_handler
+    handler.stubs(:download_image)
+
+    processed_html = handler.process_images(%(<a href="http://localhost:3000/rails/active_storage/blobs/redirect/abc123/document.pdf">Download</a>))
+
+    assert_match %r{href="images/[^/]+/document\.pdf"}, processed_html
+  end
+
+  test "leaves links to other hosts alone" do
+    handler = isolated_handler
+    handler.expects(:download_image).never
+
+    processed_html = with_asset_host do
+      handler.process_images(%(<a href="https://example.com/paper.pdf">Paper</a>))
+    end
+
+    assert_match %r{href="https://example\.com/paper\.pdf"}, processed_html
+  end
+
+  test "downloads a file linked twice only once" do
+    blob = create_pdf_blob
+    href = "https://storage.pagecord.com/#{blob.key}"
+    downloaded = []
+    handler = isolated_handler
+    handler.define_singleton_method(:download_image) do |src, path|
+      downloaded << src
+      FileUtils.touch(path)
+    end
+
+    with_asset_host do
+      handler.process_images(%(<a href="#{href}">One</a><a href="#{href}">Two</a>))
+    end
+
+    assert_equal 1, downloaded.size
+  end
+
   private
+
+    # The shared tmp/images_dir persists between runs, which the download-once
+    # guard would otherwise read as "already fetched".
+    def isolated_handler
+      Blog::Export::ImageHandler.new(@post, Dir.mktmpdir("image-handler-test"))
+    end
+
+    def with_asset_host(host = "https://storage.pagecord.com", &block)
+      ENV.stubs(:[]).with("ACTIVE_STORAGE_ASSET_HOST").returns(host)
+      yield
+    end
+
+    def create_pdf_blob
+      ActiveStorage::Blob.create_and_upload!(
+        io: file_fixture("document.pdf").open, filename: "document.pdf", content_type: "application/pdf"
+      )
+    end
 
     def create_blob
       ActiveStorage::Blob.create_and_upload!(

--- a/test/models/blog/export_test.rb
+++ b/test/models/blog/export_test.rb
@@ -116,6 +116,23 @@ class Blog::ExportTest < ActiveSupport::TestCase
     end
   end
 
+  test "markdown export keeps links inside figure captions" do
+    html = <<~HTML
+      <figure>
+        <img src="doc.png">
+        <figcaption>
+          <span>Worksheet</span>
+          <a href="doc.pdf">Download</a>
+          <span>89.4 KB</span>
+        </figcaption>
+      </figure>
+    HTML
+
+    markdown = Blog::Export.new(blog: @blog).send(:html_to_markdown, html)
+
+    assert_includes markdown, "_Worksheet [Download](doc.pdf) 89.4 KB_"
+  end
+
   test "markdown export preserves code block language" do
     post = @blog.posts.new(title: "Code Test")
     post.content = ActionText::Content.new(<<~HTML)


### PR DESCRIPTION
PDFs couldn't be attached to posts at all. Worksheets, papers and zines are exactly the sort of thing people want to hang off a post, and Lexxy already supports them end to end; the block was ours.

## What changed

- `application/pdf` joins `UploadLimits::CONTENT_TYPES` at 10MB, free tier, counting against the free quota like images. That one constant gates the editor, API, Micropub and posting by email.
- A `GeneratePdfPreviewJob` renders the first page to a PNG once, triggered when the blob is attached, so all four ingress routes are covered. Requires `pdftoppm` (poppler), already on the server and now installed in CI; without it the job no-ops and the chip renders instead.
- The blob partial renders a PDF as a first-page thumbnail with the caption, a Download link and file size beneath, all class-hooked so custom CSS can restyle or hide each part (documented in the help guide, unsynced). The partial previously emitted an empty `<figure>` for any non-media type, which also fed digest emails, both RSS feeds and exports.
- Exports bundle storage-hosted links as well as images, so the PDF file lands in the zip. The figcaption Markdown converter now converts its children rather than flattening to text, so the Download link survives in Markdown exports.
- The lightbox skips PDF thumbnails, and figure extension classes are downcased to match the editor (prod custom CSS audited, no uppercase selectors).

## Behaviour changes

- New posts can attach PDFs; existing content renders byte-identically apart from the downcased extension class.
- The Download link opens the file in a new tab in production (cross-origin ignores the `download` attribute); a true attachment-disposition download is deliberately left for later.
- PDFs cannot join image galleries; that's upstream in Lexxy (basecamp/lexxy#1235, #1236, #1237).
