### PR TITLE
Previous and next post links

### DIFF
--- a/app/assets/stylesheets/blog-print.css
+++ b/app/assets/stylesheets/blog-print.css
@@ -18,6 +18,7 @@
   }
 
   nav,
+  .post-navigation,
   .post-actions,
   .email-subscriber-form,
   .email-form-container,

--- a/app/assets/stylesheets/blogs.css
+++ b/app/assets/stylesheets/blogs.css
@@ -527,6 +527,48 @@ footer.blog-footer #brand svg {
 }
 
 /* ============================= */
+/* Post Navigation               */
+/* ============================= */
+
+:where(.blog) {
+  :where(.post-navigation) {
+    display: flex;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-block: 0.5rem 2rem;
+    font-size: 0.875em;
+    line-height: 1.4;
+
+    a {
+      display: flex;
+      align-items: baseline;
+      gap: 0.5em;
+      max-width: 48%;
+      color: var(--color-accent);
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: var(--color-accent-hover);
+    }
+
+    .post-navigation-title {
+      text-decoration: underline;
+    }
+
+    .post-navigation-arrow {
+      flex-shrink: 0;
+      color: var(--color-text-muted);
+    }
+
+    .post-navigation-older {
+      margin-left: auto;
+      text-align: right;
+    }
+  }
+}
+
+/* ============================= */
 /* Forms                         */
 /* ============================= */
 

--- a/app/controllers/app/settings/blogs_controller.rb
+++ b/app/controllers/app/settings/blogs_controller.rb
@@ -23,6 +23,7 @@ class App::Settings::BlogsController < App::BaseController
         :show_metrics,
         :external_links_in_new_tab,
         :show_upvotes,
+        :show_post_navigation,
         :use_password,
         :password,
         :post_url_format,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -85,6 +85,14 @@ class Post < ApplicationRecord
     published_at.present? && published_at > Time.current
   end
 
+  def newer_post
+    blog.posts.visible.where("(published_at, id) > (?, ?)", published_at, id).ordered_by_published(:asc).first
+  end
+
+  def older_post
+    blog.posts.visible.where("(published_at, id) < (?, ?)", published_at, id).ordered_by_published.first
+  end
+
   def summary(limit: 64)
     return "" unless has_text_content?
     text_summary.truncate(limit, separator: /\s/)

--- a/app/views/app/settings/blogs/_form.html.erb
+++ b/app/views/app/settings/blogs/_form.html.erb
@@ -62,6 +62,17 @@
         </div>
       <% end %>
 
+      <%= settings_row "Post Navigation" do %>
+        <div class="flex gap-3">
+          <div class="flex h-6 shrink-0 items-center">
+            <%= styled_check_box form, :show_post_navigation, checked: @blog.show_post_navigation %>
+          </div>
+          <div>
+            <%= form.label :show_post_navigation, "Show links to previous and next posts at the bottom of each post", class: "text-slate-800 dark:text-slate-100" %>
+          </div>
+        </div>
+      <% end %>
+
       <% saved_password = persisted_value(@blog, :password_digest).present? %>
       <%= settings_row "Privacy", stacked: true do %>
         <div class="group">

--- a/app/views/blogs/posts/_post_navigation.html.erb
+++ b/app/views/blogs/posts/_post_navigation.html.erb
@@ -1,0 +1,18 @@
+<% newer = post.newer_post %>
+<% older = post.older_post %>
+<% if newer || older %>
+  <div class="post-navigation">
+    <% if newer %>
+      <%= link_to post_path(newer), class: "post-navigation-newer" do %>
+        <span class="post-navigation-arrow" aria-hidden="true">&larr;</span>
+        <span class="post-navigation-title"><%= newer.display_title %></span>
+      <% end %>
+    <% end %>
+    <% if older %>
+      <%= link_to post_path(older), class: "post-navigation-older" do %>
+        <span class="post-navigation-title"><%= older.display_title %></span>
+        <span class="post-navigation-arrow" aria-hidden="true">&rarr;</span>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/blogs/posts/show.html.erb
+++ b/app/views/blogs/posts/show.html.erb
@@ -16,6 +16,8 @@
 <%= render "blogs/posts/post", post: @post %>
 </div>
 
+<%= render "blogs/posts/post_navigation", post: @post if @blog.show_post_navigation? && @post.post? %>
+
 <%= render "blogs/email_subscriber_form" if @post.post? && @blog.show_subscription_in_footer? %>
 
 <%= render 'shared/analytics_tracking', post: @post %>

--- a/db/migrate/20260828163326_add_show_post_navigation_to_blogs.rb
+++ b/db/migrate/20260828163326_add_show_post_navigation_to_blogs.rb
@@ -1,0 +1,5 @@
+class AddShowPostNavigationToBlogs < ActiveRecord::Migration[8.2]
+  def change
+    add_column :blogs, :show_post_navigation, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_08_26_192016) do
+ActiveRecord::Schema[8.2].define(version: 2026_08_28_163326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -139,6 +139,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_26_192016) do
     t.string "password_digest"
     t.string "post_url_format", default: "flat", null: false
     t.string "post_url_prefix"
