### PR TITLE
Render the private blog gate in the blog's language

### DIFF
--- a/app/controllers/blogs/base_controller.rb
+++ b/app/controllers/blogs/base_controller.rb
@@ -13,7 +13,7 @@ class Blogs::BaseController < ApplicationController
   # The order is load bearing. load_blog sets @blog for everything after it, and
   # the domain redirects run before the access check so a request on the wrong
   # host is moved on rather than shown a password form.
-  before_action :load_blog, :validate_user, :enforce_custom_domain, :require_blog_access, :set_locale, :reject_malicious_params
+  before_action :load_blog, :set_locale, :validate_user, :enforce_custom_domain, :require_blog_access, :reject_malicious_params
 
   rescue_from ActiveRecord::RecordNotFound, with: :render_blog_not_found
   rescue_from ActionController::TooManyRequests, with: :render_too_many_requests

--- a/test/controllers/blogs/access_controller_test.rb
+++ b/test/controllers/blogs/access_controller_test.rb
@@ -29,6 +29,16 @@ class Blogs::AccessControllerTest < ActionDispatch::IntegrationTest
     assert_no_match post.title, response.body
   end
 
+  test "the gate is in the blog's language" do
+    @blog.update!(password: "letmein", locale: "pt")
+
+    get blog_posts_path
+
+    assert_response :unauthorized
+    assert_select "p", I18n.t("private_blog.intro", locale: :pt)
+    assert_select "input[name=password][placeholder=?]", I18n.t("private_blog.placeholder", locale: :pt)
+  end
+
   test "correct password returns the visitor to the page they asked for and grants access" do
     @blog.update!(password: "letmein")
     wanted = posts(:one)


### PR DESCRIPTION
A password-protected blog set to Português still showed its gate in English, reported by a customer today. The page's `<html lang>` said `pt`, the form said "Enter the password to read this blog".

**Cause.** In `Blogs::BaseController` the callbacks ran `… require_blog_access, set_locale`. The access check renders the login form and halts the chain, so `set_locale` never ran for a locked blog and the form rendered in whatever locale the thread last had.

**Fix.** Run `set_locale` straight after `load_blog`. It only needs `@blog`, and the domain redirect still precedes the access check, which is the ordering the comment was protecting.

**Test.** A locked blog with `locale: "pt"` renders the Portuguese intro and placeholder. Fails on `main`, passes here.
