### PR TITLE
Add image alt text separate from captions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: bd885faee983c6986da1919d96ee6f671a35164c
+  revision: 52fa23ce8e1d39ff281bf300867e9ba7c7d66111
   branch: main
   specs:
     actioncable (8.2.0.alpha)
@@ -302,7 +302,7 @@ GEM
     nanoid (2.0.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.6)
+    net-imap (0.6.7)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/models/api/post_params.rb
+++ b/app/models/api/post_params.rb
@@ -95,6 +95,7 @@ class Api::PostParams
     def preview_attributes_from(node)
       {}.tap do |attributes|
         attributes[:caption] = node["caption"] if node["caption"].present?
+        attributes[:alt] = node["alt"] if node["alt"].present?
         attributes[:presentation] = node["presentation"] if node["presentation"].present?
       end
     end

--- a/app/models/html/resolve_blob_images.rb
+++ b/app/models/html/resolve_blob_images.rb
@@ -7,6 +7,9 @@ module Html
     # Micropub clients reference uploaded images by blob URL returned from the
     # media endpoint. Convert those <img> tags to Action Text attachments so the
     # blob remains associated with the saved post.
+    #
+    # Markdown gives an image two descriptions: ![alt](url "title"). The alt
+    # becomes the accessible description, the title the visible caption.
     def transform(html)
       return html unless html&.match?(BLOB_URL_PATTERN)
 
@@ -16,7 +19,7 @@ module Html
         next unless blob = blob_from_url(img["src"])
 
         node = img.parent&.name == "figure" ? img.parent : img
-        node.replace attachment_preview_node(blob, img["src"], attributes: { caption: img["alt"] })
+        node.replace attachment_preview_node(blob, img["src"], attributes: { caption: img["title"], alt: img["alt"] })
       end
 
       doc.to_html

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -4,7 +4,7 @@
   <% elsif blob.audio? %>
     <%= audio_tag rails_public_blob_url(blob), preload: "auto", controls: "controls", class: "attachment__audio w-full" %>
   <% elsif blob.image? %>
-    <% image_alt = blob.try(:caption).presence || "Uploaded image" %>
+    <% image_alt = blob.try(:alt).presence || blob.try(:caption).presence || "Uploaded image" %>
     <% if blob.content_type == "image/gif" %>
       <%= image_tag rails_public_blob_url(blob), alt: image_alt %>
     <% else %>

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -4,7 +4,7 @@
   <% elsif blob.audio? %>
     <%= audio_tag rails_public_blob_url(blob), preload: "auto", controls: "controls", class: "attachment__audio w-full" %>
   <% elsif blob.image? %>
-    <% image_alt = blob.try(:alt).presence || blob.try(:caption).presence || "Uploaded image" %>
+    <% image_alt = blob.try(:alt).presence || blob.try(:caption).presence %>
     <% if blob.content_type == "image/gif" %>
       <%= image_tag rails_public_blob_url(blob), alt: image_alt %>
     <% else %>

--- a/docs/help-guide/micropub.md
+++ b/docs/help-guide/micropub.md
@@ -58,7 +58,7 @@ Pagecord supports creating and updating posts with:
 - Slug
 - Published date
 - Image uploads through the media endpoint
-- Image descriptions from apps, stored as captions
+- Image alt text and captions
 
 Pagecord does not currently support cross-posting targets through Micropub. The `syndicate-to` response is intentionally empty.
 
