### PR TITLE
Billing event log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ updated when a model is added — a trap the code genuinely can't express.
 - Use plain branch names without category prefixes (for example `help-dialogs`, not `feature/help-dialogs` or `fix/help-dialogs`)
 - Use plain PR titles without automation prefixes (for example `Help dialogs`, not `[codex] Help dialogs`)
 - **NEVER** add "Co-Authored-By", "Generated with Claude Code", or any AI attribution to commit messages, PR descriptions, or code comments. This is a hard rule — no exceptions.
+- **NEVER** put customer data in commit messages, PR descriptions, code comments, test names, or test data: no subdomains, emails, names, user ids, or Paddle customer ids. Describe the shape of a case ("a cancellation requested weeks before it takes effect"), never the customer it came from. This is a hard rule — no exceptions.
 - Ask for human review before committing generated code
 
 ## Tooling

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -68,13 +68,12 @@ class Admin::UsersController < Admin::BaseController
   def destroy
     @user = User.find(params[:id])
 
-    if params[:spam]
-      flash[:notice] = "User was marked as spam and discarded"
-      DestroyUserJob.perform_now(@user.id, reason: :spam)
-    else
-      flash[:notice] = "User was successfully discarded"
-      DestroyUserJob.perform_now(@user.id, reason: :admin_deleted)
-    end
+    reason = params[:spam] ? :spam : :admin_deleted
+
+    BillingEventLog.record(:account_deleted, for_user: @user, paid: @user.paying?, source: "admin", reason: reason)
+
+    flash[:notice] = reason == :spam ? "User was marked as spam and discarded" : "User was successfully discarded"
+    DestroyUserJob.perform_now(@user.id, reason: reason)
 
     redirect_to admin_users_path
   end

--- a/app/controllers/app/settings/subscriptions/cancellations_controller.rb
+++ b/app/controllers/app/settings/subscriptions/cancellations_controller.rb
@@ -9,10 +9,11 @@ class App::Settings::Subscriptions::CancellationsController < App::BaseControlle
     Rails.logger.info "Cancelling subscription for #{Current.user.id}"
 
     if @subscription.present?
-      response = PaddleApi.new.cancel_subscription(@subscription.paddle_subscription_id)
-      Rails.logger.info response
+      PaddleApi.new.cancel_subscription(@subscription.paddle_subscription_id)
       @subscription.update!(cancelled_at: Time.current)
       SendCancellationEmailJob.set(wait: 4.hours).perform_later(Current.user.id, subscriber: true)
+
+      BillingEventLog.record(:cancel_requested, for_subscription: @subscription, effective: @subscription.next_billed_at, source: "app")
     end
 
     redirect_to app_settings_path, notice: "Your subscription has been cancelled. You'll keep access until the end of your current billing period."

--- a/app/controllers/app/settings/users_controller.rb
+++ b/app/controllers/app/settings/users_controller.rb
@@ -11,6 +11,8 @@ class App::Settings::UsersController < App::BaseController
     DestroyUserJob.perform_later(Current.user.id)
     SendCancellationEmailJob.set(wait: 24.hours).perform_later(Current.user.id, subscriber: false)
 
+    BillingEventLog.record(:account_deleted, for_user: Current.user, paid: Current.user.paying?, source: "app")
+
     redirect_to root_path
   end
 

--- a/app/controllers/billing/paddle_events_controller.rb
+++ b/app/controllers/billing/paddle_events_controller.rb
@@ -22,6 +22,14 @@ module Billing
           process_event params[:event_type]
         else
           Rails.logger.warn("Unable to find user for Paddle #{params[:event_type]} (customer #{params.dig(:data, :customer_id)})")
+
+          BillingEventLog.record(
+            :webhook_unmatched,
+            type: params[:event_type],
+            customer: payload.customer_id,
+            user: payload.user_id,
+            blog: params.dig(:data, :custom_data, :blog_subdomain)
+          )
         end
       else
         Rails.logger.error("Unable to verify Paddle request signature")
@@ -105,11 +113,15 @@ module Billing
 
         Rails.logger.info "Subscription #{@subscription.id} cancelled at #{cancelled_at}"
 
