### PR TITLE
Break published_at ties so paginated API listings are stable

### DIFF
--- a/app/controllers/api/pages_controller.rb
+++ b/app/controllers/api/pages_controller.rb
@@ -18,7 +18,7 @@ class Api::PagesController < Api::BaseController
     pages = pages.where("published_at >= ?", parse_iso8601_timestamp(params[:published_after])) if params[:published_after]
     pages = pages.where("published_at <= ?", parse_iso8601_timestamp(params[:published_before])) if params[:published_before]
 
-    @pagy, @pages = pagy(pages.order(published_at: :desc))
+    @pagy, @pages = pagy(pages.order(published_at: :desc, id: :desc))
     set_pagination_headers(@pagy)
 
     render json: @pages.map { |page| page_json(page) }

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -18,7 +18,7 @@ class Api::PostsController < Api::BaseController
     posts = posts.where("published_at >= ?", parse_iso8601_timestamp(params[:published_after])) if params[:published_after]
     posts = posts.where("published_at <= ?", parse_iso8601_timestamp(params[:published_before])) if params[:published_before]
 
-    @pagy, @posts = pagy(posts.order(published_at: :desc))
+    @pagy, @posts = pagy(posts.order(published_at: :desc, id: :desc))
     set_pagination_headers(@pagy)
 
     render json: @posts.map { |post| post_json(post) }

--- a/docs/help-guide/custom-code-recipes.md
+++ b/docs/help-guide/custom-code-recipes.md
@@ -1,6 +1,7 @@
 ---
 title: "Custom code recipes"
 published: true
+published_at: 2026-08-10T08:10:57+00:00
 ---
 
 These are custom code snippets you can paste straight into **Settings** → **Custom Code**. Each one is self-contained, so take only the ones you want.

--- a/docs/help-guide/custom-code.md
+++ b/docs/help-guide/custom-code.md
@@ -1,6 +1,7 @@
 ---
 title: "Adding custom code"
 published: true
+published_at: 2026-08-02T20:48:29+00:00
 ---
 
 Premium customers can add their own HTML (including `<script>`) to every page of their blog. This is useful for things like:

--- a/docs/help-guide/custom-css.md
+++ b/docs/help-guide/custom-css.md
@@ -1,6 +1,7 @@
 ---
 title: "Using Custom CSS for advanced customisation"
 published: true
+published_at: 2026-01-31T11:54:29+00:00
 attachments:
   gallery-title-below:
     file: images/dynamic-variables/gallery-title-below.webp

--- a/docs/help-guide/custom-footer.md
+++ b/docs/help-guide/custom-footer.md
@@ -1,6 +1,7 @@
 ---
 title: "Adding a custom footer"
 published: true
+published_at: 2026-05-29T17:22:59+00:00
 ---
 
 Premium customers can add an HTML snippet to the footer of their blog, and it keeps rendering afterwards whatever plan you're on. This is useful for things like:

--- a/lib/tasks/help.rake
+++ b/lib/tasks/help.rake
@@ -3,6 +3,10 @@ require "json"
 require "yaml"
 require "erb"
 
+# Raised when a single file's API call fails, so the sync can report it and
+# carry on with the remaining files rather than aborting the whole run.
+HelpSyncError = Class.new(StandardError)
+
 namespace :help do
   desc "Sync help guide markdown files to help.pagecord.com pages via API"
   task :sync do
@@ -28,6 +32,7 @@ namespace :help do
     home_token = home_res.code == "200" ? JSON.parse(home_res.body)["token"] : nil
 
     docs_dir = help_docs_dir
+    failures = []
     Dir.glob("#{docs_dir}/*.md").each do |file|
       slug = File.basename(file, ".md")
       next if ENV["SLUG"] && ENV["SLUG"] != slug
@@ -55,6 +60,13 @@ namespace :help do
         help_api_call(:post, base_url, api_key, "/pages",
           content: content, content_format: "markdown", status: status, slug: slug) unless dry_run
       end
+    rescue HelpSyncError => e
+      puts "  FAILED: #{slug}: #{e.message}"
+      failures << slug
+    end
+
+    unless failures.empty?
+      abort "\n#{failures.size} file(s) failed: #{failures.join(", ")}"
     end
   end
 
@@ -132,7 +144,7 @@ namespace :help do
     req["Authorization"] = "Bearer #{api_key}"
     req.set_form_data(params)
     res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") { |http| http.request(req) }
-    abort "API error #{res.code}: #{res.body}" unless res.code.start_with?("2")
+    raise HelpSyncError, "API error #{res.code}: #{res.body}" unless res.code.start_with?("2")
     res
   end
 

--- a/test/controllers/api/pages_controller_test.rb
+++ b/test/controllers/api/pages_controller_test.rb
@@ -40,6 +40,16 @@ class Api::PagesControllerTest < ActionDispatch::IntegrationTest
     assert response.headers["link"].present?
   end
 
+  test "index breaks published_at ties by id so pagination is stable" do
+    get "/pages", headers: auth_header
+
+    assert_response :success
+    tokens = JSON.parse(response.body).map { |p| p["token"] }
+    expected = @blog.pages.kept.published.order(published_at: :desc, id: :desc).limit(tokens.size).pluck(:token)
+
+    assert_equal expected, tokens
+  end
+
   test "index does not include posts" do
     get "/pages", headers: auth_header
 


### PR DESCRIPTION
## Problem

`Api::PagesController#index` and `Api::PostsController#index` ordered only by `published_at`, with no tiebreaker:

```ruby
pagy(pages.order(published_at: :desc))
```

Pagy walks the listing with `LIMIT`/`OFFSET` (15 per page here). With ties on the sort column, Postgres is free to return tied rows in a different order for each of those requests — so a row can land on page 1 in one query and page 2 in the next, and never be returned at all.

That bit `rake help:sync`, which builds a slug → token map from `GET /pages` to decide update-vs-create. `seo-and-discovery` was missed, so the task tried to create it:

```
CREATE: seo-and-discovery
API error 422: {"errors":["Slug This slug has already been taken. Please choose another one."]}
```

`Sluggable` validates uniqueness across the whole blog, including records the listing didn't return — so the create was rejected, and `help_api_call`'s `abort` killed the run, leaving `setting-up-navigation`, `support` and `writing-posts` unsynced.

The help guide has real ties: `seo-and-discovery`/`support` share `2026-02-13T12:00:00+00:00`, `contact-form`/`reply-by-email` share `2025-12-18T16:37:19+00:00`, and four docs had no `published_at` at all, sorting as one unordered NULL block.

## Changes

- Order both API index actions by `published_at: :desc, id: :desc`, so paginated listings are stable for every API consumer, not just this rake task.
- Give the four help guide docs with no `published_at` one (taken from each file's first commit date), so they stop sorting as NULLs.
- Let `help:sync` report a failed file and carry on, instead of aborting the whole run. Failures are collected and the task still exits non-zero.
- Add a test asserting the tie-break contract on `GET /pages`.

## Notes

The ordering fix is server-side, so `help:sync` will keep missing `seo-and-discovery` until this is deployed — it just won't abort any more.

Once the four docs sync, those pages get a real `published_at` in production where they previously had none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)