### PR TITLE
Apply "open external links in a new tab" to navigation and bio

### DIFF
--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -89,6 +89,13 @@ module BlogsHelper
     end
   end
 
+  def blog_bio(blog)
+    bio = auto_link(blog.bio)
+    return bio unless blog.external_links_in_new_tab?
+
+    Html::ExternalLinksInNewTab.new(blog).transform(bio).html_safe
+  end
+
   def custom_footer_html(blog)
     sanitize blog.custom_footer_html,
       tags: Blog::CustomFooter::ALLOWED_TAGS,

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -22,6 +22,12 @@ module PostsHelper
     item.link_url
   end
 
+  def navigation_item_link_options(item)
+    return {} unless @blog.external_links_in_new_tab? && item.external?
+
+    { target: "_blank", rel: "noopener" }
+  end
+
   def filter_description
     parts = []
     parts << "tagged with <strong>#{h @current_tags.join(", ")}</strong>" if @current_tags.present?

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -1,6 +1,6 @@
 class Blog < ApplicationRecord
   include Discard::Model
-  include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, Blog::CustomFooter, Blog::CustomCode, Blog::Contactable, Blog::ApiKey, Blog::RobotsTxt, Blog::PasswordProtected, Blog::PostUrls, Blog::Spotlit
+  include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, Blog::CustomFooter, Blog::CustomCode, Blog::Contactable, Blog::ApiKey, Blog::RobotsTxt, Blog::PasswordProtected, Blog::PostUrls, Blog::Spotlit, Blog::Hosts
 
   enum :layout, [ :stream_layout, :title_layout, :cards_layout ]
 
@@ -58,21 +58,6 @@ class Blog < ApplicationRecord
     title.blank? ? "@#{subdomain}" : title
   end
 
-  def host
-    custom_domain.presence || "#{subdomain}.#{Rails.application.config.x.domain}"
-  end
-
-  # A blog stays reachable on its subdomain after a custom domain is set, so a
-  # post URL is matched against both.
-  def find_post_by_url(url)
-    uri = URI.parse(url.to_s)
-    return unless hosts.include?(uri.host&.downcase)
-
-    posts.kept.find_by(slug: uri.path.delete_prefix("/").chomp("/").delete_prefix("posts/"))
-  rescue URI::Error
-    nil
-  end
-
   # Perks of paying rather than things the blogger made, so the stored
   # preference only applies while the plan includes it. Replies are an ongoing
   # service – we mail the owner on their behalf – and branding removal
@@ -94,10 +79,6 @@ class Blog < ApplicationRecord
   end
 
   private
-
-    def hosts
-      [ "#{subdomain}.#{Rails.application.config.x.domain}", custom_domain ].compact_blank.map(&:downcase)
-    end
 
     def within_blog_limit
       if user && blog_count_exceeds_limit?

--- a/app/models/concerns/blog/hosts.rb
+++ b/app/models/concerns/blog/hosts.rb
@@ -1,0 +1,41 @@
+module Blog::Hosts
+  extend ActiveSupport::Concern
+
+  def host
+    custom_domain.presence || "#{subdomain}.#{Rails.application.config.x.domain}"
+  end
+
+  def external_url?(url)
+    url = url.to_s
+    uri = URI.parse(url.start_with?("//") ? "https:#{url}" : url)
+    return false unless uri.is_a?(URI::HTTP) && uri.host.present?
+
+    !hosts.include?(uri.host.downcase)
+  rescue URI::Error
+    false
+  end
+
+  # A blog stays reachable on its subdomain after a custom domain is set, so a
+  # post URL is matched against both.
+  def find_post_by_url(url)
+    uri = URI.parse(url.to_s)
+    return unless hosts.include?(uri.host&.downcase)
+
+    posts.kept.find_by(slug: uri.path.delete_prefix("/").chomp("/").delete_prefix("posts/"))
+  rescue URI::Error
+    nil
+  end
+
+  private
+
+    def hosts
+      hosts = [ "#{subdomain}.#{Rails.application.config.x.domain}" ]
+
+      if custom_domain.present?
+        apex = custom_domain.delete_prefix("www.")
+        hosts += [ apex, "www.#{apex}" ]
+      end
+
+      hosts.map(&:downcase)
+    end
+end

--- a/app/models/html/external_links_in_new_tab.rb
+++ b/app/models/html/external_links_in_new_tab.rb
@@ -8,7 +8,7 @@ module Html
       doc = Nokogiri::HTML::DocumentFragment.parse(html)
 
       doc.css("a[href]").each do |link|
-        next unless external?(link["href"])
+        next unless @blog.external_url?(link["href"])
 
         link["target"] = "_blank"
         link["rel"] = [ *link["rel"].to_s.split, "noopener" ].uniq.join(" ")
@@ -16,29 +16,5 @@ module Html
 
       doc.to_html
     end
-
-    private
-
-      def external?(href)
-        uri = URI.parse(href.start_with?("//") ? "https:#{href}" : href)
-        return false unless uri.is_a?(URI::HTTP) && uri.host.present?
-
-        !blog_hosts.include?(uri.host.downcase)
-      rescue URI::Error
-        false
-      end
-
-      def blog_hosts
-        @blog_hosts ||= begin
-          hosts = [ "#{@blog.subdomain}.#{Rails.application.config.x.domain}" ]
-          hosts += custom_domain_hosts(@blog.custom_domain) if @blog.custom_domain.present?
-          hosts.map(&:downcase)
-        end
-      end
-
-      def custom_domain_hosts(custom_domain)
-        apex = custom_domain.delete_prefix("www.")
-        [ apex, "www.#{apex}" ]
-      end
   end
 end