+        booked_earlier = @subscription.cancelled_at.present?
+
         # Paddle only sends this once the cancellation has taken effect, so access ends
         # now. Cancellations scheduled for the end of the term arrive as
         # subscription.updated with a scheduled_change and keep their billing period
         # until this event follows.
         @subscription.update!(cancelled_at: cancelled_at, next_billed_at: cancelled_at)
+
+        BillingEventLog.record(:cancel_effective, for_subscription: @subscription, started: payload.started_at&.to_date, booked_earlier: booked_earlier)
       end
 
       def subscription_updated
@@ -132,16 +144,32 @@ module Billing
         )
 
         notify_supporter_upgrade
+        log_plan_change
 
         if (cancelling_at = payload.cancellation_scheduled_at)
           Rails.logger.info "Subscription is being cancelled"
+
+          # The in-app cancellation form and account deletion both set this
+          # before Paddle's webhook arrives.
+          booked_earlier = @subscription.cancelled_at.present? || @user.discarded?
+
           @subscription.update!(cancelled_at: Time.parse(cancelling_at))
+
+          BillingEventLog.record(
+            :cancel_scheduled,
+            for_subscription: @subscription,
+            effective: @subscription.cancelled_at,
+            started: payload.started_at&.to_date,
+            source: "paddle",
+            booked_earlier: booked_earlier
+          )
         end
       end
 
       def subscription_past_due
-        # No-op
         Rails.logger.info "Subscription past due"
+
+        BillingEventLog.record(:past_due, for_subscription: @subscription, for_user: @user)
       end
 
       def transaction_completed
@@ -177,6 +205,8 @@ module Billing
           @subscription.update!(updates)
 
           notify_supporter_upgrade
+          log_plan_change
+          log_completed_transaction
 
           Rails.logger.info "Subscription #{@subscription.id} next billed on #{next_billed_at}, unit_price: #{updates[:unit_price]}"
         else
@@ -186,6 +216,28 @@ module Billing
 
       def transaction_payment_failed
         Rails.logger.warn "Payment failed for user #{@user.id} (#{@user.blog.subdomain}) - Paddle Retain will retry automatically"
+
+        BillingEventLog.record(:payment_failed, for_subscription: @subscription, for_user: @user, existing: @subscription.present?)
+      end
+
+      def log_completed_transaction
+        case payload.origin
+        when "web" then BillingEventLog.record(:subscription_started, for_subscription: @subscription)
+        when "subscription_recurring" then BillingEventLog.record(:renewal, for_subscription: @subscription)
+        end
+      end
+
+      # Like notify_supporter_upgrade: Paddle sends two webhooks for one plan
+      # change, and only the first to arrive flips the plan.
+      def log_plan_change
+        return unless @subscription.saved_change_to_plan?
+
+        BillingEventLog.record(
+          :plan_changed,
+          for_subscription: @subscription,
+          from: @subscription.plan_before_last_save,
+          from_amount: @subscription.unit_price_before_last_save
+        )
       end
 
       # Fires only on the save that actually flips the plan to supporter, so the

--- a/app/models/billing_event_log.rb
+++ b/app/models/billing_event_log.rb
@@ -1,0 +1,45 @@
+# Writes the [billing] lines `rake logs:billing` reads. Call from a controller,
+# never a job: LogParser skips log lines without a request context header.
+class BillingEventLog
+  TAG = "[billing]".freeze
+
+  class << self
+    def record(event, for_subscription: nil, for_user: nil, **fields)
+      attributes = { event: event }
+        .merge(identity(for_subscription, for_user))
+        .merge(fields)
+
+      Rails.logger.info(line_for(attributes))
+    rescue => error
+      Sentry.capture_exception(error) if Sentry.initialized?
+    end
+
+    private
+
+      def identity(subscription, user)
+        subscription ||= user&.subscription
+        user ||= subscription&.user
+
+        {
+          user: user&.id,
+          blog: user&.blog&.subdomain,
+          plan: subscription&.plan,
+          amount: subscription&.unit_price
+        }
+      end
+
+      def line_for(attributes)
+        pairs = attributes.filter_map do |key, value|
+          next if value.nil? || value == ""
+          "#{key}=#{value_for(value)}"
+        end
+
+        "#{TAG} #{pairs.join(" ")}"
+      end
+
+      # Space separates one key=value from the next, so no value may contain one.
+      def value_for(value)
+        value.respond_to?(:strftime) ? value.strftime("%F") : value.to_s.tr(" ", "_")
+      end
+  end
+end

