### PR TITLE
Offer to expand a pasted link into a preview

### DIFF
--- a/app/assets/stylesheets/lexxy-editor-overrides.css
+++ b/app/assets/stylesheets/lexxy-editor-overrides.css
@@ -353,3 +353,37 @@ lexxy-link-dropdown {
 .lexxy-editor__content .media-embed > * {
   pointer-events: none;
 }
+
+/* ================================== */
+/* Link Unfurls                       */
+/* ================================== */
+
+/* The prompt under a freshly pasted link offering to expand it into a preview.
+   Editor chrome only: the stored post holds the bare link until a preview is
+   chosen, so nothing here appears on the blog. */
+.lexxy-editor__content .link-unfurl {
+  margin-block: 0 var(--lexxy-content-margin);
+}
+
+.lexxy-editor__content .link-unfurl__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--lexxy-toolbar-gap);
+  margin-top: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--lexxy-color-text-subtle);
+}
+
+.lexxy-editor__content .link-unfurl__actions button {
+  padding: 0.125rem 0.5rem;
+  border: 1px solid var(--lexxy-color-ink-lighter);
+  border-radius: var(--lexxy-radius);
+  background: var(--lexxy-color-canvas);
+  color: var(--lexxy-color-text);
+  font-size: inherit;
+  cursor: pointer;
+}
+
+.lexxy-editor__content .link-unfurl__actions button:hover {
+  background: var(--lexxy-color-ink-lightest);
+}

--- a/app/controllers/app/link_previews_controller.rb
+++ b/app/controllers/app/link_previews_controller.rb
@@ -1,0 +1,30 @@
+class App::LinkPreviewsController < App::BaseController
+  rate_limit to: 10, within: 1.minute, by: -> { Current.user.id }
+
+  def create
+    preview = LinkPreview.new(params.expect(:url)).fetch
+    blob = preview.create_image_blob(allowed_content_types: Current.user.upload_quota.allowed_content_types)
+
+    render json: {
+      title: preview.title,
+      description: preview.description,
+      image: blob && image_json(blob, preview)
+    }
+  rescue => e
+    Rails.logger.info "Link preview failed for #{params[:url]}: #{e.message}"
+    head :unprocessable_entity
+  end
+
+  private
+
+    def image_json(blob, preview)
+      {
+        attachable_sgid: blob.attachable_sgid,
+        url: url_for(blob),
+        content_type: blob.content_type,
+        filename: blob.filename.to_s,
+        width: preview.image_width,
+        height: preview.image_height
+      }
+    end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,10 +7,11 @@ import CalloutExtension from "editor/callout_extension"
 import EmbedExtension from "editor/embed_extension"
 import FootnoteExtension from "editor/footnote_extension"
 import ToolbarOrderExtension from "editor/toolbar_order_extension"
+import UnfurlExtension from "editor/unfurl_extension"
 import "@rails/actiontext"
 
 // ToolbarOrderExtension last: it rearranges the buttons the others have added.
-Lexxy.configure({ global: { extensions: [ CalloutExtension, EmbedExtension, FootnoteExtension, ToolbarOrderExtension ] } })
+Lexxy.configure({ global: { extensions: [ CalloutExtension, EmbedExtension, UnfurlExtension, FootnoteExtension, ToolbarOrderExtension ] } })
 
 import LocalTime from "local-time"
 

