### PR TITLE
Harden the Paddle webhook controller

### DIFF
--- a/app/controllers/app_controller.rb
+++ b/app/controllers/app_controller.rb
@@ -3,6 +3,10 @@ class AppController < ApplicationController
 
   include Authorization
 
+  # Only the signed-in app. Public blogs inherit from ApplicationController and must
+  # stay readable on whatever browser the reader happens to have.
+  allow_browser versions: :modern
+
   before_action :load_user, :onboarding_check
   around_action :set_timezone, if: -> { Current.user.present? }
 

--- a/app/controllers/billing/paddle_events_controller.rb
+++ b/app/controllers/billing/paddle_events_controller.rb
@@ -8,12 +8,21 @@ module Billing
 
     PADDLE_CONFIG = Rails.application.config_for(:paddle)
 
+    HANDLERS = {
+      "subscription.created" => :subscription_created,
+      "subscription.updated" => :subscription_updated,
+      "subscription.canceled" => :subscription_canceled,
+      "subscription.past_due" => :subscription_past_due,
+      "transaction.completed" => :transaction_completed,
+      "transaction.payment_failed" => :transaction_payment_failed
+    }.freeze
+
     def create
       if verify_signature
         if @user = load_user
           process_event params[:event_type]
         else
-          Rails.logger.warn("Unable to find user for Paddle Event")
+          Rails.logger.warn("Unable to find user for Paddle #{params[:event_type]} (customer #{params.dig(:data, :customer_id)})")
         end
       else
         Rails.logger.error("Unable to verify Paddle request signature")
@@ -26,9 +35,10 @@ module Billing
 
       def verify_signature
         paddle_signature = request.headers["Paddle-Signature"]
-        ts_part, h1_part = paddle_signature.split(";")
-        var, ts = ts_part.split("=")
-        var, h1 = h1_part.split("=")
+        ts_part, h1_part = paddle_signature.to_s.split(";")
+        var, ts = ts_part.to_s.split("=")
+        var, h1 = h1_part.to_s.split("=")
+        return false if ts.blank? || h1.blank?
 
         signed_payload = "#{ts}:#{request.raw_post}"
 
@@ -37,14 +47,18 @@ module Billing
         digest = OpenSSL::Digest.new("sha256")
         hmac = OpenSSL::HMAC.hexdigest(digest, key, data)
 
-        hmac == h1
+        ActiveSupport::SecurityUtils.secure_compare(hmac, h1)
       end
 
       def load_user
-        if data.custom_data.present?
-          @user = User.find_by(id: data.custom_data.user_id.to_i)
+        if (user_id = data.custom_data&.user_id).present?
+          @user = User.find_by(id: user_id.to_i)
           @subscription = @user&.subscription
-        elsif data.customer_id
+        end
+
+        # Fall back to the customer when custom_data is missing or does not resolve,
+        # rather than dropping the event and leaving the subscription stale.
+        if @user.nil? && data.customer_id.present?
           @subscription = Subscription.find_by(paddle_customer_id: data.customer_id)
           @user = @subscription&.user
         end
@@ -57,8 +71,8 @@ module Billing
 
         Rails.logger.info "Paddle #{event} for user #{@user.id}"
 
-        method_name = event.gsub(".", "_")
-        send(method_name) if respond_to?(method_name, true)
+        handler = HANDLERS[event]
+        send(handler) if handler
       end
 
       def subscription_created
@@ -122,11 +136,9 @@ module Billing
 
         # this webhook is also called when a subscription is cancelled, with the
         # scheduled_change action set to cancel.
-        if data.scheduled_change.present? &&
-          if data.scheduled_change.action == "cancel"
-            Rails.logger.info "Subscription is being cancelled"
-            @subscription.update!(cancelled_at: Time.parse(data.scheduled_change.effective_at))
-          end
+        if data.scheduled_change.present? && data.scheduled_change.action == "cancel"
+          Rails.logger.info "Subscription is being cancelled"
+          @subscription.update!(cancelled_at: Time.parse(data.scheduled_change.effective_at))
         end
       end
 

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -75,7 +75,8 @@ module PostsHelper
 
     processor = DynamicVariableProcessor.new(post: post, view: self)
     processor.process(post.content.to_s)
-  rescue
+  rescue StandardError => e
+    Rails.logger.error "Dynamic variable processing failed for post #{post.id}: #{e.class}: #{e.message}"
     post.content.to_s
   end
 

--- a/app/models/page_view.rb
+++ b/app/models/page_view.rb
@@ -67,7 +67,11 @@ class PageView < ApplicationRecord
     def self.parse_path_and_query(full_path)
       return [ nil, nil ] if full_path.blank?
 
-      uri = URI.parse(full_path) rescue nil
+      uri = begin
+        URI.parse(full_path)
+      rescue URI::InvalidURIError
+        nil
+      end
       return [ full_path, nil ] if uri.nil?
 
       clean_path = uri.path.presence&.chomp("/").presence || "/"

--- a/config/initializers/redirect_trailing_slash.rb
+++ b/config/initializers/redirect_trailing_slash.rb
@@ -8,7 +8,11 @@ class RedirectTrailingSlash
     # Reject requests with invalid UTF-8 encoding (typically bot scanners)
     # URL-decode first since percent-encoded bytes may decode to invalid UTF-8
     path_info = env["PATH_INFO"].to_s