--- a/app/models/concerns/subscribable.rb
+++ b/app/models/concerns/subscribable.rb
@@ -15,6 +15,10 @@ module Subscribable
     subscription&.active?
   end
 
+  def paying?
+    subscription.present? && subscription.active_paid?
+  end
+
   def on_trial?
     trial_ends_at.present? && trial_ends_at >= Date.current && !subscribed?
   end

--- a/app/models/paddle_payload.rb
+++ b/app/models/paddle_payload.rb
@@ -32,6 +32,10 @@ class PaddlePayload
     @data[:origin]
   end
 
+  def started_at
+    @data[:started_at]
+  end
+
   def billing_period_ends_at
     @data.dig(:billing_period, :ends_at)
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -98,6 +98,10 @@ class Subscription < ApplicationRecord
     cancelled_at.present?
   end
 
+  def active_paid?
+    !complimentary? && !cancelled? && !lapsed?
+  end
+
   def lapsed?
     return false if complimentary?
 

--- a/lib/log_billing.rb
+++ b/lib/log_billing.rb
@@ -1,0 +1,82 @@
+require_relative "log_parser"
+
+# Reads the [billing] lines BillingEventLog writes.
+module LogBilling
+  TAG = "[billing] ".freeze
+
+  MONTHS_PER_TERM = { "monthly" => 12 }.freeze
+
+  # Events that can move the run rate. A renewal never does; the rest are
+  # excluded per line when they carry booked_earlier=true, which marks money
+  # already counted on the day the customer decided.
+  BOOKING_EVENTS = %w[
+    subscription_started
+    plan_changed
+    cancel_requested
+    cancel_scheduled
+    cancel_effective
+    account_deleted
+  ].freeze
+
+  GAINS = %w[ subscription_started plan_changed ].freeze
+
+  class << self
+    def events_for(entries)
+      entries.filter_map do |entry|
+        next unless entry.line_type == :other
+
+        body = entry.detail.to_s
+        next unless body.start_with?(TAG)
+
+        parse(body, entry)
+      end
+    end
+
+    def annualised_delta(events)
+      events.sum { |event| signed_annual_amount(event) }
+    end
+
+    def annualised_amount(event)
+      amount = event[:amount].to_i
+      return 0 if amount.zero?
+
+      amount * MONTHS_PER_TERM.fetch(event[:plan], 1)
+    end
+
+    def books_revenue?(event)
+      BOOKING_EVENTS.include?(event[:event]) &&
+        event[:booked_earlier] != "true" &&
+        event[:paid] != "false" &&
+        event[:reason] != "spam"
+    end
+
+    private
+
+      def parse(body, entry)
+        event = { timestamp: entry.timestamp, uuid: entry.uuid }
+
+        body.delete_prefix(TAG).split(" ").each do |pair|
+          key, value = pair.split("=", 2)
+          next if key.nil? || value.nil?
+
+          event[key.to_sym] = value
+        end
+
+        event
+      end
+
+      def signed_annual_amount(event)
+        return 0 unless books_revenue?(event)
+
+        case event[:event]
+        when "plan_changed"
+          annualised_amount(event) -
+            annualised_amount(event.merge(amount: event[:from_amount], plan: event[:from]))
+        when *GAINS
+          annualised_amount(event)
+        else
+          -annualised_amount(event)
+        end
+      end
+  end
+end

--- a/lib/tasks/logs.rake
+++ b/lib/tasks/logs.rake
@@ -1,5 +1,6 @@
 require_relative "../log_parser"
 require_relative "../log_performance"
+require_relative "../log_billing"
 
 module LogDisplay
   unless defined?(RESET)
@@ -33,6 +34,12 @@ module LogDisplay
 
   def self.number(value, precision: 1)
     value ? value.round(precision).to_s : "-"
+  end
+
+  def self.price(cents, plan = nil)
+    return "-" if cents.to_s.empty?
+
+    "#{format("$%.2f", cents.to_i / 100.0)}#{plan == "monthly" ? "/mo" : "/yr"}"
   end
 
   # Renders a box-drawn table.
