### PR TITLE
Drop the spam_detections table

### DIFF
--- a/app/models/concerns/blog/robots_txt.rb
+++ b/app/models/concerns/blog/robots_txt.rb
@@ -12,7 +12,11 @@ module Blog::RobotsTxt
   end
 
   def crawlable?
-    allow_search_indexing? && !password_protected? && user.search_indexable?
+    allow_search_indexing? && !password_protected? && search_indexable?
+  end
+
+  def search_indexable?
+    reviewed_at.present? || user.subscribed?
   end
 
   def custom_robots_txt_active?

--- a/app/models/concerns/blog/spotlit.rb
+++ b/app/models/concerns/blog/spotlit.rb
@@ -14,6 +14,7 @@ module Blog::Spotlit
         .where(allow_search_indexing: true)
         .not_password_protected
         .where(users: { discarded_at: nil })
+        .where.not(reviewed_at: nil)
         .where("users.created_at <= ?", MINIMUM_ACCOUNT_AGE.ago)
         .where.missing(:spotlight_exclusion)
     }
@@ -27,9 +28,11 @@ module Blog::Spotlit
     end
   end
 
+  # The Spotlight is Pagecord's front page, so review is required even for paying users.
   def spotlit?
     allow_search_indexing? &&
       !password_protected? &&
+      reviewed_at.present? &&
       user.created_at <= MINIMUM_ACCOUNT_AGE.ago &&
       user.discarded_at.nil? &&
       spotlight_exclusion.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,10 +32,6 @@ class User < ApplicationRecord
     self.update! verified: true
   end
 
-  def search_indexable?
-    self.created_at&.before?(1.week.ago) || subscribed?
-  end
-
   def blog
     blogs.first
   end

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -50,7 +50,7 @@
     <%= javascript_importmap_tags "blog", importmap: Rails.application.config.importmap_blog %>
 
     <% if @blog.present? %>
-      <% unless @blog.user.search_indexable? %>
+      <% unless @blog.search_indexable? %>
         <meta name="robots" content="noindex, nofollow">
       <% else %>
         <%= yield :robots_meta %>

--- a/db/migrate/20260901130002_drop_spam_detections.rb
+++ b/db/migrate/20260901130002_drop_spam_detections.rb
@@ -1,0 +1,9 @@
+class DropSpamDetections < ActiveRecord::Migration[8.2]
+  def up
+    drop_table :spam_detections
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_09_01_130001) do
+ActiveRecord::Schema[8.2].define(version: 2026_09_01_130002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -374,19 +374,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_09_01_130001) do
     t.index ["token_digest"], name: "index_sender_email_addresses_on_token_digest", unique: true
   end
 
-  create_table "spam_detections", force: :cascade do |t|
-    t.bigint "blog_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "detected_at"
-    t.string "model_version"
-    t.text "reason"
-    t.datetime "reviewed_at"
-    t.integer "status", default: 0, null: false
-    t.datetime "updated_at", null: false
-    t.index ["blog_id", "detected_at"], name: "index_spam_detections_on_blog_id_and_detected_at", order: { detected_at: :desc }
-    t.index ["status"], name: "index_spam_detections_on_status"
-  end
-
   create_table "subscription_renewal_reminders", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "period", null: false
@@ -496,7 +483,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_09_01_130001) do
   add_foreign_key "post_replies", "posts"
   add_foreign_key "posts", "blogs"
   add_foreign_key "sender_email_addresses", "blogs"
-  add_foreign_key "spam_detections", "blogs"
   add_foreign_key "subscription_renewal_reminders", "subscriptions"
   add_foreign_key "subscriptions", "users"
   add_foreign_key "unengaged_follow_ups", "users"

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -856,22 +856,23 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should initially prevent free blogs from being indexed" do
+  test "should prevent unreviewed free blogs from being indexed" do
     @blog = blogs(:vivian)
-    @blog.user.update!(created_at: 1.day.ago)
+    @blog.update!(reviewed_at: nil)
     host_subdomain! @blog.subdomain
 
     get blog_posts_path
 
-    assert @blog.user.created_at.after?(1.week.ago)
     assert_not @blog.user.subscribed?
     assert_select 'meta[name="robots"][content="noindex, nofollow"]'
   end
 
-  test "should not prevent new subscribed blogs from being indexed" do
+  test "should not prevent unreviewed subscribed blogs from being indexed" do
+    @blog.update!(reviewed_at: nil)
+
     get blog_posts_path
 
-    assert @blog.created_at.after?(1.week.ago)
+    assert @blog.user.subscribed?
     assert_select 'meta[name="robots"][content="noindex, nofollow"]', count: 0
   end
 

--- a/test/models/blog/spotlit_test.rb
+++ b/test/models/blog/spotlit_test.rb
@@ -67,4 +67,12 @@ class Blog::SpotlitTest < ActiveSupport::TestCase
   test "include_in_spotlight is a no-op when not excluded" do
     assert_nothing_raised { @blog.include_in_spotlight }
   end
+
+  test "an unreviewed blog is not spotlit" do
+    blog = blogs(:joel)
+    blog.update!(reviewed_at: nil)
+
+    assert_not blog.spotlit?
+    assert_not_includes Blog.spotlit, blog
+  end
 end

--- a/test/models/concerns/blog/robots_txt_test.rb
+++ b/test/models/concerns/blog/robots_txt_test.rb
@@ -78,7 +78,25 @@ class Blog::RobotsTxtTest < ActiveSupport::TestCase
     assert_not blog.crawlable?
 
     blog.update!(allow_search_indexing: true)
-    blog.user.stubs(:search_indexable?).returns(false)
+    blog.stubs(:search_indexable?).returns(false)
     assert_not blog.crawlable?
+  end
+
+  test "search_indexable? waits for review" do
+    blog = blogs(:elliot)
+    blog.update!(reviewed_at: nil)
+
+    assert_not blog.search_indexable?
+
+    blog.update!(reviewed_at: Time.current)
+    assert blog.search_indexable?
+  end
+
+  test "search_indexable? skips the wait for a paying user" do
+    blog = blogs(:joel)
+    blog.update!(reviewed_at: nil)
+
+    assert blog.user.subscribed?
+    assert blog.search_indexable?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -19,22 +19,6 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "newuser@newuser.com", user.email
   end
 
-  test "should be search indexable if created_at is more than 1 week ago" do
-    user = User.create!(email: "test@example.com", created_at: 2.weeks.ago)
-    assert user.search_indexable?
-  end
-
-  test "should not be search indexable if created_at is less than 1 week ago" do
-    user = User.create!(email: "test@example.com", created_at: 6.days.ago)
-    assert_not user.search_indexable?
-  end
-
-  test "should be search indexable if created_at is less than 1 week ago but user subscribed" do
-    user = users(:joel)
-    user.update!(created_at: 6.days.ago)
-    assert user.search_indexable?
-  end
-
   # Free trial tests
   test "on_trial? returns true when user created within 14 days and not subscribed" do
     user = User.create!(email: "trial@example.com", created_at: 5.days.ago)


### PR DESCRIPTION
Stacked on #1213. Merge last, and only once the queue has been running for a while.

Nothing has referenced the table since #1212. **Irreversible** — the migration raises on `down`, and it takes the eleven manual spam marks with it. Export them first if that history is worth keeping:

```ruby
SpamDetection.where.not(status: "clean").includes(:blog).map { |d| [ d.blog.subdomain, d.status, d.reason, d.detected_at ] }
```