### PR TITLE
Record an account tombstone on every deletion

### DIFF
--- a/app/controllers/admin/moderation/spam/confirmations_controller.rb
+++ b/app/controllers/admin/moderation/spam/confirmations_controller.rb
@@ -3,7 +3,7 @@ class Admin::Moderation::Spam::ConfirmationsController < Admin::BaseController
     spam_detection = SpamDetection.find(params[:spam_id])
     spam_detection.mark_as_reviewed!
 
-    DestroyUserJob.perform_later(spam_detection.blog.user.id, spam: true)
+    DestroyUserJob.perform_later(spam_detection.blog.user.id, reason: :spam)
 
     redirect_to admin_moderation_spam_index_path, notice: "Spam confirmed and user will be discarded"
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -70,10 +70,10 @@ class Admin::UsersController < Admin::BaseController
 
     if params[:spam]
       flash[:notice] = "User was marked as spam and discarded"
-      DestroyUserJob.perform_now(@user.id, spam: true)
+      DestroyUserJob.perform_now(@user.id, reason: :spam)
     else
       flash[:notice] = "User was successfully discarded"
-      DestroyUserJob.perform_now(@user.id)
+      DestroyUserJob.perform_now(@user.id, reason: :admin_deleted)
     end
 
     redirect_to admin_users_path

--- a/app/jobs/destroy_user_job.rb
+++ b/app/jobs/destroy_user_job.rb
@@ -1,17 +1,21 @@
 class DestroyUserJob < ApplicationJob
   queue_as :default
 
-  def perform(user_id, options = {})
+  def perform(user_id, reason: :user_deleted)
     user = User.find(user_id)
     with_sentry_context(user: user, blog: user.blog) do
-      user.discard!
+      ActiveRecord::Base.transaction do
+        user.discard!
+        AccountTombstone.record!(user, reason: reason)
+      end
+
       user.blogs.find_each(&:touch)
 
       if user.subscription
         PaddleApi.new.cancel_subscription(user.subscription.paddle_subscription_id)
       end
 
-      if options[:spam]
+      if reason.to_s == "spam"
         create_spam_detection(user.blog)
         MarketingAutomation::DeleteContactJob.perform_later(user_id)
       end

--- a/app/models/account_tombstone.rb
+++ b/app/models/account_tombstone.rb
@@ -1,0 +1,18 @@
+# What survives when a discarded user is purged.
+class AccountTombstone < ApplicationRecord
+  enum :reason, {
+    user_deleted: "user_deleted",
+    spam: "spam",
+    admin_deleted: "admin_deleted"
+  }
+
+  def self.record!(user, reason:)
+    create!(
+      signed_up_at: user.created_at,
+      deleted_at: Time.current,
+      reason: reason,
+      plan: user.subscription&.plan,
+      subdomain: (user.blogs.pluck(:subdomain).join(" ").presence if reason.to_s == "spam")
+    )
+  end
+end