@@ -740,6 +747,117 @@ namespace :logs do
 
     puts "#{LogDisplay::DIM}\"Signup validation failed\" lines carry the email address in plain text — " \
       "never paste those lines anywhere.#{LogDisplay::RESET}"
+  end
+
+  desc "Subscriptions, cancellations and payment failures for a date: rake \"logs:billing[2026-09-05]\""
+  task :billing, [ :date ] do |_t, args|
+    date = args[:date]
+
+    unless date
+      puts "#{LogDisplay::RED}Usage: rake \"logs:billing[2026-09-05]\"#{LogDisplay::RESET}"
+      exit 1
+    end
+
+    puts "#{LogDisplay::BOLD}Analysing billing events for #{date} ...#{LogDisplay::RESET}"
+
+    events = LogBilling.events_for(LogParser.each_entry_for_date(date))
+
+    labels = {
+      "subscription_started" => "New",
+      "plan_changed" => "Plan change",
+      "cancel_requested" => "Cancel requested",
+      "cancel_scheduled" => "Cancel scheduled",
+      "cancel_effective" => "Access ended",
+      "account_deleted" => "Account deleted",
+      "webhook_unmatched" => "Unmatched webhook"
+    }
+
+    movements = events.reject { |e| %w[ renewal payment_failed past_due ].include?(e[:event]) }
+    renewals = events.select { |e| e[:event] == "renewal" }
+    failures = events.select { |e| e[:event] == "payment_failed" }
+    past_due = events.select { |e| e[:event] == "past_due" }
+
+    detail_for = ->(e) do
+      parts = []
+      parts << (e[:paid] == "true" ? "paid" : "free") if e[:event] == "account_deleted"
+      parts << e[:reason] if e[:reason]
+      parts << "was #{e[:from]} #{LogDisplay.price(e[:from_amount], e[:from])}" if e[:from]
+      parts << "ends #{e[:effective]}" if e[:effective]
+      parts << "since #{e[:started]}" if e[:started]
+      parts << "booked earlier" if e[:booked_earlier] == "true"
+      parts << "#{e[:type]} for customer #{e[:customer]}" if e[:customer]
+      parts.join(", ")
+    end
+
+    puts LogDisplay.table(
+      title: "Subscription movements for #{date} (#{movements.size})",
+      columns: [
+        { label: "Time", width: 8, align: :left },
+        { label: "Blog", width: 22, align: :left },
+        { label: "Event", width: 17, align: :left },
+        { label: "Plan", width: 9, align: :left },
+        { label: "Price", width: 10, align: :right },
+        { label: "Detail", width: 46, align: :left }
+      ],
+      rows: movements.sort_by { |e| e[:timestamp].to_s }.map do |e|
+        [
+          e[:timestamp]&.strftime("%H:%M:%S") || "-",
+          e[:blog] || "user #{e[:user]}",
+          labels.fetch(e[:event], e[:event]),
+          e[:plan] || "-",
+          LogBilling.books_revenue?(e) ? LogDisplay.price(e[:amount], e[:plan]) : "-",
+          detail_for.(e)
+        ]
+      end
+    )
+
+    delta = LogBilling.annualised_delta(events)
+    sign = delta.negative? ? "-" : "+"
+    puts "Net annualised run rate: #{sign}#{format("$%.2f", delta.abs / 100.0)}"
+    puts "#{LogDisplay::DIM}Priced rows are the ones that move it. A dash means the change was " \
+      "counted on the day it was decided.#{LogDisplay::RESET}"
+
+    billed = renewals.sum { |e| e[:amount].to_i }
+    puts "Renewals billed: #{renewals.size}, totalling #{format("$%.2f", billed / 100.0)}"
+
+    if failures.any? || past_due.any?
+      # A failure and its recovery usually land minutes apart, so the outcome is
+      # only reliable for the same day.
+      outcome_for = ->(e) do
+        later = events.select { |o| o[:user] == e[:user] && o[:timestamp].to_s > e[:timestamp].to_s }
+        return "recovered" if later.any? { |o| %w[ renewal subscription_started ].include?(o[:event]) }
+        return "cancelled after failing" if later.any? { |o| o[:event].to_s.start_with?("cancel", "account_deleted") }
+
+        "unresolved"
+      end
+
+      puts LogDisplay.table(
+        title: "Payment failures for #{date} (#{failures.size}, #{past_due.size} past due)",
+        columns: [
+          { label: "Time", width: 8, align: :left },
+          { label: "Blog", width: 22, align: :left },
+          { label: "Plan", width: 10, align: :left },
+          { label: "Price", width: 10, align: :right },
+          { label: "Stage", width: 12, align: :left },
+          { label: "Same-day outcome", width: 24, align: :left }
+        ],
+        rows: failures.sort_by { |e| e[:timestamp].to_s }.map do |e|
+          [
+            e[:timestamp]&.strftime("%H:%M:%S") || "-",
+            e[:blog] || "user #{e[:user]}",
+            e[:plan] || "-",
+            LogDisplay.price(e[:amount], e[:plan]),
+            e[:existing] == "true" ? "renewal" : "checkout",
+            outcome_for.(e)
+          ]
+        end
+      )
+    end
+
+    if events.empty?
+      puts "#{LogDisplay::DIM}No billing events. Lines are only written from #{LogDisplay::RESET}" \
+        "#{LogDisplay::DIM}the deploy that added BillingEventLog onwards.#{LogDisplay::RESET}"
+    end
   end
 
   desc "AI bot robots.txt compliance: which disallowed crawlers still hit the site. rake \"logs:bots\" or rake \"logs:bots[2026-07-21]\"; optional DAYS=7 for a recent window"

