### PR TITLE
Choose where reader notifications are sent

### DIFF
--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -26,7 +26,8 @@ class App::Settings::BlogsController < App::BaseController
         :use_password,
         :password,
         :post_url_format,
-        :post_url_prefix
+        :post_url_prefix,
+        :notifications_email_address_id
       ]
 
       if @blog.user.subscribed?

--- a/app/controllers/app/settings/sender_email_addresses/verifications_controller.rb
+++ b/app/controllers/app/settings/sender_email_addresses/verifications_controller.rb
@@ -8,7 +8,7 @@ class App::Settings::SenderEmailAddresses::VerificationsController < App::BaseCo
     if sender_email_address && !sender_email_address.accepted? && !sender_email_address.expired?
       sender_email_address.accept!
 
-      redirect_to redirect_path, notice: "Sender email address has been verified! You can now send posts to your blog from #{sender_email_address.email}."
+      redirect_to redirect_path, notice: "Email address has been verified! You can now post to your blog from #{sender_email_address.email}."
     else
       redirect_to redirect_path, alert: "Invalid or expired verification link :("
     end

--- a/app/controllers/app/settings/sender_email_addresses_controller.rb
+++ b/app/controllers/app/settings/sender_email_addresses_controller.rb
@@ -16,7 +16,7 @@ class App::Settings::SenderEmailAddressesController < App::BaseController
     @sender_email_address = @blog.sender_email_addresses.find(params[:id])
     @sender_email_address&.destroy
 
-    redirect_to edit_app_settings_account_path, notice: "Sender email address has been removed."
+    redirect_to edit_app_settings_account_path, notice: "Email address has been removed."
   end
 
   private

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -7,7 +7,7 @@ class CommentMailer < MailpaceMailer
 
     I18n.with_locale(@blog.locale) do
       mail(
-        to: @blog.user.email,
+        to: @blog.notifications_email,
         subject: t("comments.mailer.subject")
       )
     end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -8,7 +8,7 @@ class ContactMailer < MailpaceMailer
 
     I18n.with_locale(@blog.locale) do
       mail(
-        to: @blog.user.email,
+        to: @blog.notifications_email,
         subject: t("contact_form.mailer.subject", name: @contact_message.name),
         reply_to: @contact_message.email
       )

--- a/app/mailers/digest_reply_mailer.rb
+++ b/app/mailers/digest_reply_mailer.rb
@@ -12,7 +12,7 @@ class DigestReplyMailer < PostmarkMailer
     sender_name = original_mail[:from].display_names.first.presence || sender
 
     mail(
-      to: @blog.user.email,
+      to: @blog.notifications_email,
       from: "#{sender_name} <hello@notifications.pagecord.com>",
       reply_to: sender,
       subject: "Re: #{@digest.subject}",

--- a/app/mailers/reply_mailer.rb
+++ b/app/mailers/reply_mailer.rb
@@ -9,7 +9,7 @@ class ReplyMailer < MailpaceMailer
 
     I18n.with_locale(@blog.locale) do
       mail(
-        to: @blog.user.email,
+        to: @blog.notifications_email,
         subject: "Re: #{@post.display_title}",
         reply_to: @reply.email
       )

--- a/app/mailers/sender_email_address_mailer.rb
+++ b/app/mailers/sender_email_address_mailer.rb
@@ -5,7 +5,7 @@ class SenderEmailAddressMailer < MailpaceMailer
 
     mail(
       to: @sender_email_address.email,
-      subject: "Verify your sender email address for #{@blog.display_name}"
+      subject: "Verify your email address for #{@blog.display_name}"
     )
   end
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -19,6 +19,7 @@ class Blog < ApplicationRecord
   belongs_to :home_page, class_name: "Post", optional: true
 
   has_many :sender_email_addresses, dependent: :destroy
+  belongs_to :notifications_email_address, class_name: "SenderEmailAddress", optional: true
 
   has_many :navigation_items, dependent: :destroy
   has_many :social_navigation_items, -> { where(type: "SocialNavigationItem") }, class_name: "SocialNavigationItem", foreign_key: :blog_id
@@ -41,6 +42,7 @@ class Blog < ApplicationRecord
 
   validates :subdomain, presence: true, uniqueness: true, length: { minimum: Subdomain::MIN_LENGTH, maximum: Subdomain::MAX_LENGTH }
   validate  :subdomain_valid
+  validate  :notifications_email_address_is_own
   validates :google_site_verification, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "can only contain letters, numbers, underscores, and hyphens" }, allow_blank: true
 
   def has_custom_home_page?
@@ -90,7 +92,17 @@ class Blog < ApplicationRecord
     comments_enabled && user.has_premium_access?
   end
 
+  def notifications_email
+    notifications_email_address&.email || user.email
+  end
+
   private
