### PR TITLE
Fix Docker dev setup and run system tests in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
-ARG RUBY_VERSION=4.0.5
+ARG RUBY_VERSION=4.0.6
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim AS base
 
 
@@ -41,13 +41,13 @@ RUN bundle exec bootsnap precompile app/ lib/
 
 
 # Final stage for app image
-FROM base
+FROM base AS app
 
 # Install packages needed for deployment
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl postgresql-client libvips && \
+    apt-get install --no-install-recommends -y curl postgresql-client libvips poppler-utils && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application
@@ -65,3 +65,15 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
 CMD ["./bin/rails", "server"]
+
+
+# Development stage, adds Chromium for system tests. docker-compose builds this.
+FROM app AS dev
+
+USER root:root
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && \
+    apt-get install --no-install-recommends -y chromium chromium-driver fonts-liberation && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+USER rails:rails

--- a/README.md
+++ b/README.md
@@ -40,12 +40,17 @@ Your local files are mounted into the container, so changes to `.erb` views and 
 
 ### Running commands in Docker
 
-With `docker compose up` running in one terminal, use a second terminal for one-off commands:
+With `docker compose up` running in one terminal, use a second terminal for one-off commands. The everyday equivalents:
+
+| Native | Docker |
+| --- | --- |
+| `bin/dev` | `docker compose up` |
+| `bin/rails c` | `docker compose exec web bin/rails c` |
+| `bin/rails ci` | `docker compose exec web bin/rails ci` |
+
+Anything else follows the same `docker compose exec web ...` pattern:
 
 ```bash
-# Rails console
-docker compose exec web bin/rails console
-
 # Run tests
 docker compose exec web bin/rails test
 docker compose exec web bin/rails test:system
@@ -55,7 +60,12 @@ docker compose exec web bin/rails db:migrate
 
 # Process emails (debug)
 docker compose exec web bash -c "DIR=tmp/emails rake email:load"
+
+# Stop everything
+docker compose down
 ```
+
+System tests run against the Chromium installed in the image's `dev` build stage, which is why `docker-compose.yml` builds with `target: dev`. Everyday app images built without a target stay slim.
 
 ### Native Development (Alternative)
 
@@ -64,7 +74,7 @@ If you prefer to run Rails natively without Docker:
 <details>
 <summary>Click to expand native setup instructions</summary>
 
-Install Ruby 3.4.5+ using [HomeBrew](https://brew.sh/) and [rbenv](https://github.com/rbenv/rbenv).
+Install the Ruby version in `.ruby-version` using [HomeBrew](https://brew.sh/) and [rbenv](https://github.com/rbenv/rbenv).
 
 ```bash
 bundle install

--- a/bin/system-test
+++ b/bin/system-test
@@ -1,17 +1,14 @@
 #!/bin/bash
 
 # System test script for running Capybara tests with Docker PostgreSQL
-# This must be run on the HOST machine, not inside Docker containers
-# Docker containers can't run browsers properly for system tests
 
 if [ -n "$DOCKER" ] || [ -f /.dockerenv ]; then
-  echo "❌ This script must be run on the host machine, not inside Docker."
-  echo "Run this command on your host:"
-  echo "  bin/system-test"
-  exit 1
+  # Inside the container, the compose environment already points at the db service
+  # and the dev build stage provides Chromium.
+  echo "Running system tests in Docker..."
+else
+  export DATABASE_URL=postgresql://postgres:password@localhost:5432/pagecord_test
+  echo "Running system tests with Docker PostgreSQL..."
 fi
 
-export DATABASE_URL=postgresql://postgres:password@localhost:5432/pagecord_test
-
-echo "Running system tests with Docker PostgreSQL..."
 bin/rails test:system "$@"

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,6 @@
 development:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
 
 test:
   adapter: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
 
   redis:
     image: redis:latest
@@ -20,13 +25,20 @@ services:
       - "11211:11211"
 
   web:
-    build: .
+    build:
+      context: .
+      target: dev
     ports:
       - "3000:3000"
+    # Chromium needs more than the default 64MB of /dev/shm for system tests
+    shm_size: "1gb"
     depends_on:
-      - db
-      - redis
-      - memcached
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      memcached:
+        condition: service_started
     environment:
       DATABASE_HOST: db
       DATABASE_USERNAME: postgres
@@ -34,6 +46,8 @@ services:
       REDIS_URL: redis://redis:6379/0
       MEMCACHE_SERVERS: memcached:11211
       RAILS_ENV: development
+      # Tells the system tests to use the container's Chromium
+      RUNNING_IN_DOCKER: "true"
     volumes:
       - .:/rails
     stdin_open: true

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -9,8 +9,18 @@ Capybara::Selenium::Driver.class_eval do
   end
 end
 
+# In Docker, use the Chromium and driver installed by the Dockerfile's dev stage
+# rather than letting Selenium Manager download a browser at test time.
+Selenium::WebDriver::Chrome::Service.driver_path = "/usr/bin/chromedriver" if ENV["RUNNING_IN_DOCKER"]
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome
+  driven_by :selenium, using: :headless_chrome do |options|
+    if ENV["RUNNING_IN_DOCKER"]
+      options.binary = "/usr/bin/chromium"
+      # Chromium's sandbox needs privileges the container doesn't have
+      options.add_argument("--no-sandbox")
+    end
+  end
 
   setup do
     Capybara.always_include_port = true


### PR DESCRIPTION
Docker dev had drifted since it was last used. The image couldn't build at all: `RUBY_VERSION` was pinned to 4.0.5 while `.ruby-version` and `Gemfile.lock` had moved to 4.0.6, so bundler aborted on the version mismatch.

## System tests now run in Docker

The Dockerfile is split into `app` and `dev` stages. The `dev` stage adds Chromium and chromedriver — Debian trixie ships both at the same version (151.0.7922.137), so there's no browser/driver skew and Selenium Manager never needs to download anything. Compose builds that target and raises `shm_size`, since Chromium crashes on Docker's default 64MB `/dev/shm`.

The driver config in `application_system_test_case.rb` is gated on `RUNNING_IN_DOCKER`, which compose sets. Native runs and GitHub CI are unaffected — same code path as before. `bin/system-test` previously hard-exited inside a container with "Docker containers can't run browsers properly"; that's no longer true.

Image sizes: `dev` is 1.94GB, `app` (`docker build --target app`) stays at 1.24GB.

## poppler-utils

Without `pdftoppm`, ActiveStorage PDF previews silently no-op — `GeneratePdfPreviewJob`'s own comment predicts this — which failed three tests in the container. CI's test job already installs `poppler-utils`, so the Docker image was the odd one out. It's an app runtime dependency, so it goes in the `app` stage.

## Smaller fixes

- `pg_isready` healthcheck on `db` plus `condition: service_healthy`, so `db:prepare` stops racing Postgres startup on first boot
- Dev Action Cable reads `REDIS_URL` instead of hardcoding `localhost`, which is unreachable from inside the container
- README: native→Docker command table, and the Ruby version now points at `.ruby-version` rather than the stale "3.4.5+"

## Verification

Built from scratch, `docker compose down -v` then `up`, and confirmed a clean first run: Postgres healthy, migrations and seeds applied, no `db/schema.rb` churn, app 200 on `localhost:3000` and on `joel.localhost:3000`.

`docker compose exec web bin/rails ci` is fully green in the container:

```
Brakeman             ✅ Passed
Rubocop              ✅ Passed
Importmap Audit      ✅ Passed
Unit Tests           ✅ Passed     1985 runs, 6429 assertions, 0 failures
System Tests         ✅ Passed       27 runs,  126 assertions, 0 failures
```