--- a/test/controllers/app/settings/subscriptions/cancellations_controller_test.rb
+++ b/test/controllers/app/settings/subscriptions/cancellations_controller_test.rb
@@ -28,4 +28,23 @@ class App::Settings::Subscriptions::CancellationsControllerTest < ActionDispatch
     assert_equal "Your subscription has been cancelled. You'll keep access until the end of your current billing period.", flash[:notice]
     assert @user.subscription.reload.cancelled?
   end
+
+  test "should log the cancellation with the price they were paying" do
+    mock_api = mock
+    mock_api.stubs(:cancel_subscription).returns(true)
+    PaddleApi.stubs(:new).returns(mock_api)
+
+    io = StringIO.new
+    previous = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(io)
+    post app_settings_subscriptions_cancellation_url
+    Rails.logger = previous
+
+    line = io.string[/\[billing\].*/]
+    assert_includes line, "event=cancel_requested"
+    assert_includes line, "blog=#{@user.blog.subdomain}"
+    assert_includes line, "amount=#{@user.subscription.unit_price}"
+    assert_includes line, "source=app"
+    assert @user.subscription.reload.cancelled?
+  end
 end

--- a/test/controllers/app/settings/users_controller_test.rb
+++ b/test/controllers/app/settings/users_controller_test.rb
@@ -32,4 +32,38 @@ class App::Settings::UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to root_url
   end
+
+  test "delete account logs the blog and whether they were paying" do
+    lines = billing_lines { delete app_settings_user_url(@user) }
+
+    line = lines.find { |l| l.include?("event=account_deleted") }
+    assert line, "expected an account_deleted line, got: #{lines.inspect}"
+    assert_includes line, "blog=#{@user.blog.subdomain}"
+    assert_includes line, "paid=true"
+    assert_includes line, "source=app"
+  end
+
+  test "delete account of a free user records no plan or amount" do
+    free_user = users(:vivian)
+    login_as free_user
+
+    lines = billing_lines { delete app_settings_user_url(free_user) }
+
+    line = lines.find { |l| l.include?("event=account_deleted") }
+    assert_includes line, "paid=false"
+    assert_includes line, "blog=#{free_user.blog.subdomain}"
+    assert_no_match(/amount=/, line)
+  end
+
+  private
+
+    def billing_lines
+      io = StringIO.new
+      previous = Rails.logger
+      Rails.logger = ActiveSupport::Logger.new(io)
+      yield
+      io.string.scan(/\[billing\].*/)
+    ensure
+      Rails.logger = previous
+    end
 end