+
+    def notifications_email_address_is_own
+      if notifications_email_address && (notifications_email_address.blog_id != id || !notifications_email_address.accepted?)
+        errors.add(:notifications_email_address, "is invalid")
+      end
+    end
 
     def hosts
       [ "#{subdomain}.#{Rails.application.config.x.domain}", custom_domain ].compact_blank.map(&:downcase)

--- a/app/views/app/settings/account/_form.html.erb
+++ b/app/views/app/settings/account/_form.html.erb
@@ -73,7 +73,7 @@
       <% end %>
     <% end %>
 
-    <%= settings_row "Sender Email Addresses", stacked: true, hint: "Up to 3 additional addresses that can post to your blog by email" do %>
+    <%= settings_row "Additional Email Addresses", stacked: true, hint: "Up to 3 verified addresses you can post to your blog from, or receive notifications at" do %>
       <% if @blog.sender_email_addresses.any? %>
         <div class="space-y-3 mb-6">
           <% @blog.sender_email_addresses.each do |sender| %>
@@ -93,7 +93,7 @@
                 </div>
               </div>
               <div class="flex items-center gap-2 ml-4">
-                <%= button_to app_settings_sender_email_address_path(sender), method: :delete, class: "p-1 text-slate-400 hover:text-red-600 dark:text-slate-500 dark:hover:text-red-400 transition-colors cursor-pointer", title: "Remove sender email address", data: { turbo_confirm: "Are you sure you want to remove this sender email address?" } do %>
+                <%= button_to app_settings_sender_email_address_path(sender), method: :delete, class: "p-1 text-slate-400 hover:text-red-600 dark:text-slate-500 dark:hover:text-red-400 transition-colors cursor-pointer", title: "Remove email address", data: { turbo_confirm: "Are you sure you want to remove this email address?" } do %>
                   <%= inline_svg_tag "icons/trash.svg", class: "w-4 h-4 mt-1" %>
                 <% end %>
               </div>
@@ -105,18 +105,18 @@
       <%= form_with model: @sender_email_address, url: app_settings_sender_email_addresses_path, local: true do |form| %>
         <div class="sm:flex items-center gap-3">
           <fieldset>
-            <%= form.label :email, "Add sender email address", class: "sr-only" %>
+            <%= form.label :email, "Add email address", class: "sr-only" %>
             <%= form.email_field :email, required: true, placeholder: "sender@email.com", class: "w-full md:w-96 form-field" %>
             <div class="field-error"><%= @sender_email_address.errors[:email].to_sentence if @sender_email_address&.errors&.[](:email)&.any? %></div>
           </fieldset>
           <div class="mt-4 sm:mt-0 sm:ml-2">
-            <%= form.submit "Add Sender Email", class: "btn-primary" %>
+            <%= form.submit "Add Email Address", class: "btn-primary" %>
           </div>
         </div>
       <% end %>
 
       <p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
-        You'll need to verify the address before it can post.
+        You'll need to verify the address before it can be used.
       </p>
     <% end %>
 

--- a/app/views/app/settings/audience/show.html.erb
+++ b/app/views/app/settings/audience/show.html.erb
@@ -94,6 +94,19 @@
         </div>
       <% end %>
 
+      <%= settings_row "Email Notifications", stacked: true, hint: "Which of your email addresses to send comments, replies and contact form messages to" do %>
+        <% if @blog.sender_email_addresses.accepted.any? %>
+          <%= form.collection_select :notifications_email_address_id, @blog.sender_email_addresses.accepted, :id, :email,
+                { include_blank: "Account email (#{Current.user.email})" },
+                { class: "w-full md:w-96 form-field" } %>
+        <% else %>
+          <p class="text-slate-800 dark:text-slate-100">
+            These go to your account email. To use a different address, add an
+            <%= link_to "additional email address", edit_app_settings_account_path, class: "underline" %> first.
+          </p>
+        <% end %>
+      <% end %>
+
       <%= settings_row "Post Likes", stacked: true do %>
         <div class="flex gap-3">
           <div class="flex h-6 shrink-0 items-center">

--- a/app/views/sender_email_address_mailer/verify.html.erb
+++ b/app/views/sender_email_address_mailer/verify.html.erb
@@ -1,6 +1,6 @@
 <p>Hi 👋</p>
 
-<p>Your email address (<strong><%= @sender_email_address.email %></strong>) has been added as a sender address for <strong><%= @blog.display_name %></strong>. Please click the link below to accept this request:</p>
+<p>Your email address (<strong><%= @sender_email_address.email %></strong>) has been added as an additional email address for <strong><%= @blog.display_name %></strong>. Please click the link below to accept this request:</p>
 
 <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="padding-top:5px; padding-bottom:5px;">
   <tbody>