--- a/app/models/navigation_item.rb
+++ b/app/models/navigation_item.rb
@@ -14,6 +14,10 @@ class NavigationItem < ApplicationRecord
     raise NotImplementedError, "Subclass must implement link_url"
   end
 
+  def external?
+    blog.external_url?(link_url)
+  end
+
   def icon
     nil
   end

--- a/app/views/blogs/_header.html.erb
+++ b/app/views/blogs/_header.html.erb
@@ -5,7 +5,7 @@
 
   <% if @blog.bio.present? && !local_assigns[:hide_bio] %>
   <div class="bio lexxy-content">
-    <%= auto_link @blog.bio %>
+    <%= blog_bio @blog %>
   </div>
   <% end %>
 

--- a/app/views/blogs/_nav.html.erb
+++ b/app/views/blogs/_nav.html.erb
@@ -2,11 +2,11 @@
   <nav>
     <% @blog.navigation_items.ordered.each do |item| %>
       <% if item.icon %>
-        <%= link_to navigation_item_url(item), class: "social-link", aria: { label: item.icon_label } do %>
+        <%= link_to navigation_item_url(item), class: "social-link", aria: { label: item.icon_label }, **navigation_item_link_options(item) do %>
           <%= inline_svg_tag item.icon %>
         <% end %>
       <% else %>
-        <%= link_to item.label, navigation_item_url(item) %>
+        <%= link_to item.label, navigation_item_url(item), **navigation_item_link_options(item) %>
       <% end %>
     <% end %>
   </nav>

--- a/test/controllers/blogs/posts_controller_test.rb
+++ b/test/controllers/blogs/posts_controller_test.rb
@@ -936,6 +936,37 @@ class Blogs::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_select "nav a[href=?]", "/search"
   end
 
+  test "should open external navigation links in a new tab when enabled" do
+    @blog.update!(external_links_in_new_tab: true)
+
+    get blog_posts_path
+
+    assert_select "nav a[href=?][target=\"_blank\"][rel=\"noopener\"]", "https://bsky.app/profile/joel.example.com"
+    assert_select "nav a[href=?]:not([target])", "/posts"
+  end
+
+  test "should leave navigation links in the same tab when disabled" do
+    get blog_posts_path
+
+    assert_select "nav a[href=?]:not([target])", "https://bsky.app/profile/joel.example.com"
+  end
+
+  test "should open external bio links in a new tab when enabled" do
+    @blog.update!(bio: "<p>Visit https://example.org</p>", external_links_in_new_tab: true)
+
+    get blog_posts_path
+
+    assert_select ".bio a[href=?][target=\"_blank\"][rel=\"noopener\"]", "https://example.org"
+  end
+
+  test "should leave bio links in the same tab when disabled" do
+    @blog.update!(bio: "<p>Visit https://example.org</p>")
+
+    get blog_posts_path
+
+    assert_select ".bio a[href=?]:not([target])", "https://example.org"
+  end
+
   test "should render avatar favicon when blog has an avatar" do
     @blog.avatar.attach(
       io: File.open(Rails.root.join("test/fixtures/files/avatar.png")),

--- a/test/models/navigation_item_test.rb
+++ b/test/models/navigation_item_test.rb
@@ -244,4 +244,20 @@ class SocialNavigationItemTest < ActiveSupport::TestCase
     assert_not item.valid?
     assert_includes item.errors[:url], "is not a valid URL"
   end
+
+  test "external? is true for social profiles" do
+    assert navigation_items(:joel_social_bluesky).external?
+  end
+
+  test "external? is false for email, page and relative custom links" do
+    assert_not navigation_items(:saul_social_email).external?
+    assert_not navigation_items(:joel_about).external?
+    assert_not navigation_items(:joel_custom).external?
+  end
+
+  test "external? is false for a link back to the blog's own host" do
+    item = CustomNavigationItem.new(blog: @blog, label: "Archive", url: "https://#{@blog.subdomain}.example.com/archive")
+
+    assert_not item.external?
+  end
 end


### PR DESCRIPTION
A customer reported that the "Open external links in a new tab" setting doesn't affect header navigation. It only ever applied to post and page content, so navigation links and bio links were missed.

## What changed

- `Blog::Hosts` concern owns "which hosts serve this blog" and the `external_url?` predicate, lifted out of `Html::ExternalLinksInNewTab`. It also takes `host`, `hosts` and `find_post_by_url` off `Blog`, so `blog.rb` shrinks.
- `NavigationItem#external?` covers all five item types: page, posts and search items are relative paths, email items are `mailto:`, so only social and custom links can be external.
- `navigation_item_link_options` adds `target`/`rel` in `blogs/_nav.html.erb`, and `blog_bio` does the same for the bio.

## Behaviour changes

- Navigation and bio links now honour the setting. Markup is byte-identical when it's off.
- The blog's own hosts now include the `www.` variant of a custom domain, matching what the content transformation already did. `find_post_by_url` picks that up too, which is correct since that host serves the blog.
- The custom footer is untouched. It's raw HTML and already allows `target` and `rel`.