--- a/test/controllers/billing/paddle_events_controller_test.rb
+++ b/test/controllers/billing/paddle_events_controller_test.rb
@@ -452,7 +452,158 @@ class Billing::PaddleEventsControllerTest < ActionDispatch::IntegrationTest
     assert_equal Time.parse(payload["data"]["billing_period"]["ends_at"]), subscription.reload.next_billed_at
   end
 
+  test "should log a subscription start with the amount actually charged" do
+    subscription = subscriptions(:one)
+    payload = payload_for("transaction.completed", subscription.user)
+    json_payload = payload.to_json
+
+    lines = billing_lines do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    line = lines.find { |l| l.include?("event=subscription_started") }
+    assert line, "expected a subscription_started line, got: #{lines.inspect}"
+    assert_includes line, "blog=#{subscription.user.blog.subdomain}"
+    assert_includes line, "amount=2900"
+  end
+
+  test "should log the blog even when Paddle sends no blog_subdomain" do
+    subscription = subscriptions(:one)
+    payload = payload_for("transaction.completed", subscription.user)
+    payload["data"]["custom_data"].delete("blog_subdomain")
+    json_payload = payload.to_json
+
+    lines = billing_lines do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    line = lines.find { |l| l.include?("event=subscription_started") }
+    assert_includes line, "blog=#{subscription.user.blog.subdomain}"
+  end
+
+  test "should log a scheduled cancellation with the date access ends" do
+    subscription = subscriptions(:one)
+    payload = payload_for("subscription.updated.cancellation", subscription.user)
+    effective_at = 1.month.from_now
+    payload["data"]["customer_id"] = "ctm_01hvnxx8katrjdh3xjph09mef7"
+    payload["data"]["id"] = "sub_01hvrk1481njzb874tn7wyrksv"
+    payload["data"]["scheduled_change"]["effective_at"] = effective_at.iso8601
+    json_payload = payload.to_json
+
+    lines = billing_lines do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    line = lines.find { |l| l.include?("event=cancel_scheduled") }
+    assert line, "expected a cancel_scheduled line, got: #{lines.inspect}"
+    assert_includes line, "effective=#{effective_at.to_date.iso8601}"
+    assert_includes line, "source=paddle"
+  end
+
+  test "should log a plan change from the webhook that flips it, with the old price" do
+    subscription = subscriptions(:one)
+    subscription.update!(plan: :supporter, unit_price: 7500)
+    payload = payload_for("subscription.updated.plan_change", subscription.user)
+    json_payload = payload.to_json
+
+    lines = billing_lines do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    line = lines.find { |l| l.include?("event=plan_changed") }
+    assert line, "expected a plan_changed line, got: #{lines.inspect}"
+    assert_includes line, "from=supporter"
+    assert_includes line, "from_amount=7500"
+    assert_includes line, "plan=annual"
+    assert_includes line, "amount=3900"
+  end
+
+  test "should not log a plan change when the plan did not change" do
+    subscription = subscriptions(:one)
+    payload = payload_for("subscription.updated.plan_change", subscription.user)
+    json_payload = payload.to_json
+
+    lines = billing_lines do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    assert_nil lines.find { |l| l.include?("event=plan_changed") }
+  end
+
+  test "should still process the webhook when billing logging fails" do
+    subscription = subscriptions(:one)
+    payload = payload_for("subscription.canceled", subscription.user)
+    payload["data"]["canceled_at"] = Time.current.iso8601
+    json_payload = payload.to_json
+
+    BillingEventLog.stubs(:line_for).raises(RuntimeError, "boom")
+
+    post billing_paddle_events_url,
+      params: json_payload,
+      headers: {
+        "Content-Type" => "application/json",
+        "Paddle-Signature" => paddle_signature_for(json_payload)
+      }
+
+    assert_response :success
+    assert subscription.reload.cancelled?
+  end
+
+  test "should log a payment failure at checkout as having no existing subscription" do
+    user = users(:vivian)
+    payload = payload_for("transaction.payment_failed", user)
+    json_payload = payload.to_json
+
+    lines = billing_lines do
+      post billing_paddle_events_url,
+        params: json_payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "Paddle-Signature" => paddle_signature_for(json_payload)
+        }
+    end
+
+    line = lines.find { |l| l.include?("event=payment_failed") }
+    assert line, "expected a payment_failed line, got: #{lines.inspect}"
+    assert_includes line, "existing=false"
+  end
+
   private