@@ -143,6 +143,24 @@ file=@photo.jpg
 ```
 
 On success, Pagecord returns `201 Created` with a `Location` header. Use that URL in your Markdown content or as a Micropub `photo` property.
+
+### Alt text and captions
+
+A Markdown image carries two descriptions, and Pagecord uses both:
+
+```text
+![A fishing boat at sunset](image-url "Sunset on the Mekong")
+```
+
+The text in the square brackets becomes the image's alt text. It describes the image for screen readers and is not shown on the page. The quoted title after the URL becomes the visible caption underneath the image.
+
+Give an image alt text alone and it stays undescribed on screen but readable to assistive technology:
+
+```text
+![A fishing boat at sunset](image-url)
+```
+
+The `alt` value on a Micropub `photo` property is treated the same way.
 
 ## Source Queries
 

--- a/docs/help-guide/obsidian.md
+++ b/docs/help-guide/obsidian.md
@@ -30,4 +30,28 @@ Obsidian's callout syntax is supported, so `> [!note] Title` publishes as a styl
 
 Footnotes are supported too, so `[^1]` markers and their definitions publish as a numbered list at the foot of the post. See [Footnotes](footnotes.md).
 
+## Images and alt text
+
+Obsidian's own embed syntax uploads the file but gives it no description:
+
+```text
+![[photo.jpg]]
+```
+
+Use Markdown embed syntax when you want to describe an image. It carries two descriptions, and Pagecord uses both:
+
+```text
+![A fishing boat at sunset](photo.jpg "Sunset on the Mekong")
+```
+
+The text in the square brackets becomes the image's alt text. It describes the image for screen readers and is not shown on the page. The quoted title after the path becomes the visible caption underneath the image.
+
+Leave the title off and the image is described but not captioned:
+
+```text
+![A fishing boat at sunset](photo.jpg)
+```
+
+Images already hosted on the web are left alone, so only files in your vault are uploaded. A vault path containing parentheses or quotation marks will not match, so use a wikilink for those.
+
 Full details are [on the plugin home page](https://community.obsidian.md/plugins/pagecord).

--- a/test/controllers/api/micropub_controller_test.rb
+++ b/test/controllers/api/micropub_controller_test.rb
@@ -179,7 +179,55 @@ class Api::MicropubControllerTest < ActionDispatch::IntegrationTest
     created_post = @blog.posts.find_by(slug: "photo-post")
     stored_html = created_post.content.body.to_html
     assert_includes stored_html, "action-text-attachment"
-    assert_includes stored_html, 'caption="Stars"'
+    assert_includes stored_html, 'alt="Stars"'
+  end
+
+  test "markdown image alt describes the image and title captions it" do
+    file = fixture_file_upload("space.jpg", "image/jpeg")
+    post "/micropub/media", params: { file: file }, headers: auth_header
+    media_url = response.headers["Location"]
+
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "Boat Post" ],
+          content: [ %(![A boat at sunset](#{media_url} "Sunset on the Mekong")) ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    created_post = @blog.posts.find_by(slug: "boat-post")
+    stored_html = created_post.content.body.to_html
+    assert_includes stored_html, 'alt="A boat at sunset"'
+    assert_includes stored_html, 'caption="Sunset on the Mekong"'
+
+    # Rendering rebuilds the attachment node, so assert the alt survives it
+    rendered = created_post.content.body.to_s
+    assert_includes rendered, 'alt="A boat at sunset"'
+    assert_includes rendered, "Sunset on the Mekong"
+  end
+
+  test "markdown image without a title has no caption" do
+    file = fixture_file_upload("space.jpg", "image/jpeg")
+    post "/micropub/media", params: { file: file }, headers: auth_header
+    media_url = response.headers["Location"]
+
+    post "/micropub",
+      params: {
+        type: [ "h-entry" ],
+        properties: {
+          name: [ "Quiet Post" ],
+          content: [ %(![A boat at sunset](#{media_url})) ]
+        }
+      }.to_json,
+      headers: auth_header.merge("Content-Type" => "application/json")
+
+    assert_response :created
+    stored_html = @blog.posts.find_by(slug: "quiet-post").content.body.to_html
+    assert_includes stored_html, 'alt="A boat at sunset"'
+    assert_not_includes stored_html, "caption="
   end
 
   test "updates a post with replace and returns created when url changes" do

--- a/test/controllers/api/posts_controller_test.rb
+++ b/test/controllers/api/posts_controller_test.rb
@@ -419,6 +419,22 @@ class Api::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_includes JSON.parse(response.body)["content"], 'alt="A boat at sunset"'
   end
 
+  test "an attachment with neither alt nor caption renders without an alt attribute" do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("space.jpg").open,
+      filename: "space.jpg",
+      content_type: "image/jpeg"
+    )
+
+    patch "/posts/#{@post.token}", params: {
+      content: %(Hello\n\n<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>),
+      content_format: "markdown"
+    }, headers: auth_header
+
+    assert_response :success
+    assert_not_includes @post.reload.content.body.to_s, "alt="
+  end
+
   test "update with identical content skips attachment churn" do
     blob = ActiveStorage::Blob.create_and_upload!(
       io: file_fixture("space.jpg").open,

--- a/test/controllers/api/posts_controller_test.rb
+++ b/test/controllers/api/posts_controller_test.rb
@@ -403,6 +403,22 @@ class Api::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes json["content"], "<figure"
   end
 
+  test "update with attachment preserves a client supplied alt" do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("space.jpg").open,
+      filename: "space.jpg",
+      content_type: "image/jpeg"
+    )
+
+    patch "/posts/#{@post.token}", params: {
+      content: %(Hello\n\n<action-text-attachment sgid="#{blob.attachable_sgid}" alt="A boat at sunset"></action-text-attachment>),
+      content_format: "markdown"
+    }, headers: auth_header
+
+    assert_response :success
+    assert_includes JSON.parse(response.body)["content"], 'alt="A boat at sunset"'
+  end
+
   test "update with identical content skips attachment churn" do
     blob = ActiveStorage::Blob.create_and_upload!(
       io: file_fixture("space.jpg").open,


### PR DESCRIPTION
Action Text described an image only by its caption, which is always visible. An image could not be described for screen readers without that description also appearing on the page, and images with no caption fell back to `alt="Uploaded image"`.

Supersedes #1141, which needed an initialiser that swapped `ActionText::Attachment::ATTRIBUTES` out from under Rails. [rails/rails#58337](https://github.com/rails/rails/pull/58337) has since landed `alt` in that list, along with `ActionText::Attachment#alt`, so the hack is gone and this is four lines of app code. Rails moves from `bd885fa` to `52fa23c` to pick it up.

## What changed

Markdown images carry two descriptions, so Micropub maps them to different things:

```
![A boat at sunset](image-url "Sunset on the Mekong")
```

- alt text (invisible, for screen readers): `A boat at sunset`
- visible caption: `Sunset on the Mekong`

The API accepts an `alt` attribute on `<action-text-attachment>` tags for the same purpose. The Obsidian plugin has been sending exactly that since 1.2.0, and Pagecord has been discarding it, so this is the missing half.

## Behaviour changes

- Micropub markdown alt no longer produces a visible caption. The title does that. Stored posts are unaffected.
- mf2 `photo` alt now maps to alt text rather than caption, matching what the spec means by it.
- Lexxy captions still supply the alt through a fallback, so the editor is unchanged.

## Also here

`alt="Uploaded image"` no longer stands in for an image with neither alt nor caption. Rails deliberately emits no `alt` attribute at all in that case, and a generic string is the one option that is wrong both for a meaningful image and for a decorative one. It also fools anything auditing for missing descriptions. This changes the markup of every existing undescribed image, so it is worth a deliberate deploy.

`og:image:alt` for Mastodon link previews is still not emitted. Tracked separately.
