### PR TITLE
Settings API for appearance and custom code

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -14,6 +14,10 @@ class Api::BaseController < ActionController::API
     render json: { error: e.message }, status: :bad_request
   end
 
+  rescue_from Api::ForbiddenError do |e|
+    render json: { error: e.message }, status: :forbidden
+  end
+
   rescue_from Post::FrontMatter::InvalidError do |e|
     render json: { error: "Invalid front matter: #{e.message}" }, status: :unprocessable_entity
   end
@@ -57,6 +61,13 @@ class Api::BaseController < ActionController::API
 
     def rate_limit_reached
       render json: { error: "Rate limit exceeded" }, status: :too_many_requests
+    end
+
+    def settings_params(*fields, subscriber_only: [])
+      forbidden = subscriber_only.find { params.key?(it) } unless Current.blog.user.subscribed?
+      raise Api::ForbiddenError, "#{forbidden} requires a subscription" if forbidden
+
+      params.permit(*fields, *subscriber_only)
     end
 
     def unchanged_content_skipped(params, record)

--- a/app/controllers/api/settings/appearance_controller.rb
+++ b/app/controllers/api/settings/appearance_controller.rb
@@ -1,0 +1,26 @@
+class Api::Settings::AppearanceController < Api::BaseController
+  FIELDS = %i[
+    theme font width layout
+    custom_theme_bg_light custom_theme_text_light custom_theme_accent_light
+    custom_theme_bg_dark custom_theme_text_dark custom_theme_accent_dark
+  ].freeze
+  SUBSCRIBER_FIELDS = %i[ show_branding ].freeze
+
+  def show
+    render json: appearance_json
+  end
+
+  def update
+    if Current.blog.update(settings_params(*FIELDS, subscriber_only: SUBSCRIBER_FIELDS))
+      render json: appearance_json
+    else
+      render json: { errors: Current.blog.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def appearance_json
+      Current.blog.as_json(only: FIELDS + SUBSCRIBER_FIELDS + [ :updated_at ])
+    end
+end

--- a/app/controllers/api/settings/custom_code_controller.rb
+++ b/app/controllers/api/settings/custom_code_controller.rb
@@ -1,0 +1,22 @@
+class Api::Settings::CustomCodeController < Api::BaseController
+  FIELDS = %i[ custom_css custom_footer_html ].freeze
+  SUBSCRIBER_FIELDS = %i[ custom_head_html custom_body_html custom_code_enabled ].freeze
+
+  def show
+    render json: custom_code_json
+  end
+
+  def update
+    if Current.blog.update(settings_params(*FIELDS, subscriber_only: SUBSCRIBER_FIELDS))
+      render json: custom_code_json
+    else
+      render json: { errors: Current.blog.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def custom_code_json
+      Current.blog.as_json(only: FIELDS + SUBSCRIBER_FIELDS + [ :updated_at ])
+    end
+end

--- a/app/models/api/forbidden_error.rb
+++ b/app/models/api/forbidden_error.rb
@@ -1,0 +1,1 @@
+class Api::ForbiddenError < StandardError; end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -2,7 +2,7 @@ class Blog < ApplicationRecord
   include Discard::Model
   include DeliveryEmail, CustomDomain, EmailSubscribable, Themeable, Localisable, CssSanitizable, Blog::CustomFooter, Blog::CustomCode, Blog::Contactable, Blog::ApiKey, Blog::RobotsTxt, Blog::PasswordProtected, Blog::PostUrls, Blog::Spotlit, Blog::Hosts
 
-  enum :layout, [ :stream_layout, :title_layout, :cards_layout ]
+  enum :layout, [ :stream_layout, :title_layout, :cards_layout ], validate: true
 
   belongs_to :user, inverse_of: :blogs
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,10 @@ Rails.application.routes.draw do
       resources :pages, only: [ :index, :show, :create, :update, :destroy ], param: :token
       resource :home_page, only: [ :show, :create, :update, :destroy ]
       resources :attachments, only: [ :create ]
+      namespace :settings do
+        resource :appearance, only: [ :show, :update ], controller: "appearance"
+        resource :custom_code, only: [ :show, :update ], controller: "custom_code"
+      end
       # The Micropub spec mandates a single endpoint, so these two stay as they are.
       post "/micropub", to: "micropub#create"
       get "/micropub", to: "micropub#query", as: nil

--- a/docs/help-guide/api.md
+++ b/docs/help-guide/api.md
@@ -236,6 +236,62 @@ Unlinks the home page from the blog but keeps the underlying page. Returns `204 
 
 Returns `404 Not Found` if no home page is set.
 
+## Settings
+
+Two singular resources mirror the Appearance and Custom code screens in your blog settings. An update only changes the fields you send, and returns the whole resource. Both include `updated_at`.
+
+Fields marked "subscribers only" return `403 Forbidden` naming the field if your blog is on a trial rather than a paid plan.
+
+### Get appearance
+
+```
+GET /settings/appearance
+```
+
+Returns `200 OK` with the appearance settings.
+
+### Update appearance
+
+```
+PATCH /settings/appearance
+```
+
+Parameters:
+
+- `theme` – `base`, `mint`, `lavender`, `coral`, `sand`, `sky`, `berry`, or `custom`
+- `font` – `sans`, `serif`, or `mono`
+- `width` – `narrow`, `standard`, or `wide`
+- `layout` – `stream_layout`, `title_layout`, or `cards_layout`
+- `custom_theme_bg_light`, `custom_theme_text_light`, `custom_theme_accent_light` – hex colours, used when `theme` is `custom`
+- `custom_theme_bg_dark`, `custom_theme_text_dark`, `custom_theme_accent_dark` – hex colours, used when `theme` is `custom`
+- `show_branding` – `true` or `false` (subscribers only)
+
+Returns `200 OK` with the updated settings. Returns `422 Unprocessable Entity` when validation fails.
+
+### Get custom code
+
+```
+GET /settings/custom_code
+```
+
+Returns `200 OK` with the custom code settings.
+
+### Update custom code
+
+```
+PATCH /settings/custom_code
+```
+
+Parameters:
+
+- `custom_css` – custom stylesheet for your blog
+- `custom_footer_html` – HTML appended to the footer
+- `custom_head_html` – HTML injected into `<head>` (subscribers only)
+- `custom_body_html` – HTML injected at the end of `<body>` (subscribers only)
+- `custom_code_enabled` – `true` or `false` (subscribers only)
+
+Returns `200 OK` with the updated settings. Returns `422 Unprocessable Entity` when validation fails.
+
 ## Attachments
 
 Upload images, videos, or audio files to use in your posts.
@@ -361,7 +417,7 @@ Validation errors use `errors`:
 |--------|---------|
 | 400 | Bad request – invalid timestamp, out-of-range page, invalid status value, or invalid attachment sgid |
 | 401 | Missing or invalid API key |
-| 403 | Premium subscription required, or the upload allowance is used up |
+| 403 | Premium subscription required, the upload allowance is used up, or a subscriber-only setting was sent without a subscription |
 | 404 | Resource not found |
 | 422 | Validation failed, invalid front matter, missing file, unsupported file type, or oversized file |
 | 429 | Rate limit exceeded |

--- a/test/controllers/api/settings/appearance_controller_test.rb
+++ b/test/controllers/api/settings/appearance_controller_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+class Api::Settings::AppearanceControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "api.example.com"
+
+    @blog = blogs(:joel)
+    @user = users(:joel)
+  end
+
+  # -- Show --
+
+  test "show returns the appearance settings" do
+    get "/settings/appearance", headers: auth_header
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal @blog.theme, json["theme"]
+    assert_equal "stream_layout", json["layout"]
+    assert json.key?("updated_at")
+  end
+
+  test "show returns unauthorized without a token" do
+    get "/settings/appearance"
+    assert_response :unauthorized
+  end
+
+  test "show returns forbidden without premium access" do
+    @user.subscription.destroy!
+    @user.update!(trial_ends_at: nil)
+
+    get "/settings/appearance", headers: auth_header
+    assert_response :forbidden
+  end
+
+  # -- Update --
+
+  test "update only changes the attributes it is given" do
+    @blog.update!(theme: "base", font: "serif")
+
+    patch "/settings/appearance", params: { theme: "sand" }, headers: auth_header
+
+    assert_response :success
+    assert_equal "sand", @blog.reload.theme
+    assert_equal "serif", @blog.font
+  end
+
+  test "update rejects an invalid theme" do
+    patch "/settings/appearance", params: { theme: "neon" }, headers: auth_header
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"], "Theme neon is not a valid theme"
+  end
+
+  test "update rejects an invalid layout" do
+    patch "/settings/appearance", params: { layout: "sideways" }, headers: auth_header
+
+    assert_response :unprocessable_entity
+    assert_equal "stream_layout", @blog.reload.layout
+  end
+
+  test "update sets a valid layout" do
+    patch "/settings/appearance", params: { layout: "cards_layout" }, headers: auth_header
+
+    assert_response :success
+    assert_equal "cards_layout", @blog.reload.layout
+  end
+
+  test "update sets show branding for a subscriber" do
+    patch "/settings/appearance", params: { show_branding: false }, headers: auth_header
+
+    assert_response :success
+    assert_not @blog.reload.show_branding
+  end
+
+  test "update rejects show branding on trial" do
+    @user.subscription.destroy!
+    @user.update!(trial_ends_at: 30.days.from_now)
+
+    patch "/settings/appearance", params: { show_branding: false }, headers: auth_header
+
+    assert_response :forbidden
+    assert_equal "show_branding requires a subscription", JSON.parse(response.body)["error"]
+    assert @blog.reload.show_branding
+  end
+
+  test "update allows other attributes on trial" do
+    @user.subscription.destroy!
+    @user.update!(trial_ends_at: 30.days.from_now)
+
+    patch "/settings/appearance", params: { theme: "sand" }, headers: auth_header
+
+    assert_response :success
+    assert_equal "sand", @blog.reload.theme
+  end
+
+  private
+
+    def auth_header(token = "test_api_key_for_fixtures")
+      { "Authorization" => "Bearer #{token}" }
+    end
+end

--- a/test/controllers/api/settings/custom_code_controller_test.rb
+++ b/test/controllers/api/settings/custom_code_controller_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class Api::Settings::CustomCodeControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "api.example.com"
+
+    @blog = blogs(:joel)
+    @user = users(:joel)
+  end
+
+  # -- Show --
+
+  test "show returns the custom code settings" do
+    @blog.update!(custom_css: "body { color: red }")
+
+    get "/settings/custom_code", headers: auth_header
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal "body { color: red }", json["custom_css"]
+    assert json.key?("custom_head_html")
+    assert json.key?("updated_at")
+  end
+
+  test "show returns unauthorized without a token" do
+    get "/settings/custom_code"
+    assert_response :unauthorized
+  end
+
+  test "show returns forbidden without premium access" do
+    @user.subscription.destroy!
+    @user.update!(trial_ends_at: nil)
+
+    get "/settings/custom_code", headers: auth_header
+    assert_response :forbidden
+  end
+
+  # -- Update --
+
+  test "update only changes the attributes it is given" do
+    @blog.update!(custom_css: "body { color: red }", custom_footer_html: "<p>Bye</p>")
+
+    patch "/settings/custom_code", params: { custom_css: "body { color: blue }" }, headers: auth_header
+
+    assert_response :success
+    assert_equal "body { color: blue }", @blog.reload.custom_css
+    assert_equal "<p>Bye</p>", @blog.custom_footer_html
+  end
+
+  test "update rejects unsafe custom CSS" do
+    patch "/settings/custom_code",
+      params: { custom_css: ".blog { color: red; }</style><script>alert(1)</script>" },
+      headers: auth_header
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"], "Custom css contains invalid or potentially unsafe content"
+  end
+
+  test "update sets custom head html for a subscriber" do
+    patch "/settings/custom_code",
+      params: { custom_head_html: "<meta name=\"x\" content=\"y\">" },
+      headers: auth_header
+
+    assert_response :success
+    assert_equal "<meta name=\"x\" content=\"y\">", @blog.reload.custom_head_html
+  end
+
+  test "update sets custom code enabled for a subscriber" do
+    patch "/settings/custom_code", params: { custom_code_enabled: false }, headers: auth_header
+
+    assert_response :success
+    assert_not @blog.reload.custom_code_enabled
+  end
+
+  test "update rejects custom head html on trial" do
+    @user.subscription.destroy!
+    @user.update!(trial_ends_at: 30.days.from_now)
+
+    patch "/settings/custom_code", params: { custom_head_html: "<meta name=\"x\">" }, headers: auth_header
+
+    assert_response :forbidden
+    assert_equal "custom_head_html requires a subscription", JSON.parse(response.body)["error"]
+    assert_nil @blog.reload.custom_head_html
+  end
+
+  test "update allows custom CSS on trial" do
+    @user.subscription.destroy!
+    @user.update!(trial_ends_at: 30.days.from_now)
+
+    patch "/settings/custom_code", params: { custom_css: "body { color: blue }" }, headers: auth_header
+
+    assert_response :success
+    assert_equal "body { color: blue }", @blog.reload.custom_css
+  end
+
+  private
+
+    def auth_header(token = "test_api_key_for_fixtures")
+      { "Authorization" => "Bearer #{token}" }
+    end
+end


### PR DESCRIPTION
An agent can't currently change a blog's design. This adds the API half of that, and the CLI half is in lylo/pagecord-cli.

## What changed

Two singular resources on the API domain, mirroring the settings screens one to one:

- `GET` / `PATCH` `/settings/appearance` — theme, font, width, layout, the six custom theme colours, `show_branding`
- `GET` / `PATCH` `/settings/custom_code` — `custom_css`, `custom_footer_html`, `custom_head_html`, `custom_body_html`, `custom_code_enabled`

Mirroring the screens rather than inventing a grouping means each endpoint reuses a permit list that already exists, and future settings screens get an endpoint with an obvious name.

Updates merge: only the fields in the request are written. Plan gating copies the web controllers, so custom CSS and footers are trial-eligible while branding removal and head/body HTML need a subscription.

## Behaviour changes

- Sending a subscriber-only field without a subscription returns `403` naming the field. The web app silently drops it, which would tell an agent a write worked when it didn't.
- `layout` gains `validate: true`, so an invalid value is a `422` like theme and font instead of raising `ArgumentError`. No change for the web form, which is a select.
- Both `GET`s return `updated_at`, which is what a conditional update would need later.

Help guide docs updated; `help:sync` not run.
