### PR TITLE
Launch private blogs

### DIFF
--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -34,12 +34,10 @@ class App::Settings::BlogsController < AppController
         :locale,
         :show_metrics,
         :external_links_in_new_tab,
-        :show_upvotes
+        :show_upvotes,
+        :use_password,
+        :password
       ]
-
-      if current_features.enabled?(:private_blogs)
-        permitted_params += [ :use_password, :password ]
-      end
 
       if @blog.user.subscribed?
         permitted_params += [ :custom_domain, :custom_robots_txt, :use_custom_robots_txt, :email_subscriptions_enabled, :show_subscription_in_header, :show_subscription_in_footer, :email_delivery_mode ]

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -7,9 +7,7 @@ class Blog < ApplicationRecord
   belongs_to :user, inverse_of: :blogs
 
   MAX_BLOGS_FREE = 1
-  MAX_BLOGS_PAID = 2
-  # The extra slot exists so a private blog can sit alongside a public one.
-  MAX_BLOGS_PAID_WITH_PRIVATE = 3
+  MAX_BLOGS_PAID = 3
 
   AVATAR_CONTENT_TYPES = %w[ image/jpeg image/png image/webp ].freeze
   AVATAR_MAX_SIZE = 5.megabytes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,10 +37,7 @@ class User < ApplicationRecord
   end
 
   def blog_limit
-    return Blog::MAX_BLOGS_FREE unless subscribed?
-    return Blog::MAX_BLOGS_PAID_WITH_PRIVATE if Rails.features.enabled?(:private_blogs, user: self)
-
-    Blog::MAX_BLOGS_PAID
+    subscribed? ? Blog::MAX_BLOGS_PAID : Blog::MAX_BLOGS_FREE
   end
 
   # Fresh each call: a quota read after a save that attached images must not

--- a/app/views/app/blogs/index.html.erb
+++ b/app/views/app/blogs/index.html.erb
@@ -8,7 +8,7 @@
 
   <% unless Current.user.subscribed? %>
     <%= callout(:info) do %>
-      <%= link_to "Subscribe to Pagecord Premium", app_settings_subscriptions_path, class: "underline font-medium" %> to add a second blog to your account. Handy for a separate photo blog or microblog!
+      <%= link_to "Subscribe to Pagecord Premium", app_settings_subscriptions_path, class: "underline font-medium" %> to add up to <%= Blog::MAX_BLOGS_PAID %> blogs to your account. Handy for a separate photo blog, microblog, or a private journal!
     <% end %>
   <% end %>
 

--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -62,7 +62,6 @@
         </div>
       <% end %>
 
-      <% if current_features.enabled?(:private_blogs) %>
       <% saved_password = persisted_value(@blog, :password_digest).present? %>
       <%= settings_row "Privacy", stacked: true do %>
         <div class="group">
@@ -89,7 +88,6 @@
             </fieldset>
           </div>
         </div>
-      <% end %>
       <% end %>
 
       <% saved_robots = @blog.custom_robots_txt.present? %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -382,7 +382,7 @@
         </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>
-          Two blogs from one account
+          Three blogs from one account
         </li>
         <li class="flex items-center text-slate-700 dark:text-slate-300">
           <%= inline_svg_tag "icons/check.svg", class: "w-5 h-5 text-green-500 mr-3" %>

--- a/app/views/public/pagecord_vs_about_me.html.erb
+++ b/app/views/public/pagecord_vs_about_me.html.erb
@@ -65,7 +65,7 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
         </tr>
         <tr>
-          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 2)</td>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 3)</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
         </tr>

--- a/app/views/public/pagecord_vs_hey_world.html.erb
+++ b/app/views/public/pagecord_vs_hey_world.html.erb
@@ -67,7 +67,7 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
         </tr>
         <tr>
-          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 2)</td>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 3)</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
         </tr>

--- a/app/views/public/pagecord_vs_medium.html.erb
+++ b/app/views/public/pagecord_vs_medium.html.erb
@@ -93,7 +93,7 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
         </tr>
         <tr>
-          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 2)</td>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 3)</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">❌</td>
         </tr>