+    t.boolean "show_post_navigation", default: false, null: false
     t.index ["api_key_digest"], name: "index_blogs_on_api_key_digest", unique: true
     t.index ["custom_domain"], name: "index_blogs_on_custom_domain", unique: true, where: "(custom_domain IS NOT NULL)"
     t.index ["home_page_id"], name: "index_blogs_on_home_page_id"

--- a/test/controllers/app/settings/blogs_controller_test.rb
+++ b/test/controllers/app/settings/blogs_controller_test.rb
@@ -208,6 +208,13 @@ class App::Settings::BlogsControllerTest < ActionDispatch::IntegrationTest
     assert_equal false, @blog.reload.show_metrics
   end
 
+  test "should update show_post_navigation" do
+    patch app_settings_blog_url, params: { blog: { show_post_navigation: true } }, as: :turbo_stream
+
+    assert_redirected_to app_settings_url
+    assert_equal true, @blog.reload.show_post_navigation
+  end
+
   test "should update external links in new tab" do
     patch app_settings_blog_url, params: { blog: { external_links_in_new_tab: true } }, as: :turbo_stream
 

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -186,6 +186,45 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "turbo-frame#email_subscriber_form", count: 0
   end
 
+  test "should show post navigation links when enabled" do
+    @blog.update!(show_post_navigation: true)
+    post = posts(:two)
+
+    get blog_post_path(post.slug)
+
+    assert_response :success
+    assert_select ".post-navigation a.post-navigation-newer[href=?]", post_path(posts(:one))
+    assert_select ".post-navigation a.post-navigation-older[href=?]", post_path(posts(:photography_and_tech))
+  end
+
+  test "should not show post navigation when disabled" do
+    post = posts(:two)
+
+    get blog_post_path(post.slug)
+
+    assert_response :success
+    assert_select ".post-navigation", count: 0
+  end
+
+  test "should not show post navigation on pages" do
+    @blog.update!(show_post_navigation: true)
+
+    get blog_post_path(posts(:about).slug)
+
+    assert_response :success
+    assert_select ".post-navigation", count: 0
+  end
+
+  test "should only show older link on the newest post" do
+    @blog.update!(show_post_navigation: true)
+
+    get blog_post_path(posts(:one).slug)
+
+    assert_response :success
+    assert_select ".post-navigation a.post-navigation-newer", count: 0
+    assert_select ".post-navigation a.post-navigation-older[href=?]", post_path(posts(:two))
+  end
+
   test "should get show" do
     post = @blog.posts.visible.first
 

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -683,6 +683,39 @@ class PostTest < ActiveSupport::TestCase
     assert post.reload.update(title: "Renamed")
   end
 
+  test "newer_post and older_post return adjacent visible posts" do
+    post = posts(:two)
+
+    assert_equal posts(:one), post.newer_post
+    assert_equal posts(:photography_and_tech), post.older_post
+  end
+
+  test "newer_post is nil for the newest post and older_post is nil for the oldest" do
+    assert_nil posts(:one).newer_post
+    assert_nil posts(:joel_titleless).older_post
+  end
+
+  test "newer_post and older_post break published_at ties by id" do
+    a = posts(:photography_and_tech)
+    b = posts(:embeds)
+    b.update!(published_at: a.published_at)
+
+    older, newer = [ a, b ].sort_by(&:id)
+    assert_equal newer, older.newer_post
+    assert_equal older, newer.older_post
+  end
+
+  test "newer_post and older_post skip hidden posts" do
+    posts(:one).update!(hidden: true)
+
+    assert_nil posts(:two).newer_post
+  end
+
+  test "newer_post and older_post never return pages" do
+    assert_nil posts(:four).newer_post
+    assert_nil posts(:four).older_post
+  end
+
   test "a lapsed subscriber cannot add a new video" do
     blog = blogs(:joel)
     blog.user.subscription.update!(next_billed_at: 1.day.ago)


### PR DESCRIPTION
Adds an opt-in "Post Navigation" setting (off by default) that shows links to the previous and next post at the bottom of each post.

- New `show_post_navigation` boolean on blogs, toggled in Blog Settings.
- `Post#newer_post` / `#older_post` find neighbours among visible posts, ordered by `(published_at, id)` so same-timestamp posts (imports, bulk publishes) can't skip or loop.
- Rendered on the post page only (outside the fragment cache, so it never appears in the index stream). Newer post on the left, older on the right, muted arrows with the title as an accent link. Full titles wrap; `display_title` handles title-less posts.
- Uses a `div`, not `nav`, so theme rules targeting the header nav don't restyle it; hidden in print.
- No cache changes needed: publishing a post already touches `blog.updated_at`, which keys the etag and Cloudflare purge.

No behaviour change for existing blogs until the setting is enabled.