@@ -21,5 +21,5 @@
 </table>
 
 <p>
-  This link will expire in 24 hours. If you've decided not to add this sender email address after all, you can just ignore this email.
+  This link will expire in 24 hours. If you've decided not to add this email address after all, you can just ignore this email.
 </p>

--- a/app/views/sender_email_address_mailer/verify.text.erb
+++ b/app/views/sender_email_address_mailer/verify.text.erb
@@ -1,7 +1,7 @@
 Hi 👋
 
-Your email address (<%= @sender_email_address.email %>) has been added as a sender address for <%= @blog.display_name %>. Please click the link below to accept this request:
+Your email address (<%= @sender_email_address.email %>) has been added as an additional email address for <%= @blog.display_name %>. Please click the link below to accept this request:
 
 <%= app_settings_sender_email_addresses_verification_url(token: @sender_email_address.token_digest) %>
 
-This link will expire in 24 hours. If you've decided not to add this sender email address after all, you can just ignore this email.
+This link will expire in 24 hours. If you've decided not to add this email address after all, you can just ignore this email.

--- a/db/migrate/20260828155939_add_notifications_email_address_to_blogs.rb
+++ b/db/migrate/20260828155939_add_notifications_email_address_to_blogs.rb
@@ -1,0 +1,5 @@
+class AddNotificationsEmailAddressToBlogs < ActiveRecord::Migration[8.2]
+  def change
+    add_reference :blogs, :notifications_email_address, foreign_key: { to_table: :sender_email_addresses, on_delete: :nullify }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_08_26_192016) do
+ActiveRecord::Schema[8.2].define(version: 2026_08_28_155939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -139,9 +139,11 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_26_192016) do
     t.string "password_digest"
     t.string "post_url_format", default: "flat", null: false
     t.string "post_url_prefix"
+    t.bigint "notifications_email_address_id"
     t.index ["api_key_digest"], name: "index_blogs_on_api_key_digest", unique: true
     t.index ["custom_domain"], name: "index_blogs_on_custom_domain", unique: true, where: "(custom_domain IS NOT NULL)"
     t.index ["home_page_id"], name: "index_blogs_on_home_page_id"
+    t.index ["notifications_email_address_id"], name: "index_blogs_on_notifications_email_address_id"
     t.index ["subdomain"], name: "index_blogs_on_subdomain", unique: true
     t.index ["user_id"], name: "index_blogs_on_user_id"
   end
@@ -460,6 +462,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_26_192016) do
   add_foreign_key "blog_exports", "blogs"
   add_foreign_key "blog_spotlight_exclusions", "blogs"
   add_foreign_key "blogs", "posts", column: "home_page_id", on_delete: :nullify
+  add_foreign_key "blogs", "sender_email_addresses", column: "notifications_email_address_id", on_delete: :nullify
   add_foreign_key "blogs", "users"
   add_foreign_key "contact_messages", "blogs"
   add_foreign_key "content_moderations", "posts"

--- a/docs/help-guide/account-settings.md
+++ b/docs/help-guide/account-settings.md
@@ -23,16 +23,16 @@ Set your time zone to display dates and times in your local time. This affects h
 
 Pagecord uses magic link emails by default – no password needed. If you prefer a password, click the link to set one via the forgot password flow.
 
-## Sender email addresses
+## Additional email addresses
 
-By default, you can only post by email from the address you signed up with. You can add up to 3 additional sender addresses:
+By default, Pagecord only uses the email address you signed up with. You can add up to 3 additional addresses:
 
 1. Enter the email address
-2. Click **Add Sender Email**
+2. Click **Add Email Address**
 3. Check that email for a verification link
 4. Click the link to confirm
 
-Once verified, you can post to your blog from that address too.
+Once verified, you can post to your blog from that address, and choose it to receive comment, reply and contact form notifications in **Settings** → **Audience**.
 
 ## Deleting your account
 

--- a/docs/help-guide/posting-by-email.md
+++ b/docs/help-guide/posting-by-email.md
@@ -65,7 +65,7 @@ The hashtags are extracted and converted to tags called **travel** and **japan**
 
 If your post doesn't appear:
 
-- Check the email was sent from the right email address. This must be the email address you signed up with! This is the most common issue people face. You can add up to three additional sender email addresses in the settings so you can publish from different addresses.Look in your spam folder for any bounce messages
+- Check the email was sent from the right email address. This must be the email address you signed up with! This is the most common issue people face. You can add up to three additional email addresses in the settings so you can publish from different addresses.Look in your spam folder for any bounce messages
 
 Posts from email are published immediately, unless you send them to your `+draft` address (see above). If you need to edit, you can do so in the app at any time.
 