--- a/app/views/public/pagecord_vs_substack.html.erb
+++ b/app/views/public/pagecord_vs_substack.html.erb
@@ -98,7 +98,7 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700"><span class="text-xl">✅</span><br><span class="text-sm">($50 charge)</span></td>
         </tr>
         <tr>
-          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 2)</td>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 3)</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
         </tr>

--- a/app/views/public/pagecord_vs_wordpress.html.erb
+++ b/app/views/public/pagecord_vs_wordpress.html.erb
@@ -92,7 +92,7 @@
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
         </tr>
         <tr>
-          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 2)</td>
+          <td class="py-3 px-4 border-b border-slate-200 dark:border-slate-700">Multiple blogs from one account (Premium includes 3)</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
           <td class="text-center py-3 px-4 border-b border-slate-200 dark:border-slate-700 text-xl">✅</td>
         </tr>

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,8 +1,1 @@
 env "FEATURE"
-
-# Gates who can put a password on a blog. Enforcement is deliberately not
-# gated: a blog with a password stays private whatever this returns, so
-# turning the flag off can never expose one that's already locked.
-feature :private_blogs do |user: nil, blog: nil|
-  user&.features&.include?("private_blogs")
-end

--- a/docs/help-guide/index.md
+++ b/docs/help-guide/index.md
@@ -38,6 +38,12 @@ Pages are for content that lives outside your blog feed – like an About page, 
 - [Search](blog-search.md)
 - [Dynamic variables for pages](dynamic-variables-for-pages.md)
 
+## Privacy
+
+Keep a blog to yourself, or to the people you choose.
+
+- [Private blogs](private-blogs.md)
+
 ## Customisation
 
 Make your blog your own. Choose a theme, tweak colours, change layouts, add custom CSS, and pick the perfect font.

--- a/docs/help-guide/managing-multiple-blogs.md
+++ b/docs/help-guide/managing-multiple-blogs.md
@@ -14,7 +14,7 @@ attachments:
     sgid: "eyJfcmFpbHMiOnsiZGF0YSI6ImdpZDovL3BhZ2Vjb3JkL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMjIwNjk_ZXhwaXJlc19pbiIsInB1ciI6ImF0dGFjaGFibGUifX0=--c1d7b02ca5b5fe85decd0fa6984cad4cb017462c"
 ---
 
-Premium subscribers can run two blogs from the same Pagecord account. This is useful if you want separate spaces for different projects, audiences, or writing styles.
+Premium subscribers can run three blogs from the same Pagecord account. This is useful if you want separate spaces for different projects, audiences, or writing styles – or a [private blog](private-blogs.md) just for family.
 
 ## Opening Manage blogs
 
@@ -60,6 +60,6 @@ You must always keep at least one blog on your account.
 
 ## Blog limits
 
-Free accounts can have one blog. Premium subscribers can have two blogs.
+Free accounts can have one blog. Premium subscribers can have three blogs.
 
-If you are on the free plan, upgrade to Premium from **Settings** → **Billing** to add a second blog.
+If you are on the free plan, upgrade to Premium from **Settings** → **Billing** to add another blog.

--- a/docs/help-guide/private-blogs.md
+++ b/docs/help-guide/private-blogs.md
@@ -4,13 +4,13 @@ published: true
 published_at: 2026-08-17T10:00:00+00:00
 ---
 
-Put a password on your blog so only the people you share it with can read it. Handy for a family journal, a travelogue you'd rather not have indexed, or notes meant for a small group.
+Put a password on your blog so only the people you share it with can read it. Handy for a travelogue, a family newsletter, a garden diary, a book club, or anything else that doesn't need to be fully public.
 
 ## Turning on password protection
 
-1. Go to **Settings** → **Blog**
+1. Go to **Settings** → **Blog Settings**
 2. Tick **Password protect this blog**
-3. Choose a password, then click **Update**
+3. Choose a password of 6 characters or more, then click **Update**
 
 Anyone visiting your blog now sees a password box instead of your posts. Once they enter the password they can read everything as normal, and they stay signed in on that device for 30 days.
 