+
+    def billing_lines
+      io = StringIO.new
+      previous = Rails.logger
+      Rails.logger = ActiveSupport::Logger.new(io)
+      yield
+      io.string.scan(/\[billing\].*/)
+    ensure
+      Rails.logger = previous
+    end
 
     def payload_for(event_type, user)
       json_payload = File.read(Rails.root.join("test", "fixtures", "billing", "#{event_type}.json"))

--- a/test/lib/log_billing_test.rb
+++ b/test/lib/log_billing_test.rb
@@ -90,13 +90,6 @@ class LogBillingTest < Minitest::Test
     assert_equal(-3900, LogBilling.annualised_delta(parsed))
   end
 
-  def test_a_free_account_deletion_costs_nothing_but_is_still_reported
-    parsed = events("[billing] event=account_deleted user=1 blog=one paid=false source=app")
-
-    assert_equal 1, parsed.size
-    assert_equal 0, LogBilling.annualised_delta(parsed)
-  end
-
   private
 
     def events(*bodies)

--- a/test/lib/log_billing_test.rb
+++ b/test/lib/log_billing_test.rb
@@ -1,0 +1,111 @@
+require "minitest/autorun"
+require_relative "../../lib/log_billing"
+
+class LogBillingTest < Minitest::Test
+  def test_reads_only_billing_lines
+    parsed = events(
+      "[billing] event=renewal user=1 blog=one plan=annual amount=3900",
+      "Completed 200 OK in 12ms",
+      "Cancelling subscription for 1"
+    )
+
+    assert_equal 1, parsed.size
+    assert_equal "renewal", parsed.first[:event]
+    assert_equal "one", parsed.first[:blog]
+  end
+
+  def test_monthly_is_worth_a_year_of_run_rate
+    parsed = events("[billing] event=subscription_started user=1 blog=one plan=monthly amount=400")
+
+    assert_equal 4800, LogBilling.annualised_delta(parsed)
+  end
+
+  # A cancellation requested weeks earlier: the day access ends must not book
+  # the loss a second time.
+  def test_access_ending_does_not_move_the_run_rate
+    parsed = events(
+      "[billing] event=cancel_effective user=1 blog=one plan=monthly amount=400 booked_earlier=true"
+    )
+
+    assert_equal 0, LogBilling.annualised_delta(parsed)
+  end
+
+  # The in-app form books the loss, and Paddle's webhook describes the same
+  # cancellation a second later.
+  def test_a_cancellation_and_its_webhook_are_one_loss
+    parsed = events(
+      "[billing] event=cancel_requested user=1 blog=one plan=monthly amount=400 source=app",
+      "[billing] event=cancel_scheduled user=1 blog=one plan=monthly amount=400 source=paddle booked_earlier=true"
+    )
+
+    assert_equal(-4800, LogBilling.annualised_delta(parsed))
+  end
+
+  # Two declines at checkout, then a subscription. The declines are not a
+  # failing renewal, and the subscription is genuinely new.
+  def test_a_decline_at_checkout_books_nothing_and_the_start_that_follows_does
+    parsed = events(
+      "[billing] event=payment_failed user=1 blog=one existing=false",
+      "[billing] event=subscription_started user=1 blog=one plan=annual amount=3900"
+    )
+
+    assert_equal 3900, LogBilling.annualised_delta(parsed)
+  end
+
+  def test_a_plan_change_books_only_the_difference
+    parsed = events(
+      "[billing] event=plan_changed user=1 blog=one plan=supporter amount=7500 from=annual from_amount=3900"
+    )
+
+    assert_equal 3600, LogBilling.annualised_delta(parsed)
+  end
+
+  def test_a_spam_removal_is_not_churn
+    parsed = events(
+      "[billing] event=account_deleted user=1 blog=one plan=annual amount=3900 source=admin reason=spam"
+    )
+
+    assert_equal 0, LogBilling.annualised_delta(parsed)
+  end
+
+  # Failed renewals, then Paddle cancelled. Nothing was scheduled first, so
+  # this is the first and only word of the loss.
+  def test_access_ending_with_nothing_booked_earlier_is_a_loss
+    parsed = events("[billing] event=cancel_effective user=1 blog=one plan=monthly amount=400 booked_earlier=false")
+
+    assert_equal(-4800, LogBilling.annualised_delta(parsed))
+  end
+
+  def test_deleting_an_account_that_had_already_cancelled_books_nothing
+    parsed = events("[billing] event=account_deleted user=1 blog=one plan=annual amount=3900 paid=false source=app")
+
+    assert_equal 0, LogBilling.annualised_delta(parsed)
+  end
+
+  def test_a_paying_account_deletion_is_a_loss
+    parsed = events(
+      "[billing] event=account_deleted user=1 blog=one plan=annual amount=3900 paid=true source=app"
+    )
+
+    assert_equal(-3900, LogBilling.annualised_delta(parsed))
+  end
+
+  def test_a_free_account_deletion_costs_nothing_but_is_still_reported
+    parsed = events("[billing] event=account_deleted user=1 blog=one paid=false source=app")
+
+    assert_equal 1, parsed.size
+    assert_equal 0, LogBilling.annualised_delta(parsed)
+  end
+
+  private
+
+    def events(*bodies)
+      entries = bodies.map do |body|
+        LogParser.parse_line(
+          "2026-09-04T08:10:36+00:00 INFO [abc123] [host=pagecord.com] [ip=203.0.113.1] [user_agent=Paddle] #{body}"
+        )
+      end
+
+      LogBilling.events_for(entries)
+    end
+end


