### PR TITLE
Fix double-click to close the lightbox on pages

### DIFF
--- a/app/views/blogs/custom_tags/_posts_stream.html.erb
+++ b/app/views/blogs/custom_tags/_posts_stream.html.erb
@@ -1,4 +1,4 @@
-<div id="embedded-posts-<%= frame_id %>" class="h-feed" data-controller="media-embeds lightbox">
+<div id="embedded-posts-<%= frame_id %>" class="h-feed" data-controller="media-embeds">
   <%= render partial: "blogs/posts/stream_post", collection: posts, as: :post %>
 </div>
 <% if has_next %>

--- a/lib/tasks/help.rake
+++ b/lib/tasks/help.rake
@@ -5,7 +5,7 @@ require "erb"
 
 # Raised when a single file's API call fails, so the sync can report it and
 # carry on with the remaining files rather than aborting the whole run.
-HelpSyncError = Class.new(StandardError)
+class HelpSyncError < StandardError; end
 
 namespace :help do
   desc "Sync help guide markdown files to help.pagecord.com pages via API"

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -86,6 +86,14 @@ contact:
 
     <p>Email: joel@pagecord.com</p>
 
+archive:
+  record: archive (Post)
+  name: content
+  body: |
+    <p>Everything I've published, newest first.</p>
+
+    <p>{{ posts | style: stream }}</p>
+
 joel_draft:
   record: joel_draft (Post)
   name: content

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -99,6 +99,15 @@ contact:
   is_page: true
   <<: *default
 
+archive:
+  title: Archive
+  blog: joel
+  published_at: <%= 1.week.ago %>
+  token: <%= SecureRandom.hex(4) %>
+  slug: archive
+  is_page: true
+  <<: *default
+
 draft_page:
   title: Draft Page
   blog: joel

--- a/test/integration/custom_tags_rendering_test.rb
+++ b/test/integration/custom_tags_rendering_test.rb
@@ -400,6 +400,14 @@ class CustomTagsRenderingTest < ActionDispatch::IntegrationTest
     assert_includes lazy_frame_src, "sort=asc"
   end
 
+  test "a page embedding a stream of posts declares a single lightbox controller" do
+    get blog_post_url(subdomain: @blog.subdomain, slug: posts(:archive).slug)
+
+    assert_response :success
+    assert_select ".post-stream-item", minimum: 1
+    assert_select "[data-controller~='lightbox']", count: 1
+  end
+
   test "renders posts tag with gallery style and skips posts without images" do
     @blog.posts.visible.each { |p| p.update!(status: :draft) }
 


### PR DESCRIPTION
## Fix the lightbox

Opening the lightbox from a page that embeds `{{ posts | style: stream }}` needed two clicks to close, and two presses of Escape.

The page carried two `lightbox` controllers: one on the page shell in `blogs/posts/show.html.erb`, another on the stream wrapper in `_posts_stream.html.erb`. Neither stops propagation, so a single thumbnail click bubbled through both and appended two full-screen modals showing the same image at the same size. Clicking the large image dismissed only the topmost, revealing an identical modal underneath, so nothing appeared to happen.

The page shell already provides the controller, so the stream wrapper does not need its own.

Ruled out as safe while checking for other nesting:

- `_stream_layout.html.erb` is the blog index, and `has_many :posts, -> { where(is_page: false) }` plus the `is_page?` guard in `process_dynamic_variables` mean it can never render dynamic-variable output.
- Pages are not fragment-cached: `_post.html.erb` uses `cache_if(post.post?, ...)`.

Note for after deploy: page HTML on `*.pagecord.com` is edge-cached, so an old response can survive until the tag purge on `blog.updated_at`.

## Silence a test warning

A full `bin/rails test` run loads `lib/tasks/*.rake` twice in one process – once when the test command runs `test:prepare` through `RakeCommand`, and again from `SubscriptionsRakeTest`, whose `task_defined?` guard sees an emptied Rake registry by then. Constants outlive that registry, so the second load reassigned `HelpSyncError` and warned. Reopening a class with the same superclass is silent where reassigning a constant is not.

## Testing

New integration test asserts a single `lightbox` controller on a page embedding a stream. Reverting the view change fails it with "found 2".

Backed by a new `archive` fixture – an Archive page on the joel blog – since a page whose body embeds a stream of posts is the real shape of this bug.

Full suite green: 1989 runs, 6452 assertions, 0 failures.