@@ -38,13 +38,19 @@ Readers who have the password can subscribe by email in the usual way, which is 
 
 The subscribe form only appears once someone has entered the password, so a stranger can't sign up to receive your posts.
 
+## RSS
+
+A private blog still has an [RSS feed](rss-feeds.md), but the usual `/feed.xml` address won't work on its own. Instead the feed gets a private address with a key in it, which readers can pick up from their RSS reader once they've entered the password, in the same way as any other blog.
+
+Changing your blog's password changes the feed address too, so anyone following along in a reader will need to add it again.
+
 ## A shared family blog
 
 A private blog works nicely as a blog the whole family writes to, not just reads.
 
 Each blog can have up to three additional sender addresses alongside your own, and anyone posting from a verified address can publish by [email](posting-by-email.md). Add your partner or a relative as a sender, and they can contribute simply by sending an email – no account to create and nothing to log in to.
 
-Add sender addresses in **Settings** → **Blog**. Each one is sent a short verification email before it can post.
+Add sender addresses in **Settings** → **Blog Settings**. Each one is sent a short verification email before it can post.
 
 ## Things worth knowing
 

--- a/docs/help-guide/private-blogs.md
+++ b/docs/help-guide/private-blogs.md
@@ -1,0 +1,55 @@
+---
+title: "Private blogs"
+published: true
+published_at: 2026-08-17T10:00:00+00:00
+---
+
+Put a password on your blog so only the people you share it with can read it. Handy for a family journal, a travelogue you'd rather not have indexed, or notes meant for a small group.
+
+## Turning on password protection
+
+1. Go to **Settings** → **Blog**
+2. Tick **Password protect this blog**
+3. Choose a password, then click **Update**
+
+Anyone visiting your blog now sees a password box instead of your posts. Once they enter the password they can read everything as normal, and they stay signed in on that device for 30 days.
+
+## Changing or removing the password
+
+Enter a new password in the same box and click **Update** to change it. Everyone who had the old password is signed out and will need the new one.
+
+To make your blog public again, untick **Password protect this blog** and click **Update**.
+
+## What a password protects
+
+Every post and page is covered, including your archive and search. A private blog is also kept out of search engines and away from the Pagecord Spotlight and Shuffle, so it won't turn up in front of people you didn't invite.
+
+Your password is stored scrambled, so nobody at Pagecord can read it. If you forget it, set a new one from your settings.
+
+## Sharing the password
+
+Send it however you'd normally share something private – a message to family, or a note alongside your blog address. Everyone uses the same password, so there are no accounts for your readers to create and nothing for them to remember beyond the one word or phrase you chose.
+
+Since everyone shares one password, change it if someone should no longer have access.
+
+## Email subscriptions still work
+
+Readers who have the password can subscribe by email in the usual way, which is often the easiest way for family to follow along. They'll get new posts in their inbox without having to remember to visit.
+
+The subscribe form only appears once someone has entered the password, so a stranger can't sign up to receive your posts.
+
+## A shared family blog
+
+A private blog works nicely as a blog the whole family writes to, not just reads.
+
+Each blog can have up to three additional sender addresses alongside your own, and anyone posting from a verified address can publish by [email](posting-by-email.md). Add your partner or a relative as a sender, and they can contribute simply by sending an email – no account to create and nothing to log in to.
+
+Add sender addresses in **Settings** → **Blog**. Each one is sent a short verification email before it can post.
+
+## Things worth knowing
+
+Your blog address itself stays visible – it's the contents that are protected, not the fact that the blog exists.
+
+You'll be asked for the password on your own blog too, the same as any other visitor. Your dashboard is unaffected, so you can always write and edit as normal.
+
+A private blog isn't a vault. It's the right tool for keeping your writing away from search engines and casual passers-by, but anyone you share the password with can pass it on.