### PR DESCRIPTION
One self-describing `[billing]` log line per billing event, so the daily operations note can report subscriptions, cancellations, account deletions and payment failures from the logs alone. `rake logs:billing[DATE]` reads them back.

## Why the app has to write these

Everything needed is technically in the logs today, but only inside each Paddle webhook's 4KB `Parameters:` blob, and three things cannot be recovered from it afterwards:

- **Price on a cancellation.** A cancellation moves no money, so nothing logs its price. An annual subscriber's last transaction is a year outside the ~26-day retention by the time they cancel.
- **Subdomain on legacy subscriptions.** Paddle's `custom_data.blog_subdomain` predates some subscriptions, whose webhooks carry `user_id` only.
- **The charged amount.** `subscription.created` stores the price object's list amount; the transaction a second later corrects it (regional pricing). So `subscription_started` is emitted from `transaction.completed`, keyed on Paddle's `origin`.

Each line therefore carries `blog=` from `user.blog.subdomain` and `amount=` from `subscription.unit_price` at emit time.

## Constraints that shaped it

- **Controllers only.** `LogParser` drops lines without a request-context header, so anything logged inside a job never reaches a report. Account deletion is logged in the controller, not `DestroyUserJob`.
- **Cannot affect billing.** `BillingEventLog.record` rescues and reports to Sentry, and sits after the state change at every site. A test stubs it to raise mid-webhook and asserts the cancellation still lands.
- **Plan changes.** Paddle sends two webhooks; in the retained logs `subscription.updated` arrives first 13 times out of 14 and has already flipped the plan by the time the transaction lands. The line is emitted from whichever save actually changes the plan, using `plan_before_last_save` — the same shape as `notify_supporter_upgrade`.

## The counting rule (`lib/log_billing.rb`)

A change to the run rate is booked once, on the day the customer decided. Access ending later, a renewal, or a term expiring carry `booked_earlier=true` and count for nothing. A cancellation Paddle initiates after failed payments has nothing booked earlier, so it does count. An account deletion by a paying user and the Paddle cancel it triggers a second later are one loss, not two. Spam removals are moderation, not churn.

Each rule has a regression test for the shape that produced it: a cancellation requested weeks before it takes effect, a paying account deleted, two card declines at checkout followed by a start, and a cancellation Paddle initiates after failed renewals.

## Verified

- `docker compose exec web bin/rails test`: 2132 runs, 6979 assertions, 0 failures
- Rubocop clean
- `logs:billing` rendered against a fixture and against real payloads for two days

## After merge

The ops note section is empty until this deploys and a day of logs rotates; no back-fill by design. The companion change in pagecord-ops (`ops_note.sh`, the skill) is already on its main.
