### PR TITLE
Say "senha" on the Portuguese password page

### DIFF
--- a/config/locales/private_blog.pt.yml
+++ b/config/locales/private_blog.pt.yml
@@ -1,6 +1,6 @@
 pt:
   private_blog:
-    intro: "Introduza a palavra-passe para ler este blog"
-    placeholder: "Palavra-passe"
+    intro: "Entre com a senha para ler este blog"
+    placeholder: "Senha"
     submit: "Enviar"
-    incorrect: "Essa palavra-passe não está correta. Tente novamente."
+    incorrect: "Essa senha não está correta. Tente novamente."


### PR DESCRIPTION
The Portuguese password gate used "palavra-passe", which is European usage and rarely understood in Brazil. "Senha" is the standard Brazilian term and is recognised in Portugal, so it serves both.

Wording for the intro, placeholder and button came from a Brazilian reader. The incorrect-password message is the same sentence with the noun swapped.

Follows #1223, which made the gate render in the blog's language at all.
