### PR TITLE
Remove an account tombstone when the account is restored

### DIFF
--- a/app/models/account_tombstone.rb
+++ b/app/models/account_tombstone.rb
@@ -8,6 +8,7 @@ class AccountTombstone < ApplicationRecord
 
   def self.record!(user, reason:)
     create!(
+      user_id: user.id,
       signed_up_at: user.created_at,
       deleted_at: Time.current,
       reason: reason,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,9 @@ class User < ApplicationRecord
       )
   }
 
+  # Restoring an account unmakes its deletion, so the tombstone goes too.
+  after_undiscard -> { AccountTombstone.where(user_id: id).delete_all }
+
   validates :password, length: { minimum: 12 }, confirmation: true, allow_blank: true
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   normalizes :email, with: -> { it.downcase.strip }

--- a/db/migrate/20260901130000_add_user_to_account_tombstones.rb
+++ b/db/migrate/20260901130000_add_user_to_account_tombstones.rb
@@ -1,0 +1,6 @@
+class AddUserToAccountTombstones < ActiveRecord::Migration[8.2]
+  def change
+    add_column :account_tombstones, :user_id, :bigint
+    add_index :account_tombstones, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_09_01_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_09_01_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -36,7 +36,9 @@ ActiveRecord::Schema[8.2].define(version: 2026_09_01_120000) do
     t.string "subdomain"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["deleted_at"], name: "index_account_tombstones_on_deleted_at"
+    t.index ["user_id"], name: "index_account_tombstones_on_user_id"
   end
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|

--- a/test/controllers/admin/users/restorations_controller_test.rb
+++ b/test/controllers/admin/users/restorations_controller_test.rb
@@ -33,4 +33,14 @@ class Admin::Users::RestorationsControllerTest < ActionDispatch::IntegrationTest
     assert_operator user.blog.reload.updated_at, :>, old_time
     assert_operator second_blog.reload.updated_at, :>, old_time
   end
+
+  test "restoring through the admin button clears the tombstone" do
+    user = users(:annie)
+    AccountTombstone.record!(user, reason: :spam)
+    user.discard!
+
+    assert_difference -> { AccountTombstone.count }, -1 do
+      post admin_user_restoration_path(user)
+    end
+  end
 end

--- a/test/models/account_tombstone_test.rb
+++ b/test/models/account_tombstone_test.rb
@@ -35,4 +35,24 @@ class AccountTombstoneTest < ActiveSupport::TestCase
       AccountTombstone.record!(user, reason: :spam)
     end
   end
+
+  test "restoring the account removes its tombstone" do
+    user = users(:annie)
+    AccountTombstone.record!(user, reason: :spam)
+    user.discard!
+
+    assert_difference -> { AccountTombstone.count }, -1 do
+      user.undiscard!
+    end
+  end
+
+  test "restoring one account leaves another's tombstone alone" do
+    AccountTombstone.record!(users(:annie), reason: :spam)
+    other = users(:vivian)
+    other.discard!
+
+    assert_no_difference -> { AccountTombstone.count } do
+      other.undiscard!
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #1211.

`Admin::Users::RestorationsController` gives a one-click Restore on `/admin/users/:id`. Marking someone as spam by mistake and restoring them left the tombstone behind, permanently counting a deletion that never happened — the silent-wrong-number failure the table exists to avoid.

Tombstones had no `user_id` (deliberately, so they survive the purge), so `undiscard` had nothing to match on. This adds one.

**What changed**

- `account_tombstones.user_id`, nullable and with no foreign key: it has to outlive the user row, at which point it is a dangling id rather than a reference
- `after_undiscard` on `User` deletes any tombstone for that id, so console undiscards are covered too, not just the admin button

**Why not write the tombstone at purge time instead**

That was the first instinct, but `User.purgeable_discarded` skips users whose subscription has not lapsed, so a paying customer's churn record would be delayed until their billing period ended — up to a year on an annual plan. It would also depend on the purge task continuing to use `destroy_all` rather than `delete_all`, and a silent absence of records is worse than a stray one.