--- a/docs/help-guide/rss-feeds.md
+++ b/docs/help-guide/rss-feeds.md
@@ -20,6 +20,8 @@ If you're using a custom domain:
 https://yourdomain.com/feed.xml
 ```
 
+If your blog is [password protected](private-blogs.md), the feed lives at a private address with a key in it instead. Readers can pick it up from their RSS reader once they've entered the password.
+
 ## Filtered feeds
 
 You can filter your RSS feed using query parameters. This is useful for readers who only want to follow specific topics or languages on your blog.

--- a/docs/help-guide/seo-and-discovery.md
+++ b/docs/help-guide/seo-and-discovery.md
@@ -36,6 +36,8 @@ rel=me is one of several [microformats](microformats.md) built into every Pageco
 
 By default, your blog can be found through search engines and may be featured in the Pagecord Spotlight and Shuffle. If you'd prefer to keep things low-key, untick the "Make my blog discoverable" box – Pagecord will serve a `robots.txt` that discourages search engines, and exclude your blog from Spotlight and Shuffle.
 
+If your blog is [password protected](private-blogs.md), these settings disappear. A private blog is always kept out of search engines, the Spotlight and the Shuffle, so there's nothing to decide.
+
 ## AI Crawlers
 
 Pagecord blocks AI training crawlers (such as GPTBot and ClaudeBot) in your blog's `robots.txt` by default, so your writing isn't used to train AI models. AI search engines can still index and cite your posts, and AI assistants can read a post when a reader asks about it – so your blog stays discoverable without feeding the training pipelines.

--- a/test/controllers/app/blogs_controller_test.rb
+++ b/test/controllers/app/blogs_controller_test.rb
@@ -25,7 +25,7 @@ class App::BlogsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Your blogs"
     assert_select "a[href='#{new_app_blog_path}']", count: 0
-    assert_match "add a second blog", response.body
+    assert_match "add up to #{Blog::MAX_BLOGS_PAID} blogs", response.body
     assert_select "a[href='#{app_settings_subscriptions_path}']", text: "Subscribe to Pagecord Premium"
   end
 
@@ -40,7 +40,7 @@ class App::BlogsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Your blogs"
     assert_select "a[href='#{new_app_blog_path}']", count: 0
-    assert_match "add a second blog", response.body
+    assert_match "add up to #{Blog::MAX_BLOGS_PAID} blogs", response.body
   end
 
   test "delete blog buttons require confirmation" do

--- a/test/controllers/app/settings/blogs_controller_test.rb
+++ b/test/controllers/app/settings/blogs_controller_test.rb
@@ -287,8 +287,6 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should set a blog password" do
-    @user.update!(features: [ "private_blogs" ])
-
     patch app_settings_blog_url(@blog), params: { blog: { use_password: "1", password: "letmein" } }, as: :turbo_stream
 
     assert_redirected_to app_settings_url
@@ -297,7 +295,6 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should remove a blog password" do
-    @user.update!(features: [ "private_blogs" ])
     @blog.update!(password: "letmein")
 
     patch app_settings_blog_url(@blog), params: { blog: { use_password: "0" } }, as: :turbo_stream
@@ -307,8 +304,6 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should reject password protection with no password" do
-    @user.update!(features: [ "private_blogs" ])
-
     patch app_settings_blog_url(@blog), params: { blog: { use_password: "1", password: "" } }, as: :turbo_stream
 
     assert_response :unprocessable_entity


### PR DESCRIPTION
Stacked on #1081. Merge that first.

Flips private blogs on for everyone.

## Why

Private blogs ship behind a feature toggle so they can go to a few people first. This is the switch, kept separate so the launch is one small reviewable diff rather than a scattering of reverts.

## What changed

- Removes the `private_blogs` toggle: the feature definition, the settings-form guard, and the strong-params guard
- Raises `MAX_BLOGS_PAID` to 3 and drops the temporary `MAX_BLOGS_PAID_WITH_PRIVATE`, so `blog_limit` is a plain constant again
- Updates the marketing copy (home page and five comparison pages) to three blogs
- Publishes the private blogs help guide and links it from the index

## Behaviour changes

Everyone on Premium can password protect a blog and gets a third blog slot. The help guide goes live on the next `help:sync`.

## Note on the copy

The marketing copy was held at two blogs on the base branch rather than made toggle-aware, because the comparison pages are `caches_page`d: a beta user's render would be written to `public/` and then served to everyone. Same reasoning for holding the help guide back, since `help:sync` publishes publicly.