--- a/app/javascript/editor/embed_node.js
+++ b/app/javascript/editor/embed_node.js
@@ -137,7 +137,7 @@ export function $embedLinkParagraph(paragraph) {
 // selection pointing at a node that no longer exists. Lexical resolves that by
 // dropping the selection, and the embed goes with it, so the caret has to be given
 // somewhere to land, which at the end of a post means a new paragraph.
-function $moveCaretAfter(embed) {
+export function $moveCaretAfter(embed) {
   const next = embed.getNextSibling()
 
   if (next) {

--- a/app/javascript/editor/unfurl_extension.js
+++ b/app/javascript/editor/unfurl_extension.js
@@ -1,0 +1,66 @@
+import * as Lexxy from "lexxy"
+import { UnfurlNode, $createUnfurlNode } from "editor/unfurl_node"
+import { $moveCaretAfter } from "editor/embed_node"
+import { isSameTarget, matchingSite, mediaSites } from "media_sites"
+
+const { ParagraphNode, PASTE_COMMAND, COMMAND_PRIORITY_CRITICAL } = Lexxy.Lexical
+
+// Every media site, not just the editor's subset: a Strava or image link embeds
+// on the published blog, so offering to unfurl it would promise one thing and
+// render another.
+const SITES = mediaSites()
+
+// Offers to expand a pasted link into a preview of what it points at. Pasting
+// is the only trigger, so opening an old post never sprouts prompts over links
+// the author already chose to leave alone.
+export default class UnfurlExtension extends Lexxy.Extension {
+  get enabled() {
+    return this.editorElement.supportsRichText
+  }
+
+  get lexicalExtension() {
+    // The URL the last paste consisted of, if that is all it was. The paste
+    // settles into a link node asynchronously, so the transform matches on the
+    // URL itself rather than trying to catch the right update.
+    let pastedUrl = null
+
+    return this.defineExtension({
+      name: "pagecord/link-unfurls",
+      nodes: [ UnfurlNode ],
+      register(editor) {
+        const unregisterPaste = editor.registerCommand(PASTE_COMMAND, (event) => {
+          const text = event.clipboardData?.getData("text/plain")?.trim()
+          pastedUrl = text?.match(/^https:\/\/\S+$/) ? text : null
+          return false
+        }, COMMAND_PRIORITY_CRITICAL)
+
+        const unregisterTransform = editor.registerNodeTransform(ParagraphNode, (paragraph) => {
+          if (pastedUrl && $offerUnfurl(paragraph, pastedUrl)) pastedUrl = null
+        })
+
+        return () => {
+          unregisterPaste()
+          unregisterTransform()
+        }
+      }
+    })
+  }
+}
+
+function $offerUnfurl(paragraph, url) {
+  const children = paragraph.getChildren()
+  if (children.length !== 1) return false
+  if (!isUnfurlableLinkNode(children[0], url)) return false
+
+  const prompt = $createUnfurlNode(children[0].getURL())
+  paragraph.replace(prompt)
+  $moveCaretAfter(prompt)
+  return true
+}
+
+function isUnfurlableLinkNode(node, url) {
+  return node.getType() === "link" &&
+    isSameTarget(node.getURL(), url) &&
+    isSameTarget(node.getURL(), node.getTextContent().trim()) &&
+    matchingSite(node.getURL(), SITES) === null
+}

--- a/app/javascript/editor/unfurl_node.js
+++ b/app/javascript/editor/unfurl_node.js
@@ -1,0 +1,192 @@
+import * as Lexxy from "lexxy"
+
+const { DecoratorNode, $applyNodeReplacement, $getNodeByKey } = Lexxy.Lexical
+
+// The prompt under a freshly pasted link asking whether to expand it into a
+// preview. Never stored: exportDOM hands back the paragraph and link, so a post
+// saved with the question still open holds nothing but the link. Expanding
+// replaces the node with ordinary content built from the link's Open Graph
+// tags: the image as a regular attachment, the title as a bold link, the
+// description as a paragraph, each editable and deletable on its own.
+export class UnfurlNode extends DecoratorNode {
+  __url
+
+  static getType() {
+    return "link-unfurl"
+  }
+
+  static clone(node) {
+    return new UnfurlNode(node.__url, node.__key)
+  }
+
+  static importJSON(serializedNode) {
+    return $createUnfurlNode(serializedNode.url).updateFromJSON(serializedNode)
+  }
+
+  constructor(url, key) {
+    super(key)
+    this.__url = url
+  }
+
+  isInline() {
+    return false
+  }
+
+  createDOM(_config, editor) {
+    const element = document.createElement("div")
+    element.className = "link-unfurl"
+    element.appendChild(linkTo(this.__url))
+    element.appendChild(this.#createActions(editor))
+    return element
+  }
+
+  updateDOM() {
+    return false
+  }
+
+  exportDOM() {
+    const paragraph = document.createElement("p")
+    paragraph.appendChild(linkTo(this.__url))
+
+    return { element: paragraph }
+  }
+
+  exportJSON() {
+    return { ...super.exportJSON(), url: this.__url }
+  }
+
+  decorate() {
+    return null
+  }
+
+  #createActions(editor) {
+    const actions = document.createElement("div")
+    actions.className = "link-unfurl__actions"
+    actions.append(
+      button("Show preview", () => this.#expand(editor, actions)),
+      button("Dismiss", () => this.#replaceWith(editor, linkParagraphHtml(this.__url)))
+    )
+    return actions
+  }
+
+  async #expand(editor, actions) {
+    actions.replaceChildren("Fetching preview…")
+
+    const preview = await fetchPreview(this.__url)
+
+    if (preview) {
+      this.#replaceWith(editor, previewHtml(this.__url, preview))
+    } else {
+      actions.replaceChildren("No preview available")
+      setTimeout(() => this.#replaceWith(editor, linkParagraphHtml(this.__url)), 2000)
+    }
+  }
+
+  #replaceWith(editor, html) {
+    const editorElement = editor.getRootElement().closest("lexxy-editor")
+
+    editor.update(() => {
+      const node = $getNodeByKey(this.getKey())
+      if (!node) return
+
+      const doc = new DOMParser().parseFromString(html, "text/html")
+      const replacements = editorElement.$generateNodesFromDOM(doc)
+
+      let previous = node
+      for (const replacement of replacements) {
+        previous.insertAfter(replacement)
+        previous = replacement
+      }
+      node.remove()
+
+      previous.selectEnd()
+    })
+  }
+}
+
+function linkTo(url) {
+  const link = document.createElement("a")
+  link.setAttribute("href", url)
+  link.textContent = url
+
+  return link
+}
+
+function button(label, action) {
+  const element = document.createElement("button")
+  element.type = "button"
+  element.textContent = label
+
+  // The clicks stay in the prompt: reaching Lexical's own click handling would
+  // select the node the action is busy replacing, and the whole update batch
+  // rolls back.
+  element.addEventListener("mousedown", (event) => event.stopPropagation())
+  element.addEventListener("click", (event) => {
+    event.preventDefault()
+    event.stopPropagation()
+    action()
+  })
+
+  return element
+}
+
+function linkParagraphHtml(url) {
+  const paragraph = document.createElement("p")
+  paragraph.appendChild(linkTo(url))
+
+  return paragraph.outerHTML
+}
+
+// Built from DOM elements rather than an interpolated string, because the title
+// and description are whatever the fetched page put in its meta tags.
+function previewHtml(url, preview) {
+  const container = document.createElement("div")
+
+  if (preview.image) {
+    const attachment = document.createElement("action-text-attachment")
+    attachment.setAttribute("sgid", preview.image.attachable_sgid)
+    attachment.setAttribute("url", preview.image.url)
+    attachment.setAttribute("content-type", preview.image.content_type)
+    attachment.setAttribute("filename", preview.image.filename)
+    if (preview.image.width) attachment.setAttribute("width", preview.image.width)
+    if (preview.image.height) attachment.setAttribute("height", preview.image.height)
+    container.appendChild(attachment)
+  }
+
+  const caption = document.createElement("p")
+  const strong = document.createElement("strong")
+  strong.appendChild(Object.assign(linkTo(url), { textContent: preview.title }))
+  caption.appendChild(strong)
+
+  if (preview.description) {
+    caption.appendChild(document.createElement("br"))
+    caption.appendChild(document.createTextNode(preview.description))
+  }
+
+  container.appendChild(caption)
+
+  return container.innerHTML
+}
+
+async function fetchPreview(url) {
+  try {
+    const token = document.querySelector('[name="csrf-token"]')?.content
+    const response = await fetch("/app/link_previews", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token && { "X-CSRF-Token": token })
+      },
+      body: JSON.stringify({ url })
+    })
+
+    if (!response.ok) return null
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+export function $createUnfurlNode(url) {
+  return $applyNodeReplacement(new UnfurlNode(url))
+}

--- a/app/models/link_preview.rb
+++ b/app/models/link_preview.rb
@@ -1,0 +1,114 @@
+require "open-uri"
+require "resolv"
+require "fastimage"
+
+# The Open Graph title, description and image behind a link the author has
+# asked to expand into a preview. The URL is author-supplied, so every fetch,
+# redirects and the image included, is refused unless the host resolves to a
+# public address.
+class LinkPreview
+  class Error < StandardError; end
+
+  MAX_HTML_BYTES = 500.kilobytes
+  MAX_REDIRECTS = 3
+
+  IMAGE_CONTENT_TYPES = {
+    jpeg: "image/jpeg",
+    png: "image/png",
+    gif: "image/gif",
+    webp: "image/webp"
+  }.freeze
+
+  BLOCKED_RANGES = %w[
+    0.0.0.0/8 10.0.0.0/8 100.64.0.0/10 127.0.0.0/8 169.254.0.0/16
+    172.16.0.0/12 192.168.0.0/16 224.0.0.0/3
+    ::1/128 fc00::/7 fe80::/10 ::ffff:0:0/96
+  ].map { |range| IPAddr.new(range) }.freeze
+
+  attr_reader :title, :description, :image_width, :image_height
+
+  def initialize(url)
+    @url = url
+  end
+
+  def fetch
+    doc = Nokogiri::HTML(read_page(@url))
+
+    @title = (meta(doc, "og:title") || doc.at("title")&.text&.strip).presence
+    @description = meta(doc, "og:description")
+    @image_url = meta(doc, "og:image")
+
+    raise Error, "No title found" if @title.nil?
+
+    self
+  end
+
+  # nil rather than an error when the image is missing, oversized or not
+  # allowed: a preview without a picture is still worth inserting.
+  def create_image_blob(allowed_content_types:)
+    return if @image_url.blank?
+
+    url = URI.join(@url, @image_url).to_s
+    content_type = image_content_type(url)
+    return unless content_type && allowed_content_types.include?(content_type)
+
+    io = download(url, limit: UploadLimits::CONTENT_TYPES[content_type])
+    ActiveStorage::Blob.create_and_upload!(io: io, filename: image_filename(url, content_type), content_type: content_type)
+  rescue Error, URI::Error, OpenURI::HTTPError
+    nil
+  end
+
+  private
+
+    def meta(doc, property)
+      doc.at("meta[property=\"#{property}\"]")&.attr("content")&.strip.presence
+    end
+
+    def read_page(url)
+      MAX_REDIRECTS.times do
+        begin
+          return open_public(url).read(MAX_HTML_BYTES)
+        rescue OpenURI::HTTPRedirect => redirect
+          url = redirect.uri.to_s
+        end
+      end
+
+      raise Error, "Too many redirects"
+    end
+
+    def image_content_type(url)
+      ensure_public!(url)
+
+      if size = FastImage.size(url)
+        @image_width, @image_height = size
+      end
+
+      IMAGE_CONTENT_TYPES[FastImage.type(url)]
+    end
+
+    def download(url, limit:)
+      too_big = ->(bytes) { raise Error, "Image too large" if bytes && bytes > limit }
+      open_public(url, content_length_proc: too_big, progress_proc: too_big)
+    end
+
+    def open_public(url, **options)
+      ensure_public!(url)
+      URI.open(url, redirect: false, open_timeout: 5, read_timeout: 5, **options)
+    end
+
+    def ensure_public!(url)
+      uri = URI.parse(url)
+      raise Error, "Not an HTTPS URL" unless uri.is_a?(URI::HTTPS)
+
+      addresses = Resolv.getaddresses(uri.hostname).map { |address| IPAddr.new(address) }
+      if addresses.empty? || addresses.any? { |address| BLOCKED_RANGES.any? { |range| range.include?(address) } }
+        raise Error, "Not a public host"
+      end
+    rescue IPAddr::InvalidAddressError, URI::InvalidURIError
+      raise Error, "Invalid URL"
+    end
+
+    def image_filename(url, content_type)
+      File.basename(URI.parse(url).path.to_s).presence || "preview.#{content_type.split("/").last}"
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
     namespace :app do
       resource :upgrade_banner, only: [ :destroy ]
       resources :analytics, only: [ :index ]
+      resources :link_previews, only: [ :create ]
       namespace :posts do
         resource :trash, only: [ :show, :create, :destroy ], controller: "trash"
         resource :details, only: [ :create, :destroy ], controller: "details"

--- a/test/controllers/app/link_previews_controller_test.rb
+++ b/test/controllers/app/link_previews_controller_test.rb
@@ -1,0 +1,131 @@
+require "test_helper"
+require "mocha/minitest"
+
+class App::LinkPreviewsControllerTest < ActionDispatch::IntegrationTest
+  include AuthenticatedTest
+
+  setup do
+    @user = users(:joel)
+    login_as @user
+
+    Resolv.stubs(:getaddresses).returns([ "93.184.216.34" ])
+  end
+
+  test "returns the Open Graph title, description and image" do
+    stub_page <<~HTML
+      <html><head>
+        <meta property="og:title" content="Summer 2026 was the hottest on record"/>
+        <meta property="og:description" content="Provisional Met Office data."/>
+        <meta property="og:image" content="https://example.com/hero.jpg"/>
+      </head></html>
+    HTML
+    stub_image
+
+    post app_link_previews_path, params: { url: article_url }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal "Summer 2026 was the hottest on record", json["title"]
+    assert_equal "Provisional Met Office data.", json["description"]
+    assert json["image"]["attachable_sgid"].present?
+    assert_equal "image/jpeg", json["image"]["content_type"]
+    assert_equal 1200, json["image"]["width"]
+    assert_equal 630, json["image"]["height"]
+    assert_kind_of ActiveStorage::Blob,
+      GlobalID::Locator.locate_signed(json["image"]["attachable_sgid"], for: ActionText::Attachable::LOCATOR_NAME)
+  end
+
+  test "falls back to the title tag and returns no image when the page has no Open Graph tags" do
+    stub_page "<html><head><title>A plain page</title></head></html>"
+
+    post app_link_previews_path, params: { url: article_url }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal "A plain page", json["title"]
+    assert_nil json["description"]
+    assert_nil json["image"]
+  end
+
+  test "rejects a page with no title at all" do
+    stub_page "<html><head></head></html>"
+
+    post app_link_previews_path, params: { url: article_url }
+
+    assert_response :unprocessable_entity
+  end
+
+  test "rejects a non-HTTPS URL without fetching it" do
+    URI.expects(:open).never
+
+    post app_link_previews_path, params: { url: "http://example.com/article" }
+
+    assert_response :unprocessable_entity
+  end
+
+  test "rejects a host that resolves to a private address without fetching it" do
+    Resolv.stubs(:getaddresses).returns([ "10.0.0.1" ])
+    URI.expects(:open).never
+
+    post app_link_previews_path, params: { url: article_url }
+
+    assert_response :unprocessable_entity
+  end
+
+  test "skips the image when it is not a supported type" do
+    stub_page <<~HTML
+      <html><head>
+        <meta property="og:title" content="A story"/>
+        <meta property="og:image" content="https://example.com/hero.svg"/>
+      </head></html>
+    HTML
+    FastImage.stubs(:size).returns(nil)
+    FastImage.stubs(:type).returns(:svg)
+
+    post app_link_previews_path, params: { url: article_url }
+
+    assert_response :success
+    assert_nil JSON.parse(response.body)["image"]
+  end
+
+  test "skips the image when the upload quota does not allow images" do
+    stub_page <<~HTML
+      <html><head>
+        <meta property="og:title" content="A story"/>
+        <meta property="og:image" content="https://example.com/hero.jpg"/>
+      </head></html>
+    HTML
+    UploadQuota.any_instance.stubs(:allowed_content_types).returns([])
+
+    post app_link_previews_path, params: { url: article_url }
+
+    assert_response :success
+    assert_nil JSON.parse(response.body)["image"]
+  end
+
+  test "requires a signed-in user" do
+    logout
+
+    post app_link_previews_path, params: { url: article_url }
+
+    assert_response :redirect
+  end
+
+  private
+
+    def article_url
+      "https://example.com/article"
+    end
+
+    def stub_page(html)
+      URI.stubs(:open).with(article_url, has_entry(redirect: false)).returns(StringIO.new(html))
+    end
+
+    def stub_image
+      FastImage.stubs(:size).returns([ 1200, 630 ])
+      FastImage.stubs(:type).returns(:jpeg)
+      URI.stubs(:open)
+         .with("https://example.com/hero.jpg", has_entry(redirect: false))
+         .returns(StringIO.new(file_fixture("space.jpg").binread))
+    end
+end

--- a/test/system/lexxy_editor_test.rb
+++ b/test/system/lexxy_editor_test.rb
@@ -329,6 +329,72 @@ class LexxyEditorTest < ApplicationSystemTestCase
     assert_includes editor_value, "A good song"
   end
 
+  # Unfurl prompts appear only on paste, so the choice is offered once. A stored
+  # link was already answered: either dismissed, or written as a link on purpose.
+  test "pasting an article link offers a preview and saves as the bare link" do
+    visit new_app_post_path
+    wait_for_editor
+
+    find("lexxy-editor .lexxy-editor__content").click
+    paste_into_editor("https://example.com/article")
+
+    assert_selector "lexxy-editor .lexxy-editor__content .link-unfurl button", text: "Show preview", wait: 5
+
+    assert_includes editor_value, %(<p><a href="https://example.com/article">https://example.com/article</a></p>)
+    assert_not_includes editor_value, "link-unfurl"
+  end
+
+  test "dismissing an unfurl prompt restores the plain link" do
+    visit new_app_post_path
+    wait_for_editor
+
+    find("lexxy-editor .lexxy-editor__content").click
+    paste_into_editor("https://example.com/article")
+
+    click_on "Dismiss"
+
+    assert_no_selector "lexxy-editor .lexxy-editor__content .link-unfurl"
+    assert_includes editor_value, %(<a href="https://example.com/article">https://example.com/article</a>)
+  end
+
+  test "expanding an unfurl prompt inserts the image, title and description" do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("space.jpg").open, filename: "space.jpg", content_type: "image/jpeg"
+    )
+    preview = stub(title: "A big story", description: "All the details.", image_width: 1024, image_height: 683)
+    preview.stubs(:fetch).returns(preview)
+    preview.stubs(:create_image_blob).returns(blob)
+    LinkPreview.stubs(:new).returns(preview)
+
+    visit new_app_post_path
+    wait_for_editor
+
+    find("lexxy-editor .lexxy-editor__content").click
+    paste_into_editor("https://example.com/article")
+
+    click_on "Show preview"
+
+    assert_selector "lexxy-editor .lexxy-editor__content strong", text: "A big story", wait: 5
+
+    value = editor_value
+    assert_includes value, "action-text-attachment"
+    assert_includes value, "sgid="
+    assert_includes value, %(<a href="https://example.com/article"><strong>A big story</strong></a>)
+    assert_includes value, "<br>All the details."
+    assert_no_selector "lexxy-editor .lexxy-editor__content .link-unfurl"
+  end
+
+  test "opening a post with a bare article link shows no unfurl prompt" do
+    html = %(<p><a href="https://example.com/article">https://example.com/article</a></p>)
+    post = @user.blog.posts.create!(title: "Link", content: html)
+
+    visit edit_app_post_path(post)
+    wait_for_editor
+
+    assert_no_selector "lexxy-editor .lexxy-editor__content .link-unfurl"
+    assert_equal html, editor_value
+  end
+
   private
 
     def wait_for_editor


### PR DESCRIPTION
Pasting a bare https link that is not a media embed now offers to expand it into a preview, the way Slack unfurls an article.

## Why

Media embeds only work because the embed URL is derivable from the link. An article's title, image and description are not, so they have to be fetched once and stored. Rather than invent a card component, the preview is inserted as ordinary content, which every existing pipeline (RSS, email, export, plain text) already knows how to render.

## What changed

- `LinkPreview` fetches the page's Open Graph title, description and image, and downloads the image into ActiveStorage.
- `App::LinkPreviewsController` exposes that at `POST /app/link_previews`, rate limited to 10/min per user.
- `UnfurlExtension` / `UnfurlNode` in `app/javascript/editor` mirror the media embed extension and node: a decorator node that shows the prompt and exports the paragraph and link it was built from.

## Behaviour

- The prompt appears only on paste, and only for a bare https link alone in its block that matches no media site. Opening an old post never raises it.
- Nothing is stored until the author chooses. A post saved with the question still open holds only the link.
- Expanding inserts an image attachment, the title as a bold link, and the description on the line below, all editable and deletable separately.
- The image counts against the upload quota, and is skipped if the quota disallows it.

## Security

The URL is author supplied, which is new ground here: every other outbound fetch is host allowlisted or operator run. `LinkPreview` requires HTTPS, resolves the host and refuses private, loopback, link-local, CGNAT and metadata ranges, follows redirects itself so each hop is re-checked, and caps both the HTML it reads and the image it downloads.

## Still open

- No help guide entry yet.
- The image sits in normal content spacing, so there is more gap below it than a card would have. Tightening that needs a marker attribute in the stored HTML, which becomes public API for custom CSS. Deliberately deferred.