--- a/test/controllers/app/settings/sender_email_addresses/verifications_controller_test.rb
+++ b/test/controllers/app/settings/sender_email_addresses/verifications_controller_test.rb
@@ -15,7 +15,7 @@ class App::Settings::SenderEmailAddresses::VerificationsControllerTest < ActionD
     get app_settings_sender_email_addresses_verification_path(token: sender.token_digest)
 
     assert_redirected_to edit_app_settings_account_path
-    assert_match "Sender email address has been verified", flash[:notice]
+    assert_match "Email address has been verified", flash[:notice]
 
     sender.reload
     assert sender.accepted?
@@ -48,7 +48,7 @@ class App::Settings::SenderEmailAddresses::VerificationsControllerTest < ActionD
     get app_settings_sender_email_addresses_verification_path(token: sender.token_digest)
 
     assert_redirected_to login_path
-    assert_match "Sender email address has been verified", flash[:notice]
+    assert_match "Email address has been verified", flash[:notice]
 
     sender.reload
     assert sender.accepted?
@@ -61,7 +61,7 @@ class App::Settings::SenderEmailAddresses::VerificationsControllerTest < ActionD
     get app_settings_sender_email_addresses_verification_path(token: sender.token_digest)
 
     assert_redirected_to edit_app_settings_account_path
-    assert_match "Sender email address has been verified", flash[:notice]
+    assert_match "Email address has been verified", flash[:notice]
 
     sender.reload
     assert sender.accepted?

--- a/test/controllers/app/settings/sender_email_addresses_controller_test.rb
+++ b/test/controllers/app/settings/sender_email_addresses_controller_test.rb
@@ -65,6 +65,6 @@ class App::Settings::SenderEmailAddressesControllerTest < ActionDispatch::Integr
     end
 
     assert_redirected_to edit_app_settings_account_path
-    assert_match "Sender email address has been removed", flash[:notice]
+    assert_match "Email address has been removed", flash[:notice]
   end
 end

--- a/test/mailers/reply_mailer_test.rb
+++ b/test/mailers/reply_mailer_test.rb
@@ -16,6 +16,15 @@ class ReplyMailerTest < ActionMailer::TestCase
     assert_match "Rails mailers", email.body.encoded
   end
 
+  test "sends to the notifications email address when set" do
+    reply = post_replies(:test)
+    reply.post.blog.update!(notifications_email_address: sender_email_addresses(:joel))
+
+    email = ReplyMailer.with(reply: reply).new_reply
+
+    assert_equal [ "joel@iamjoel.com" ], email.to
+  end
+
   test "formats multiline message correctly" do
     reply = post_replies(:test)
     email = ReplyMailer.with(reply: reply).new_reply

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -407,4 +407,31 @@ class BlogTest < ActiveSupport::TestCase
     assert blog.user.on_trial?
     assert blog.accepts_replies?
   end
+
+  test "notifications_email defaults to the account email" do
+    blog = blogs(:joel)
+
+    assert_equal blog.user.email, blog.notifications_email
+  end
+
+  test "notifications_email uses the chosen sender email address" do
+    blog = blogs(:joel)
+    blog.update!(notifications_email_address: sender_email_addresses(:joel))
+
+    assert_equal "joel@iamjoel.com", blog.notifications_email
+  end
+
+  test "notifications email address must belong to the blog" do
+    blog = blogs(:vivian)
+    blog.notifications_email_address = sender_email_addresses(:joel)
+
+    assert_not blog.valid?
+  end
+
+  test "notifications email address must be verified" do
+    blog = blogs(:joel)
+    blog.notifications_email_address = blog.sender_email_addresses.create!(email: "pending@example.com")
+
+    assert_not blog.valid?
+  end
 end


### PR DESCRIPTION
Comments, replies and contact form messages always went to the account email, with no way to change it. Requested in #1202, and something I've wanted myself.

Implements https://github.com/lylo/pagecord/issues/1204

## What changed

- `blogs.notifications_email_address_id`, a nullable FK to `sender_email_addresses` with `on_delete: :nullify`, so deleting the address falls back to the account email
- `Blog#notifications_email` returns the chosen address or `user.email`; `ReplyMailer`, `CommentMailer`, `ContactMailer` and `DigestReplyMailer` use it
- A validation that the address belongs to the blog and is verified, since Audience settings PATCH a shared endpoint
- An "Email Notifications" row in Audience settings: a select of verified addresses when you have any, otherwise a note pointing at My Account

## Behaviour changes

- Reader-generated mail (comments, replies, contact form, digest replies) can now go to a verified additional address. Account mail (billing, login, welcome) is unchanged.
- "Sender email addresses" are now "additional email addresses" throughout the UI, verification emails and help guide. They receive mail as well as send it now, so the old name was misleading. No data or route changes, `SenderEmailAddress` keeps its name internally.

Help guide changes need `help:sync` after this ships.