### PR TITLE
Add a {{ search }} dynamic variable

### DIFF
--- a/app/models/dynamic_variable/search_tag.rb
+++ b/app/models/dynamic_variable/search_tag.rb
@@ -1,0 +1,9 @@
+class DynamicVariable::SearchTag
+  def initialize(blog:, view:, params_string:)
+    @view = view
+  end
+
+  def render
+    @view.render(partial: "blogs/searches/form")
+  end
+end

--- a/app/models/dynamic_variable_processor.rb
+++ b/app/models/dynamic_variable_processor.rb
@@ -8,6 +8,7 @@ class DynamicVariableProcessor
     "table_of_contents"  => :render_table_of_contents_tag,
     "email_subscription" => DynamicVariable::EmailSubscriptionTag,
     "contact_form"       => DynamicVariable::ContactFormTag,
+    "search"             => DynamicVariable::SearchTag,
     "updated_at"         => :render_updated_at_tag
   }.freeze
 

--- a/app/views/blogs/searches/_form.html.erb
+++ b/app/views/blogs/searches/_form.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (query: nil, autofocus: false) %>
+<div class="form search-form">
+  <%= form_with url: blog_search_path, method: :get do %>
+    <%= text_field_tag :q, query, placeholder: t("search.placeholder"), autofocus: autofocus %>
+    <%= submit_tag t("search.submit"), name: nil %>
+  <% end %>
+</div>

--- a/app/views/blogs/searches/show.html.erb
+++ b/app/views/blogs/searches/show.html.erb
@@ -1,11 +1,6 @@
 <%= render "blogs/header", hide_email_form: true, hide_bio: true %>
 
-<div class="form search-form">
-  <%= form_with url: blog_search_path, method: :get do %>
-    <%= text_field_tag :q, @query, placeholder: t("search.placeholder"), autofocus: true %>
-    <%= submit_tag t("search.submit"), name: nil %>
-  <% end %>
-</div>
+<%= render "blogs/searches/form", query: @query, autofocus: true %>
 
 <% if @query.present? %>
   <% if @posts.empty? %>

--- a/docs/help-guide/blog-search.md
+++ b/docs/help-guide/blog-search.md
@@ -16,6 +16,18 @@ Search is added as a navigation item, so it sits alongside your other header lin
 
 A search icon appears in your header. Readers click it to open your search page, and you can drag it into whatever position you like.
 
+## Adding a search box to a page
+
+You can also put a search box directly into a page using the `{{ search }}` [dynamic variable](dynamic-variables-for-pages.md). It works well on an archive page, where readers are already hunting for something specific.
+
+Paste it into the page content, not inside a code block in the editor:
+
+```
+{{ search }}
+```
+
+It searches exactly as the search page does, so there's no need to add both a navigation item and an embedded box unless you want them.
+
 ## How search works
 
 Search looks across the titles and content of your published posts and pages. Results are ordered with the most recent first.

--- a/docs/help-guide/creating-pages.md
+++ b/docs/help-guide/creating-pages.md
@@ -27,7 +27,7 @@ By default, your blog's home page shows your posts. You can replace this with a 
 2. Publish it
 3. From the drop-down menu, select **Set as Home Page**
 
-Your custom home page can include [dynamic variables](https://help.pagecord.com/dynamic-variables-for-pages) to display post lists, tags, and more.
+Your custom home page can include [dynamic variables](https://help.pagecord.com/dynamic-variables-for-pages) to display post lists, tags, a search box, and more.
 
 ## Adding pages to your navigation
 

--- a/docs/help-guide/dynamic-variables-for-pages.md
+++ b/docs/help-guide/dynamic-variables-for-pages.md
@@ -352,6 +352,16 @@ _Note: this only appears for paid subscribers. It isn't included in the free tri
 
 _Paste it directly into the page content, not inside a code block in the editor._
 
+### Search
+
+Embed a search box so readers can search your posts and pages from anywhere on your blog.
+
+```javascript
+{{ search }}
+```
+
+_Note: this is the same search used by the search item in your navigation, so you don't need to add both._
+
 ## Examples
 
 ### Simple Archive Page
@@ -360,6 +370,8 @@ Create a page called "Archive" with this content:
 
 ```javascript
 Here's everything I've written:
+
+{{ search }}
 
 {{ posts_by_year }}
 ```

--- a/docs/help-guide/setting-up-navigation.md
+++ b/docs/help-guide/setting-up-navigation.md
@@ -64,6 +64,8 @@ Enter the URL to your profile, or an email address for Email links, and the appr
 
 Adds a search icon that links to your blog's [search page](blog-search.md), so readers can find your posts and pages. You can only add one.
 
+You can also embed a search box in a page with the `{{ search }}` dynamic variable, instead of or as well as the navigation icon. See [Search](blog-search.md).
+
 ## Reordering navigation items
 
 Drag items to change their order. The order you see in settings is the order they'll appear on your blog.

--- a/test/integration/custom_tags_rendering_test.rb
+++ b/test/integration/custom_tags_rendering_test.rb
@@ -736,4 +736,25 @@ class CustomTagsRenderingTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "body", text: /Portuguese Post/
   end
+
+  test "renders search tag" do
+    page = @blog.pages.create!(title: "Archive", content: "{{ search }}", status: :published)
+
+    get blog_post_url(subdomain: @blog.subdomain, slug: page.slug)
+
+    assert_response :success
+    assert_select ".search-form"
+    assert_select "form[action='#{blog_search_path}']"
+    assert_select "input[name='q']"
+  end
+
+  test "search tag renders the field unfocused and empty" do
+    page = @blog.pages.create!(title: "Archive", content: "{{ search }}", status: :published)
+
+    get blog_post_url(subdomain: @blog.subdomain, slug: page.slug)
+
+    assert_response :success
+    assert_select "input[name='q'][autofocus]", count: 0
+    assert_select "input[name='q'][value]", count: 0
+  end
 end


### PR DESCRIPTION
Lets people drop a search box onto any page with `{{ search }}`, rather than search only being reachable via the navigation icon.

Asked for by a customer who wanted it on an archive page, where readers are already hunting for something specific. Fizzy card 502.

## What's here

- The search form is extracted from the search page's view into `blogs/searches/_form`, with `query:` and `autofocus:` locals.
- `DynamicVariable::SearchTag` renders that partial – same shape as `ContactFormTag`.
- Registered as `"search"` in `DynamicVariableProcessor::TAGS`.
- Help guide: a new section in `blog-search`, a cross-reference from `setting-up-navigation`, the variable documented in `dynamic-variables-for-pages`, and a mention in `creating-pages`.

## Behaviour

The search page is unchanged – it still prefills the query and takes focus. Embedded in a page the box renders **empty and unfocused**, deliberately: an autofocusing field on an archive page would pull the reader past the content on load. There's a test pinning that.

No per-blog search toggle exists, so the variable is available to every blog exactly as the navigation item is.

## Naming

Open question before this merges: `search` reads like `posts` and `tags`, but `search_form` would sit more consistently beside `contact_form` and `email_subscription`. Currently `search`. One-line change plus docs if the other name is preferred.

## Testing

`custom_tags_rendering_test` and `searches_controller_test` pass (59 runs, 294 assertions), rubocop clean. The full suite and system tests have not been run.