### PR TITLE
Drop the spam_detections table

### DIFF
--- a/db/migrate/20260902090001_drop_spam_detections.rb
+++ b/db/migrate/20260902090001_drop_spam_detections.rb
@@ -1,0 +1,9 @@
+class DropSpamDetections < ActiveRecord::Migration[8.2]
+  def up
+    drop_table :spam_detections
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_09_02_090000) do
+ActiveRecord::Schema[8.2].define(version: 2026_09_02_090001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -374,19 +374,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_09_02_090000) do
     t.index ["token_digest"], name: "index_sender_email_addresses_on_token_digest", unique: true
   end
 
-  create_table "spam_detections", force: :cascade do |t|
-    t.bigint "blog_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "detected_at"
-    t.string "model_version"
-    t.text "reason"
-    t.datetime "reviewed_at"
-    t.integer "status", default: 0, null: false
-    t.datetime "updated_at", null: false
-    t.index ["blog_id", "detected_at"], name: "index_spam_detections_on_blog_id_and_detected_at", order: { detected_at: :desc }
-    t.index ["status"], name: "index_spam_detections_on_status"
-  end
-
   create_table "subscription_renewal_reminders", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "period", null: false
@@ -496,7 +483,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_09_02_090000) do
   add_foreign_key "post_replies", "posts"
   add_foreign_key "posts", "blogs"
   add_foreign_key "sender_email_addresses", "blogs"
-  add_foreign_key "spam_detections", "blogs", on_delete: :cascade
   add_foreign_key "subscription_renewal_reminders", "subscriptions"
   add_foreign_key "subscriptions", "users"
   add_foreign_key "unengaged_follow_ups", "users"

--- a/test/models/blog_test.rb
+++ b/test/models/blog_test.rb
@@ -152,19 +152,6 @@ class BlogTest < ActiveSupport::TestCase
     assert_empty EmailSubscriber.where(blog_id: @blog.id)
   end
 
-  test "should destroy leftover spam detections on destroy" do
-    ActiveRecord::Base.connection.execute(
-      "INSERT INTO spam_detections (blog_id, status, created_at, updated_at) " \
-      "VALUES (#{@blog.id}, 0, NOW(), NOW())"
-    )
-
-    @blog.destroy!
-
-    assert_equal 0, ActiveRecord::Base.connection.select_value(
-      "SELECT COUNT(*) FROM spam_detections WHERE blog_id = #{@blog.id}"
-    )
-  end
-
   test "should validate google site verification" do
     @blog.google_site_verification = "GzmHXW-PA_FXh29Dp31_cgsIx6ZY_h9OgR6r8DZ0I44"
     assert @blog.valid?


### PR DESCRIPTION
Replaces #1214, which GitHub auto-closed when its base branch was deleted on merge of the indexing gate.

Nothing has referenced the table since the review queue replaced the AI classifier. `blogs.reviewed_at` carries the state now, and a confirmed spam blog leaves the queue because its user is discarded.

**Irreversible.** The migration raises on `down`, and the drop takes the eleven manual spam marks with it. Export them first if that history is worth keeping:

```ruby
SpamDetection.where.not(status: "clean").includes(:blog).map { |d| [ d.blog.subdomain, d.status, d.reason, d.detected_at ] }
```

No rush on this one — an unused table costs nothing, so it is worth leaving until the queue has proved itself over a few weeks.