-    decoded_path = Rack::Utils.unescape_path(path_info) rescue path_info
+    decoded_path = begin
+      Rack::Utils.unescape_path(path_info)
+    rescue ArgumentError
+      path_info
+    end
     unless decoded_path.force_encoding("UTF-8").valid_encoding?
       return [ 400, { "Content-Type" => "text/plain" }, [ "Bad Request" ] ]
     end

--- a/test/controllers/billing/paddle_events_controller_test.rb
+++ b/test/controllers/billing/paddle_events_controller_test.rb
@@ -359,6 +359,99 @@ class Billing::PaddleEventsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 3900, subscription.unit_price, "unit_price should reconcile from the webhook, not stay at the supporter price"
   end
 
+  test "should not dispatch an event type that names an internal method" do
+    user = users(:vivian)
+    payload = payload_for("subscription.created", user)
+    payload["event_type"] = "load_user"
+    json_payload = payload.to_json
+
+    assert_difference "user.paddle_events.count", 1 do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    assert_response :success
+    assert_nil user.reload.subscription
+  end
+
+  # "subscription_created" is not a Paddle event type, but under send-based dispatch
+  # it names the handler method directly. The HANDLERS hash must only match the
+  # dotted event names, so this must not create a subscription.
+  test "should not dispatch an event type that names a handler method directly" do
+    user = users(:vivian)
+    payload = payload_for("subscription.created", user)
+    payload["event_type"] = "subscription_created"
+    json_payload = payload.to_json
+
+    post billing_paddle_events_url,
+      params: json_payload,
+      headers: {
+        "Content-Type" => "application/json",
+        "Paddle-Signature" => paddle_signature_for(json_payload)
+      }
+
+    assert_response :success
+    assert_nil user.reload.subscription
+  end
+
+  test "should ignore a request with no Paddle-Signature header" do
+    user = users(:vivian)
+    json_payload = payload_for("subscription.created", user).to_json
+
+    assert_no_difference "PaddleEvent.count" do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: { "Content-Type" => "application/json" }
+    end
+
+    assert_response :success
+    assert_nil user.reload.subscription
+  end
+
+  test "should ignore a request with a malformed or forged Paddle-Signature header" do
+    user = users(:vivian)
+    json_payload = payload_for("subscription.created", user).to_json
+
+    [ "", "garbage", "ts=123", "h1=abc", "ts=123;h1=deadbeef" ].each do |signature|
+      assert_no_difference "PaddleEvent.count" do
+        post billing_paddle_events_url,
+          params: json_payload,
+          headers: {
+            "Content-Type" => "application/json",
+            "Paddle-Signature" => signature
+          }
+      end
+
+      assert_response :success
+    end
+
+    assert_nil user.reload.subscription
+  end
+
+  test "should fall back to customer_id when custom_data carries no user_id" do
+    subscription = subscriptions(:one)
+    subscription.update!(paddle_customer_id: "ctm_01hvnxx8katrjdh3xjph09mef7")
+
+    payload = payload_for("transaction.completed", subscription.user)
+    payload["data"]["custom_data"].delete("user_id")
+    payload["data"]["customer_id"] = subscription.paddle_customer_id
+    json_payload = payload.to_json
+
+    post billing_paddle_events_url,
+      params: json_payload,
+      headers: {
+        "Content-Type" => "application/json",
+        "Paddle-Signature" => paddle_signature_for(json_payload)
+      }
+
+    assert_response :success
+    assert_equal Time.parse(payload["data"]["billing_period"]["ends_at"]), subscription.reload.next_billed_at
+  end
+
   private
 
     def payload_for(event_type, user)


### PR DESCRIPTION
## Why

The Paddle webhook controller had a timing-unsafe signature comparison, dispatched events via `send` with a `respond_to?` check spanning the whole controller ancestry, and 500ed on a missing signature header. All signature-gated today, but one misconfiguration from exploitable.

## What changed

- Signature comparison uses `ActiveSupport::SecurityUtils.secure_compare`, and a missing or malformed `Paddle-Signature` header now fails verification cleanly instead of raising
- Events dispatch through a frozen `HANDLERS` allowlist; a signed request with a crafted `event_type` can no longer invoke arbitrary internal methods (test verified to fail against the old dispatch)
- Fixed the inert `&&` in the `subscription.updated` cancellation check (probe-verified equivalent)
- `load_user` falls back to the `customer_id` lookup when `custom_data` is present but carries no resolvable `user_id` — previously those events were silently dropped, leaving `next_billed_at` stale
- `allow_browser versions: :modern` on `AppController` (not `ApplicationController`, so public blogs stay readable on older browsers)
- Narrowed the swallowing rescues in `PageView`, `RedirectTrailingSlash` and `PostsHelper`

## Behaviour changes

- Webhooks with an unresolvable `user_id` but a known `customer_id` now update the subscription instead of being dropped
- Unknown event types are logged no-ops
- Old browsers get a 406 on signed-in app pages only

Full suite green, brakeman and rubocop clean.