### PR TITLE
Gate search indexing and the Spotlight on review

### DIFF
--- a/app/models/concerns/blog/robots_txt.rb
+++ b/app/models/concerns/blog/robots_txt.rb
@@ -12,7 +12,11 @@ module Blog::RobotsTxt
   end
 
   def crawlable?
-    allow_search_indexing? && !password_protected? && user.search_indexable?
+    allow_search_indexing? && !password_protected? && search_indexable?
+  end
+
+  def search_indexable?
+    reviewed_at.present? || user.subscribed?
   end
 
   def custom_robots_txt_active?

--- a/app/models/concerns/blog/spotlit.rb
+++ b/app/models/concerns/blog/spotlit.rb
@@ -14,6 +14,7 @@ module Blog::Spotlit
         .where(allow_search_indexing: true)
         .not_password_protected
         .where(users: { discarded_at: nil })
+        .where.not(reviewed_at: nil)
         .where("users.created_at <= ?", MINIMUM_ACCOUNT_AGE.ago)
         .where.missing(:spotlight_exclusion)
     }
@@ -30,6 +31,7 @@ module Blog::Spotlit
   def spotlit?
     allow_search_indexing? &&
       !password_protected? &&
+      reviewed_at.present? &&
       user.created_at <= MINIMUM_ACCOUNT_AGE.ago &&
       user.discarded_at.nil? &&
       spotlight_exclusion.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,10 +32,6 @@ class User < ApplicationRecord
     self.update! verified: true
   end
 
-  def search_indexable?
-    self.created_at&.before?(1.week.ago) || subscribed?
-  end
-
   def blog
     blogs.first
   end

--- a/app/views/layouts/blog.html.erb
+++ b/app/views/layouts/blog.html.erb
@@ -50,7 +50,7 @@
     <%= javascript_importmap_tags "blog", importmap: Rails.application.config.importmap_blog %>
 
     <% if @blog.present? %>
-      <% unless @blog.user.search_indexable? %>
+      <% unless @blog.search_indexable? %>
         <meta name="robots" content="noindex, nofollow">
       <% else %>
         <%= yield :robots_meta %>

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -856,22 +856,23 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should initially prevent free blogs from being indexed" do
+  test "should prevent unreviewed free blogs from being indexed" do
     @blog = blogs(:vivian)
-    @blog.user.update!(created_at: 1.day.ago)
+    @blog.update!(reviewed_at: nil)
     host_subdomain! @blog.subdomain
 
     get blog_posts_path
 
-    assert @blog.user.created_at.after?(1.week.ago)
     assert_not @blog.user.subscribed?
     assert_select 'meta[name="robots"][content="noindex, nofollow"]'
   end
 
-  test "should not prevent new subscribed blogs from being indexed" do
+  test "should not prevent unreviewed subscribed blogs from being indexed" do
+    @blog.update!(reviewed_at: nil)
+
     get blog_posts_path
 
-    assert @blog.created_at.after?(1.week.ago)
+    assert @blog.user.subscribed?
     assert_select 'meta[name="robots"][content="noindex, nofollow"]', count: 0
   end
 

--- a/test/models/blog/spotlit_test.rb
+++ b/test/models/blog/spotlit_test.rb
@@ -67,4 +67,12 @@ class Blog::SpotlitTest < ActiveSupport::TestCase
   test "include_in_spotlight is a no-op when not excluded" do
     assert_nothing_raised { @blog.include_in_spotlight }
   end
+
+  test "an unreviewed blog is not spotlit" do
+    blog = blogs(:joel)
+    blog.update!(reviewed_at: nil)
+
+    assert_not blog.spotlit?
+    assert_not_includes Blog.spotlit, blog
+  end
 end

--- a/test/models/concerns/blog/robots_txt_test.rb
+++ b/test/models/concerns/blog/robots_txt_test.rb
@@ -78,7 +78,25 @@ class Blog::RobotsTxtTest < ActiveSupport::TestCase
     assert_not blog.crawlable?
 
     blog.update!(allow_search_indexing: true)
-    blog.user.stubs(:search_indexable?).returns(false)
+    blog.stubs(:search_indexable?).returns(false)
     assert_not blog.crawlable?
+  end
+
+  test "search_indexable? waits for review" do
+    blog = blogs(:elliot)
+    blog.update!(reviewed_at: nil)
+
+    assert_not blog.search_indexable?
+
+    blog.update!(reviewed_at: Time.current)
+    assert blog.search_indexable?
+  end
+
+  test "search_indexable? skips the wait for a paying user" do
+    blog = blogs(:joel)
+    blog.update!(reviewed_at: nil)
+
+    assert blog.user.subscribed?
+    assert blog.search_indexable?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -19,22 +19,6 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "newuser@newuser.com", user.email
   end
 
-  test "should be search indexable if created_at is more than 1 week ago" do
-    user = User.create!(email: "test@example.com", created_at: 2.weeks.ago)
-    assert user.search_indexable?
-  end
-
-  test "should not be search indexable if created_at is less than 1 week ago" do
-    user = User.create!(email: "test@example.com", created_at: 6.days.ago)
-    assert_not user.search_indexable?
-  end
-
-  test "should be search indexable if created_at is less than 1 week ago but user subscribed" do
-    user = users(:joel)
-    user.update!(created_at: 6.days.ago)
-    assert user.search_indexable?
-  end
-
   # Free trial tests
   test "on_trial? returns true when user created within 14 days and not subscribed" do
     user = User.create!(email: "trial@example.com", created_at: 5.days.ago)


### PR DESCRIPTION
Replaces #1213, which GitHub auto-closed when its base branch was deleted on merge of #1212.

This is the PR with customer-visible behaviour. Merge it only once the queue from #1212 has been in use for a while and you are keeping up with it weekly.

**What changed**

- `search_indexable?` moves from `User` to `Blog`: `reviewed_at.present? || user.subscribed?`
- An unreviewed free blog serves `noindex, nofollow` and a blocking `robots.txt` until cleared in the queue
- `Blog.spotlit` and `spotlit?` require `reviewed_at`

**Behaviour changes**

The old rule made every blog indexable exactly a week after signup regardless of anything. Now review is the gate. Reviewing weekly means blogs clear somewhere between day 0 and day 7, so on average they are indexed sooner than today and never later — but it depends on keeping up, where the old rule was automatic.

Paying still skips the wait entirely. The Spotlight deliberately does not honour that bypass: it is Pagecord's front page rather than the blog's own, and account age alone was letting an unreviewed blog be featured.

**Risk**

Revert the commit to restore the old behaviour without touching the queue. The revert is instant but re-indexing by Google is not, so the recovery lags the rollback.

No migration.