--- a/db/migrate/20260901120000_create_account_tombstones.rb
+++ b/db/migrate/20260901120000_create_account_tombstones.rb
@@ -1,0 +1,15 @@
+class CreateAccountTombstones < ActiveRecord::Migration[8.2]
+  def change
+    create_table :account_tombstones do |t|
+      t.datetime :signed_up_at, null: false
+      t.datetime :deleted_at, null: false
+      t.string :reason, null: false
+      t.string :plan
+      t.string :subdomain
+
+      t.timestamps
+    end
+
+    add_index :account_tombstones, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_08_26_192016) do
+ActiveRecord::Schema[8.2].define(version: 2026_09_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -26,6 +26,17 @@ ActiveRecord::Schema[8.2].define(version: 2026_08_26_192016) do
     t.index ["expires_at"], name: "index_access_requests_on_expires_at"
     t.index ["token_digest"], name: "index_access_requests_on_token_digest", unique: true
     t.index ["user_id"], name: "index_access_requests_on_user_id"
+  end
+
+  create_table "account_tombstones", force: :cascade do |t|
+    t.datetime "signed_up_at", null: false
+    t.datetime "deleted_at", null: false
+    t.string "reason", null: false
+    t.string "plan"
+    t.string "subdomain"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deleted_at"], name: "index_account_tombstones_on_deleted_at"
   end
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|

--- a/test/controllers/admin/moderation/spam/confirmations_controller_test.rb
+++ b/test/controllers/admin/moderation/spam/confirmations_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::Moderation::Spam::ConfirmationsControllerTest < ActionDispatch::Int
   test "marks the detection reviewed and queues user destruction" do
     detection = spam_detections(:spam_blog_detection)
 
-    assert_enqueued_with(job: DestroyUserJob, args: [ detection.blog.user.id, { spam: true } ]) do
+    assert_enqueued_with(job: DestroyUserJob, args: [ detection.blog.user.id, { reason: :spam } ]) do
       post admin_moderation_spam_confirmation_path(detection)
     end
 

--- a/test/jobs/destroy_user_job_test.rb
+++ b/test/jobs/destroy_user_job_test.rb
@@ -42,8 +42,49 @@ class DestroyUserJobTest < ActiveJob::TestCase
 
     assert_difference("EmailSubscriber.count", -1) do
       perform_enqueued_jobs do
-        DestroyUserJob.perform_now(@user.id, spam: true)
+        DestroyUserJob.perform_now(@user.id, reason: :spam)
       end
     end
+  end
+
+  test "records a tombstone naming why the account went" do
+    assert_difference -> { AccountTombstone.count }, 1 do
+      DestroyUserJob.perform_now(@user.id, reason: :spam)
+    end
+
+    assert AccountTombstone.last.spam?
+  end
+
+  test "distinguishes an admin removal from a self-serve deletion" do
+    DestroyUserJob.perform_now(@user.id, reason: :admin_deleted)
+
+    assert AccountTombstone.last.admin_deleted?
+  end
+
+  test "treats a deletion with no options as the user's own" do
+    DestroyUserJob.perform_now(@user.id)
+
+    assert AccountTombstone.last.user_deleted?
+  end
+
+  test "a retry cannot write a second tombstone" do
+    DestroyUserJob.perform_now(@user.id, reason: :spam)
+
+    assert_no_difference -> { AccountTombstone.count } do
+      assert_raises(Discard::RecordNotDiscarded) do
+        DestroyUserJob.perform_now(@user.id, reason: :spam)
+      end
+    end
+  end
+
+  test "a spam tombstone records every subdomain the user had" do
+    user = users(:joel)
+    mock_api = mock("paddle_api")
+    mock_api.stubs(:cancel_subscription).returns(true)
+    PaddleApi.stubs(:new).returns(mock_api)
+
+    DestroyUserJob.perform_now(user.id, reason: :spam)
+
+    assert_equal user.blogs.pluck(:subdomain).join(" "), AccountTombstone.last.subdomain
   end
 end

--- a/test/models/account_tombstone_test.rb
+++ b/test/models/account_tombstone_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class AccountTombstoneTest < ActiveSupport::TestCase
+  test "records dates and plan for a voluntary deletion, but names no blog" do
+    user = users(:annie)
+
+    tombstone = AccountTombstone.record!(user, reason: :user_deleted)
+
+    assert tombstone.user_deleted?
+    assert_equal user.created_at, tombstone.signed_up_at
+    assert_nil tombstone.subdomain
+  end
+
+  test "names the blogs on a spam deletion" do
+    user = users(:annie)
+
+    tombstone = AccountTombstone.record!(user, reason: :spam)
+
+    assert tombstone.spam?
+    assert_equal user.blogs.pluck(:subdomain).join(" "), tombstone.subdomain
+  end
+
+  test "records the plan of a paying account" do
+    tombstone = AccountTombstone.record!(users(:joel), reason: :user_deleted)
+
+    assert_equal users(:joel).subscription.plan, tombstone.plan
+  end
+
+  test "a returning spammer gets a second tombstone rather than a collision" do
+    user = users(:annie)
+
+    AccountTombstone.record!(user, reason: :spam)
+
+    assert_difference -> { AccountTombstone.count }, 1 do
+      AccountTombstone.record!(user, reason: :spam)
+    end
+  end
+end


### PR DESCRIPTION
Discarded users are hard-purged a week later by `accounts:purge_cancellations`, taking their blogs with them, so nothing survives to say why an account went. Free-plan churn is currently unrecoverable: Paddle and ProfitWell only cover the paid side.

`DestroyUserJob` is the single choke point for all three deletion paths, so one write covers every case.

**What changed**

- `DestroyUserJob.perform(user_id, reason: :user_deleted)` — the caller states the reason instead of passing opaque booleans
- `account_tombstones` records signup and deletion dates, plan, and reason
- Spam deletions also name the blogs; other deletions carry no identifiers
- `reason` is a string column, not an integer enum: this table exists to be queried ad hoc long after the code has moved on, and an integer mapping is exactly the thing that gets lost

**Behaviour changes**

None. Purely additive, and it accrues data from deploy — there is no backfill possible.

**Deploy note**

The job signature changed from `(user_id, options = {})` to a `reason:` keyword. A job enqueued before the deploy and run after it would raise `ArgumentError: unknown keyword :spam`. Account deletions are rare and the queue drains in seconds, so the window is small, but it is not zero — worth a glance at Sidekiq before deploying if one has just been triggered.

The discard and the tombstone write share a transaction, discard first, so a Sidekiq retry fails before it can write a duplicate.